### PR TITLE
Add root OWNERS file (from community)

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,8 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- bobcatfish
+- dlorenc
+- vdemeester
+- kimsterv
+- abayer


### PR DESCRIPTION
This will allow community owners to approve PRs in addition to local
OWNERS. This is especially useful in case of moving folders.

cc @bobcatfish @abayer 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>