### PR TITLE
Ability to override the env variable for the target docker registry

### DIFF
--- a/webhooks-extension/cmd/extension/README.md
+++ b/webhooks-extension/cmd/extension/README.md
@@ -29,7 +29,7 @@ Example payload response
 POST /webhooks
 Create a new webhook
 Request body must contain name, namespace gitrepositoryurl, accesstoken, and pipeline
-Request body may contain serviceaccount, registrysecret, helmsecret, and repositorysecretname
+Request body may contain serviceaccount, dockerregistry, helmsecret, and repositorysecretname
 Returns HTTP code 201 if the webhook was created successfully
 Returns HTTP code 400 if an error occurred with the request body
 Returns HTTP code 500 if an error occurred reading or writing the webhooks

--- a/webhooks-extension/config/extension-deployment.yaml
+++ b/webhooks-extension/config/extension-deployment.yaml
@@ -35,3 +35,5 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: DOCKER_REGISTRY_LOCATION
+            value: DOCKER_REPO

--- a/webhooks-extension/config/sink-kservice.yaml
+++ b/webhooks-extension/config/sink-kservice.yaml
@@ -23,8 +23,6 @@ spec:
             env:
             - name: PORT
               value: "8080"
-            - name: DOCKER_REGISTRY_LOCATION
-              value: DOCKER_REPO
             - name: INSTALLED_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/webhooks-extension/endpoints/sink.go
+++ b/webhooks-extension/endpoints/sink.go
@@ -129,7 +129,7 @@ func createPipelineRunFromWebhookData(buildInformation BuildInformation, r Resou
 		log.Printf("Error getting github webhook: %s.", err.Error())
 		return
 	}
-	registrySecret := webhook.RegistrySecret
+	dockerRegistry := webhook.DockerRegistry
 	helmSecret := webhook.HelmSecret
 	pipelineTemplateName := webhook.Pipeline
 	pipelineNs := webhook.Namespace
@@ -157,8 +157,7 @@ func createPipelineRunFromWebhookData(buildInformation BuildInformation, r Resou
 
 	log.Print("Creating PipelineResources.")
 
-	registryURL := os.Getenv("DOCKER_REGISTRY_LOCATION")
-	urlToUse := fmt.Sprintf("%s/%s:%s", registryURL, strings.ToLower(buildInformation.REPONAME), buildInformation.SHORTID)
+	urlToUse := fmt.Sprintf("%s/%s:%s", dockerRegistry, strings.ToLower(buildInformation.REPONAME), buildInformation.SHORTID)
 	log.Printf("Image URL is: %s.", urlToUse)
 
 	paramsForImageResource := []v1alpha1.Param{{Name: "url", Value: urlToUse}}
@@ -186,7 +185,7 @@ func createPipelineRunFromWebhookData(buildInformation BuildInformation, r Resou
 	resources := []v1alpha1.PipelineResourceBinding{{Name: "docker-image", ResourceRef: imageResourceRef}, {Name: "git-source", ResourceRef: gitResourceRef}}
 
 	imageTag := buildInformation.SHORTID
-	imageName := fmt.Sprintf("%s/%s", registryURL, strings.ToLower(buildInformation.REPONAME))
+	imageName := fmt.Sprintf("%s/%s", dockerRegistry, strings.ToLower(buildInformation.REPONAME))
 	releaseName := fmt.Sprintf("%s-%s", strings.ToLower(buildInformation.REPONAME), buildInformation.SHORTID)
 	repositoryName := strings.ToLower(buildInformation.REPONAME)
 	params := []v1alpha1.Param{{Name: "image-tag", Value: imageTag},
@@ -195,8 +194,8 @@ func createPipelineRunFromWebhookData(buildInformation BuildInformation, r Resou
 		{Name: "repository-name", Value: repositoryName},
 		{Name: "target-namespace", Value: pipelineNs}}
 
-	if registrySecret != "" {
-		params = append(params, v1alpha1.Param{Name: "registry-secret", Value: registrySecret})
+	if dockerRegistry != "" {
+		params = append(params, v1alpha1.Param{Name: "docker-registry", Value: dockerRegistry})
 	}
 	if helmSecret != "" {
 		params = append(params, v1alpha1.Param{Name: "helm-secret", Value: helmSecret})

--- a/webhooks-extension/endpoints/types.go
+++ b/webhooks-extension/endpoints/types.go
@@ -75,7 +75,7 @@ type webhook struct {
 	GitRepositoryURL     string `json:"gitrepositoryurl"`
 	AccessTokenRef       string `json:"accesstoken"`
 	Pipeline             string `json:"pipeline"`
-	RegistrySecret       string `json:"registrysecret,omitempty"`
+	DockerRegistry       string `json:"dockerregistry,omitempty"`
 	HelmSecret           string `json:"helmsecret,omitempty"`
 	RepositorySecretName string `json:"repositorysecretname,omitempty"`
 }

--- a/webhooks-extension/endpoints/webhook.go
+++ b/webhooks-extension/endpoints/webhook.go
@@ -42,6 +42,12 @@ func (r Resource) createWebhook(request *restful.Request, response *restful.Resp
 		RespondError(response, err, http.StatusBadRequest)
 		return
 	}
+
+	dockerRegDefault := os.Getenv("DOCKER_REGISTRY_LOCATION")
+	if webhook.DockerRegistry == "" && dockerRegDefault != "" {
+		webhook.DockerRegistry = dockerRegDefault
+	}
+
 	namespace := webhook.Namespace
 	if namespace == "" {
 		err := errors.New("namespace is required, but none was given")


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This change allows the specification of dockerregistry on the REST endpoint for
creating the webhook. The default value that would otherwise be assigned is that of the environment variable.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
