### PR TITLE
Use LoadBalancer not NodePort for Istio and Knative

### DIFF
--- a/webhooks-extension/test/install_prereqs.sh
+++ b/webhooks-extension/test/install_prereqs.sh
@@ -10,9 +10,8 @@ export test_dir="${tekton_repo_dir}/webhooks-extension/test"
 source ${test_dir}/config.sh
 source ${test_dir}/util.sh
   
-# Required for devops-back-end: istio, knative eventing, knative eventing sources, knative serving, and tekton
-install_istio_nodeport ${KNATIVE_VERSION}
-install_knative_serving_nodeport ${KNATIVE_VERSION}
+install_istio ${KNATIVE_VERSION}
+install_knative_serving ${KNATIVE_VERSION}
 install_knative_eventing ${KNATIVE_VERSION}
 install_knative_eventing_sources ${KNATIVE_VERSION}
 install_tekton ${TEKTON_VERSION}

--- a/webhooks-extension/test/util.sh
+++ b/webhooks-extension/test/util.sh
@@ -1,17 +1,15 @@
 #!/bin/bash
 
-function install_istio_nodeport() {
+function install_istio() {
     if [ -z "$1" ]; then
-        echo "Usage ERROR for function: install_istio_nodeport [version]"
+        echo "Usage ERROR for function: install_istio [version]"
         echo "Missing [version]"
         exit 1
     fi
     version="$1"
     # Install on Minikube or Docker Desktop
-    # We are changing LoadBalancer to NodePort for the istio-ingress service
     kubectl apply --filename https://github.com/knative/serving/releases/download/${version}/istio-crds.yaml &&
     curl -L https://github.com/knative/serving/releases/download/${version}/istio.yaml \
-      | sed 's/LoadBalancer/NodePort/' \
       | kubectl apply --filename -
 
     # This works but why are we only labelling the default namespace? 
@@ -23,16 +21,14 @@ function install_istio_nodeport() {
     wait_for_ready_pods istio-system 300 30
 }
 
-function install_knative_serving_nodeport() {
+function install_knative_serving() {
     if [ -z "$1" ]; then
-        echo "Usage ERROR for function: install_knative_serving_nodeport [version]"
+        echo "Usage ERROR for function: install_knative_serving [version]"
         echo "Missing [version]"
         exit 1
     fi
     version="$1"
-    # Use NodePort instead of LoadBalancer for Minikube or Docker Desktop
     curl -L https://github.com/knative/serving/releases/download/${version}/serving.yaml \
-    | sed 's/LoadBalancer/NodePort/' \
     | kubectl apply --filename -
     # Wait until all the pods come up
     wait_for_ready_pods knative-serving 180 20


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Resolves "Service Timeout" problems using Docker Desktop (I'm using version 2.0.3.0 edge). By using LoadBalancer, the Istio ingress gateway service in istio-system gives the ip `localhost` and not `none` like NodePort does.

I know https://knative.dev/docs/install/knative-with-docker-for-mac/ mentions using NodePort but I also know it reliably doesn't work and this does...

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
