### PR TITLE
Add releasename as optional param (used with Helm pipeline)

### DIFF
--- a/webhooks-extension/Gopkg.lock
+++ b/webhooks-extension/Gopkg.lock
@@ -209,6 +209,14 @@
   version = "v2.0.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:d421d847bed133d9f4635bbf19905db4560be4fc54fcb7631e58903ced9a5108"
+  name = "github.com/tektoncd/experimental"
+  packages = ["webhooks-extension/endpoints"]
+  pruneopts = "UT"
+  revision = "5b243ba3980c738ec4fc4fa633d84c485ed3c822"
+
+[[projects]]
   digest = "1:1aec373958064996926528aa0f992914d4e9612c3dc478b60c92dab906a55238"
   name = "github.com/tektoncd/pipeline"
   packages = [
@@ -562,6 +570,7 @@
     "github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1",
     "github.com/knative/eventing-sources/pkg/client/clientset/versioned",
     "github.com/knative/eventing-sources/pkg/client/clientset/versioned/fake",
+    "github.com/tektoncd/experimental/webhooks-extension/endpoints",
     "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1",
     "github.com/tektoncd/pipeline/pkg/client/clientset/versioned",
     "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake",

--- a/webhooks-extension/README.md
+++ b/webhooks-extension/README.md
@@ -21,6 +21,12 @@ To initiate this installation, run `development_install.sh`.
 
 _Note: Your git provider must be able to reach the address of this extension's sink. The sink is deployed with a Knative service, so you may need to configure Knative serving. We recommend [setting up a custom domain](https://knative.dev/v0.3-docs/serving/using-a-custom-domain/) with the extension `.nip.io`._
 
+## Running tests
+
+```bash
+docker build -f cmd/extension/Dockerfile_test .
+```
+
 ## API Definitions
 
 - [Extension API definitions](cmd/extension/README.md)
@@ -57,7 +63,12 @@ Reference the [Knative eventing GitHub source sample](https://knative.dev/docs/e
 - All knative event sources are created in the namespace into which the dashboard and this extension are installed.
 - Currently the docker registry to which built images are pushed is hard coded from the registry you specified at install time, there is work underway to change this restriction.
 - Only one webhook can be created for each git repository, so each repository will only be able to trigger a PipelineRun from one webhook.
-- Only the [simple-pipeline](https://github.com/pipeline-hotel/example-pipelines/blob/master/config/pipeline.yaml) Pipeline definition is currently supported.
+
+- Three pipeline definitions are currently supported.
+
+  - [simple-pipeline](https://github.com/pipeline-hotel/example-pipelines/blob/master/config/pipeline.yaml)
+  - [simple-helm-pipeline](https://github.com/pipeline-hotel/example-pipelines/blob/master/config/helm-pipeline.yaml) (requires a secret to talk to a secure Tiller)
+  - [simple-helm-pipeline-insecure](https://github.com/pipeline-hotel/example-pipelines/blob/master/config/helm-insecure-pipeline.yaml.yaml)
 
 ## Architecture information
 

--- a/webhooks-extension/cmd/extension/README.md
+++ b/webhooks-extension/cmd/extension/README.md
@@ -45,3 +45,9 @@ Example POST
 ```
 
 These endpoints can be accessed through the dashboard.
+
+If using Helm, you can also specify a Helm release name. If no Helm release name is provided, your Helm release name will default to be the repository name.
+
+Specify a Helm release name by providing `releasename` in the POST request.
+
+The release name __must be less than 64 characters in length__: if your repository name does not meet this requirement you must specify a `releasename` that is less than 64 characters.

--- a/webhooks-extension/endpoints/types.go
+++ b/webhooks-extension/endpoints/types.go
@@ -69,15 +69,15 @@ func NewResource() (Resource, error) {
 
 // Webhook stores the webhook information
 type webhook struct {
-	Name                 string `json:"name"`
-	Namespace            string `json:"namespace"`
-	ServiceAccount       string `json:"serviceaccount,omitempty"`
-	GitRepositoryURL     string `json:"gitrepositoryurl"`
-	AccessTokenRef       string `json:"accesstoken"`
-	Pipeline             string `json:"pipeline"`
-	DockerRegistry       string `json:"dockerregistry,omitempty"`
-	HelmSecret           string `json:"helmsecret,omitempty"`
-	RepositorySecretName string `json:"repositorysecretname,omitempty"`
+	Name             string `json:"name"`
+	Namespace        string `json:"namespace"`
+	ServiceAccount   string `json:"serviceaccount,omitempty"`
+	GitRepositoryURL string `json:"gitrepositoryurl"`
+	AccessTokenRef   string `json:"accesstoken"`
+	Pipeline         string `json:"pipeline"`
+	DockerRegistry   string `json:"dockerregistry,omitempty"`
+	HelmSecret       string `json:"helmsecret,omitempty"`
+	ReleaseName      string `json:"releasename,omitempty"`
 }
 
 // ConfigMapName ... the name of the ConfigMap to create


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

For our webhook extension we should be able to support Helm pipelines too. This gets us a step closer by being able to do helm upgrades. 

The behaviour before this PR is that we generate Pipeline parameters which includes a release name that is passed into a Helm pipeline. The release name is built up of both the repository name and the short commit ID.

This means that subsequent commits result in entirely new Helm releases instead of upgrading the existing Helm release: because the names differ.

In this PR I've added a new optional field, `releasename`, with character length validation as Helm releases have a maximum length.

I've added a test for such validation, documented that it's a new field one can use, and tested it with a Helm pipeline and deploy task (I want to contribute said pipeline and task once I make the Tiller secret an optional parameter).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._

Test code too 😄 

I've also removed two entirely used params: registrysecret and the repositorysecretname.

I'm changing it to just `releasename` based on feedback 😉 