### PR TITLE
Add delete endpoint for webhooks, optionally deleting PipelineRuns

### DIFF
--- a/webhooks-extension/cmd/extension/Dockerfile_test
+++ b/webhooks-extension/cmd/extension/Dockerfile_test
@@ -1,6 +1,6 @@
-# Start from a Debian image with the latest version of Go installed
-# and a workspace (GOPATH) configured at /go.
-FROM golang
+FROM golang:1.12-alpine
+
+RUN apk add curl git
 
 # Copy the local package files to the container's workspace.
 ADD . /go/src/github.com/tektoncd/experimental/webhooks-extension
@@ -12,4 +12,4 @@ RUN chmod +x /usr/bin/dep
 RUN dep ensure -vendor-only
 
 # Run endpoints go tests
-RUN go test github.com/tektoncd/experimental/webhooks-extension/endpoints -v
+RUN CGO_ENABLED=0 go test github.com/tektoncd/experimental/webhooks-extension/endpoints -v

--- a/webhooks-extension/cmd/extension/README.md
+++ b/webhooks-extension/cmd/extension/README.md
@@ -55,6 +55,24 @@ Example POST
 }
 ```
 
+### DELETE endpoint
+
+```
+DELETE /webhooks/<webhookid>?namespace=<my namespace>
+```
+
+You can optionally add &deletepipelineruns=true to remove all PipelineRuns associated with the same repository.
+
+Returns HTTP code 201 if the webhook was deleted successfully
+Returns HTTP code 400 if an error occurred with the request body
+Returns HTTP code 404 if the webhook wasn't found
+Returns HTTP code 405 if a query parameter alone was provided
+Returns HTTP code 500 if any other errors occurred
+
+Deletes the GithubSource (therefore the webhook from the repository) and optionally deletes all PipelineRuns for the configured repository. 
+The ConfigMap used to maintain a list of configured webhooks to Pipelines is also updated.
+
+
 These endpoints can be accessed through the dashboard.
 
 If using Helm, you can also specify a Helm release name. If no Helm release name is provided, your Helm release name will default to be the repository name.

--- a/webhooks-extension/cmd/extension/README.md
+++ b/webhooks-extension/cmd/extension/README.md
@@ -59,7 +59,6 @@ Example POST
 
 ```
 DELETE /webhooks/<webhookid>?namespace=<my namespace>
-```
 
 You can optionally add &deletepipelineruns=true to remove all PipelineRuns associated with the same repository.
 
@@ -71,6 +70,7 @@ Returns HTTP code 500 if any other errors occurred
 
 Deletes the GithubSource (therefore the webhook from the repository) and optionally deletes all PipelineRuns for the configured repository. 
 The ConfigMap used to maintain a list of configured webhooks to Pipelines is also updated.
+```
 
 
 These endpoints can be accessed through the dashboard.

