### PR TITLE
Change extension annotation and add endpoint to get default env settings

### DIFF
--- a/webhooks-extension/README.md
+++ b/webhooks-extension/README.md
@@ -43,15 +43,16 @@ data='{
   "namespace": "green",
   "gitrepositoryurl": "https://github.com/ncskier/go-hello-world",
   "accesstoken": "github-secret",
-  "pipeline": "simple-pipeline"
+  "pipeline": "simple-pipeline",
+  "dockerregistry": "mydockerregistry"
 }'
-curl -d "${data}" -H "Content-Type: application/json" -X POST http://localhost:8080/webhooks-extension/webhooks
+curl -d "${data}" -H "Content-Type: application/json" -X POST http://localhost:8080/webhooks
 ```
 
 When curling through the dashboard, use the same endpoints; for example, assuming the dashboard is at `localhost:9097`:
 
 ```bash
-curl -d "${data}" -H "Content-Type: application/json" -X POST http://localhost:9097/webhooks-extension/webhooks
+curl -d "${data}" -H "Content-Type: application/json" -X POST http://localhost:9097/webhooks
 ```
 
 Reference the [Knative eventing GitHub source sample](https://knative.dev/docs/eventing/samples/github-source/) to properly create the `accesstoken` secret. This is the secret that is used to create GitHub webhooks.

--- a/webhooks-extension/cmd/extension/README.md
+++ b/webhooks-extension/cmd/extension/README.md
@@ -22,6 +22,17 @@ Example payload response
 ]
 ```
 
+```
+GET /webhooks/defaults
+Get default values, currently install namespace and docker registry
+Returns HTTP code 200
+
+Example payload response
+{
+ "namespace": "default",
+ "dockerregistry": "mydockerhubregistry"
+}
+```
 
 ### POST endpoints
 

--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton-dashboard-extension: "true"
   annotations:
     tekton-dashboard-display-name: webhooks-extension
-    tekton-dashboard-endpoints: "webhooks-extension/webhooks"
+    tekton-dashboard-endpoints: "webhooks"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/endpoints/shared-test-funcs.go
+++ b/webhooks-extension/endpoints/shared-test-funcs.go
@@ -61,11 +61,30 @@ func dummyRestfulRequest(httpReq *http.Request, namespace string, name string) *
 	return restfulReq
 }
 
+func dummyDefaults() EnvDefaults {
+	initialValues := EnvDefaults{
+		Namespace:      "default",
+		DockerRegistry: "",
+	}
+	return initialValues
+}
+
+func updateResourceDefaults(r *Resource, newDefaults EnvDefaults) *Resource {
+	newResource := Resource{
+		K8sClient:      r.K8sClient,
+		TektonClient:   r.TektonClient,
+		EventSrcClient: r.EventSrcClient,
+		Defaults:       newDefaults,
+	}
+	return &newResource
+}
+
 func dummyResource() *Resource {
 	resource := Resource{
 		K8sClient:      dummyK8sClientset(),
 		TektonClient:   dummyClientset(),
 		EventSrcClient: dummyEventSrcClient(),
+		Defaults:       dummyDefaults(),
 	}
 	return &resource
 }

--- a/webhooks-extension/endpoints/types.go
+++ b/webhooks-extension/endpoints/types.go
@@ -20,6 +20,7 @@ import (
 	tektoncdclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	k8sclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"os"
 )
 
 // Resource stores all types here that are reused throughout files
@@ -27,6 +28,7 @@ type Resource struct {
 	EventSrcClient eventsrcclientset.Interface
 	TektonClient   tektoncdclientset.Interface
 	K8sClient      k8sclientset.Interface
+	Defaults       EnvDefaults
 }
 
 // NewResource returns a new Resource instantiated with its clientsets
@@ -59,10 +61,16 @@ func NewResource() (Resource, error) {
 		return Resource{}, err
 	}
 
+	defaults := EnvDefaults{
+		Namespace:      os.Getenv("INSTALLED_NAMESPACE"),
+		DockerRegistry: os.Getenv("DOCKER_REGISTRY_LOCATION"),
+	}
+
 	r := Resource{
 		K8sClient:      k8sClient,
 		TektonClient:   tektonClient,
 		EventSrcClient: eventSrcClient,
+		Defaults:       defaults,
 	}
 	return r, nil
 }
@@ -82,3 +90,9 @@ type webhook struct {
 
 // ConfigMapName ... the name of the ConfigMap to create
 const ConfigMapName = "githubwebhook"
+
+//
+type EnvDefaults struct {
+	Namespace      string `json:"namespace"`
+	DockerRegistry string `json:"dockerregistry"`
+}


### PR DESCRIPTION
# Changes

This commit adds an endpoint such that default settings can be
retrieved to be later displayed in UI panels.  A struct is stored
against the Resource and is configured with values at creation of
the Resource.  Additionally, there is a minor change to the url path.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