--- a/webhooks-extension/cmd/extension/main.go
+++ b/webhooks-extension/cmd/extension/main.go
@@ -32,7 +32,8 @@ func main() {
 	// Set up routes
 	wsContainer := restful.NewContainer()
 	// Add extension
-	wsContainer.Add(endpoints.ExtensionWebService(r))
+
+	r.RegisterEndpoints(wsContainer)
 	// Add liveness/readiness
 	wsContainer.Add(endpoints.LivenessWebService())
 	wsContainer.Add(endpoints.ReadinessWebService())

--- a/webhooks-extension/cmd/sink/Dockerfile_test
+++ b/webhooks-extension/cmd/sink/Dockerfile_test
@@ -1,6 +1,6 @@
-# Start from a Debian image with the latest version of Go installed
-# and a workspace (GOPATH) configured at /go.
-FROM golang
+FROM golang:1.12-alpine
+
+RUN apk add curl git
 
 # Copy the local package files to the container's workspace.
 ADD . /go/src/github.com/tektoncd/experimental/webhooks-extension
@@ -12,4 +12,4 @@ RUN chmod +x /usr/bin/dep
 RUN dep ensure -vendor-only
 
 # Run endpoints go tests
-RUN go test github.com/tektoncd/experimental/webhooks-extension/endpoints -v
+RUN CGO_ENABLED=0 go test github.com/tektoncd/experimental/webhooks-extension/endpoints -v

--- a/webhooks-extension/endpoints/webhook.go
+++ b/webhooks-extension/endpoints/webhook.go
@@ -247,8 +247,6 @@ func (r Resource) findRepoURLFromConfigMap(webhookName, namespace string) string
 
 // Delete the webhook information from our ConfigMap
 func (r Resource) deleteWebhookFromConfigMapByName(webhookName, namespace string) error {
-	// We don't want any other requests going through here so use a mutex
-	// otherwise we'll end up with operations performed on old configmaps so we'll have invalid data
 	logging.Log.Debug("Deleting webhook info from ConfigMap")
 
 	configMapClient := r.K8sClient.CoreV1().ConfigMaps(namespace)

--- a/webhooks-extension/endpoints/webhook.go
+++ b/webhooks-extension/endpoints/webhook.go
@@ -212,7 +212,7 @@ func (r Resource) deleteWebhook(request *restful.Request, response *restful.Resp
 		RespondError(response, err, http.StatusBadRequest)
 		return
 	}
-	response.WriteHeader(201)
+	response.WriteHeader(200)
 }
 
 // Find the repository URL for a webhook. We store webhook in a ConfigMap

--- a/webhooks-extension/endpoints/webhook_test.go
+++ b/webhooks-extension/endpoints/webhook_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2009 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -281,8 +281,8 @@ func TestDeleteByNameKeepRuns(t *testing.T) {
 
 	response, _ := http.DefaultClient.Do(httpReq)
 
-	if response.StatusCode != 201 {
-		t.Errorf("Status code not set to 201 when deleting, it's: %d", response.StatusCode)
+	if response.StatusCode != 200 {
+		t.Errorf("Status code not set to 200 when deleting, it's: %d", response.StatusCode)
 	}
 	_, err = r.EventSrcClient.SourcesV1alpha1().GitHubSources(installNs).Get(theWebhook.Name, metav1.GetOptions{})
 
@@ -404,8 +404,8 @@ func TestDeleteByNameDeleteRuns(t *testing.T) {
 	httpReq, _ := http.NewRequest(http.MethodDelete, server.URL+"/webhooks/"+theWebhook.Name+"?namespace="+installNs+"&deletepipelineruns=true", nil)
 
 	response, _ := http.DefaultClient.Do(httpReq)
-	if response.StatusCode != 201 {
-		t.Error("Status code not set to 201 when deleting")
+	if response.StatusCode != 200 {
+		t.Error("Status code not set to 200 when deleting")
 	}
 
 	_, err = r.EventSrcClient.SourcesV1alpha1().GitHubSources(installNs).Get(theWebhook.Name, metav1.GetOptions{})
@@ -553,12 +553,12 @@ func TestMultipleDeletesCorrectData(t *testing.T) {
 
 		wg.Wait()
 
-		if firstResponse.StatusCode != 201 {
-			t.Errorf("Should have deleted the first webhook OK, return code wasn't 201 - it's: %d", firstResponse.StatusCode)
+		if firstResponse.StatusCode != 200 {
+			t.Errorf("Should have deleted the first webhook OK, return code wasn't 200 - it's: %d", firstResponse.StatusCode)
 		}
 
-		if secondResponse.StatusCode != 201 {
-			t.Errorf("Should have deleted the second webhook OK, return code wasn't 201 - it's: %d", secondResponse.StatusCode)
+		if secondResponse.StatusCode != 200 {
+			t.Errorf("Should have deleted the second webhook OK, return code wasn't 200 - it's: %d", secondResponse.StatusCode)
 		}
 
 		//	Check both are gone from the ConfigMap


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adds the ability to delete webhooks by name and if &deletepipelineruns=true is set, delete the PipelineRuns that are for the same Git repository URL. This is only going to work for PipelineRuns we create through the extension as we label them. These labels are what I use to do the comparison with.

I've also made the images Alpine to reduce their size (for our tests Dockerfiles), added tests and API docs.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
