### PR TITLE
REST API for accesstokens

### DIFF
--- a/webhooks-extension/cmd/extension/README.md
+++ b/webhooks-extension/cmd/extension/README.md
@@ -32,6 +32,21 @@ Example payload response
  "namespace": "default",
  "dockerregistry": "mydockerhubregistry"
 }
+
+
+GET /webhooks/credentials?namespace=x
+Get all credentials in namespace x
+Returns HTTP code 200 and all the credentials
+Returns HTTP code 500 if an error occurred getting the credentials
+
+Example payload response
+[ 
+  { 
+    "name": "anAccessToken", 
+    accesstoken: "********",
+    secrettoken: "thisIsMySecretToken"
+  }
+]
 ```
 
 ### POST endpoints
@@ -53,9 +68,25 @@ Example POST
   "accesstoken": "github-secret",
   "pipeline": "simple-pipeline"
 }
+
+
+POST /webhooks/credentials?namespace=x
+Create a new credential in namespace x
+Request body must contain name and accesstoken. 
+Request body may contain secrettoken. See https://github.com/knative/docs/blob/master/docs/eventing/samples/github-source/README.md for a discussion of this field. A random secrettoken will be created if none is supplied. 
+Returns HTTP code 201 if the secret was created successfully
+Returns HTTP code 400 if an error occurred with the request body 
+Returns HTTP code 500 if an error occurred while creating the secret
+
+Example POST
+{
+  "name": "my-access-token",
+  "accesstoken": "ksdufbliubsliuvbsliucbsiucslicbsh98wehr8w9huwbcwb87ec"
+}
 ```
 
-### DELETE endpoint
+
+### DELETE endpoints
 
 ```
 DELETE /webhooks/<webhookid>?namespace=<my namespace>
@@ -70,6 +101,14 @@ Returns HTTP code 500 if any other errors occurred
 
 Deletes the GithubSource (therefore the webhook from the repository) and optionally deletes all PipelineRuns for the configured repository. 
 The ConfigMap used to maintain a list of configured webhooks to Pipelines is also updated.
+
+
+DELETE /webhooks/credentials/<credential-name>?namespace=x
+
+Deletes credential 'credential-name' from namespace x
+Returns HTTP code 201 if the credential was deleted successfully
+Returns HTTP code 404 if the credential wasn't found
+Returns HTTP code 500 if any other errors occurred
 ```
 
 

--- a/webhooks-extension/endpoints/credentials.go
+++ b/webhooks-extension/endpoints/credentials.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoints
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"time"
+
+	restful "github.com/emicklei/go-restful"
+	logging "github.com/tektoncd/experimental/webhooks-extension/pkg/logging"
+	"github.com/tektoncd/experimental/webhooks-extension/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// 'credentials' from the webhooks-extension's point of view, are access tokens. That's the only sort we handle right now.
+type credential struct {
+	Name        string `json:"name"`
+	AccessToken string `json:"accesstoken"`
+	SecretToken string `json:"secrettoken,omitempty"`
+}
+
+/*--------------------------------------
+This file implements three endpoints from webhooks.go:
+	ws.Route(ws.POST("/credentials").To(r.createCredential))
+	ws.Route(ws.GET("/credentials").To(r.getAllCredentials))
+	ws.Route(ws.DELETE("/credentials/{name}").To(r.deleteCredential))
+---------------------------------------*/
+
+func (r Resource) createCredential(request *restful.Request, response *restful.Response) {
+	cred := credential{}
+	if err := getQueryEntity(&cred, request, response); err != nil {
+		return
+	}
+	if !r.verifyCredentialParameters(cred, response) {
+		return
+	}
+	targetNamespace := request.QueryParameter("namespace")
+	if targetNamespace == "" {
+		targetNamespace = r.Defaults.Namespace
+	}
+	if !r.namespaceExists(targetNamespace, response) {
+		return
+	}
+	secret := credentialToSecret(cred, targetNamespace, response)
+	if _, err := r.K8sClient.CoreV1().Secrets(targetNamespace).Create(secret); err != nil {
+		errorMessage := fmt.Sprintf("error creating secret in K8sClient: %s", err.Error())
+		utils.RespondMessageAndLogError(response, err, errorMessage, http.StatusBadRequest)
+		return
+	}
+	writeResponseLocation(request, response, cred.Name)
+}
+
+func (r Resource) deleteCredential(request *restful.Request, response *restful.Response) {
+	targetNamespace := request.QueryParameter("namespace")
+	if targetNamespace == "" {
+		targetNamespace = r.Defaults.Namespace
+	}
+	if !r.namespaceExists(targetNamespace, response) {
+		return
+	}
+	credName := request.PathParameter("name")
+	if !r.verifySecretExists(credName, targetNamespace, response) {
+		return
+	}
+	err := r.K8sClient.CoreV1().Secrets(targetNamespace).Delete(credName, &metav1.DeleteOptions{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("error deleting secret from K8sClient: %s.", err.Error())
+		utils.RespondMessageAndLogError(response, err, errorMessage, http.StatusInternalServerError)
+		return
+	}
+}
+
+func (r Resource) getAllCredentials(request *restful.Request, response *restful.Response) {
+	targetNamespace := request.QueryParameter("namespace")
+	if targetNamespace == "" {
+		targetNamespace = r.Defaults.Namespace
+	}
+	if !r.namespaceExists(targetNamespace, response) {
+		return
+	}
+
+	// Get secrets from the resource K8sClient
+	secrets, err := r.K8sClient.CoreV1().Secrets(targetNamespace).List(metav1.ListOptions{})
+
+	if err != nil {
+		errorMessage := fmt.Sprintf("error getting secrets from K8sClient: %s.", err.Error())
+		response.WriteErrorString(http.StatusInternalServerError, errorMessage)
+		logging.Log.Error(errorMessage)
+		return
+	}
+
+	// Parse K8s secrets to credentials
+	creds := []credential{}
+	emptyCred := credential{}
+	for _, secret := range secrets.Items {
+		cred := secretToCredential(&secret, true)
+		if cred != emptyCred {
+			creds = append(creds, cred)
+			logging.Log.Infof("getAllCredentials Found credential %+v\n", cred)
+		}
+	}
+
+	logging.Log.Infof("getAllCredentials returning +%v", creds)
+
+	// Write the response
+	response.AddHeader("Content-Type", "application/json")
+	response.WriteEntity(creds)
+}
+
+// Sends error message 404 if the secret does not exist in the resource K8sClient
+func (r Resource) verifySecretExists(secretName string, namespace string, response *restful.Response) bool {
+	_, err := r.K8sClient.CoreV1().Secrets(namespace).Get(secretName, metav1.GetOptions{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("error getting secret from K8sClient: '%s'.", secretName)
+		utils.RespondMessageAndLogError(response, err, errorMessage, http.StatusNotFound)
+		return false
+	}
+	return true
+}
+
+// Convert credential struct into K8s secret struct
+func credentialToSecret(cred credential, namespace string, response *restful.Response) *corev1.Secret {
+	// Create new secret struct
+	secret := corev1.Secret{}
+	secret.Type = corev1.SecretTypeOpaque
+	secret.SetNamespace(namespace)
+	secret.SetName(cred.Name)
+	secret.Data = make(map[string][]byte)
+	secret.Data["accessToken"] = []byte(cred.AccessToken)
+	if cred.SecretToken != "" {
+		secret.Data["secretToken"] = []byte(cred.SecretToken)
+	} else {
+		secret.Data["secretToken"] = getRandomSecretToken()
+	}
+	return &secret
+}
+
+var (
+	src = rand.NewSource(time.Now().UnixNano())
+)
+
+const (
+	tokenBytes   = "123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	tokenIdxBits = 6                   // 6 bits = 2^6 = 64 characters in tokenBytes
+	tokenIdxMask = 1<<tokenIdxBits - 1 // All 1-bits, as many as tokenIdxBits
+)
+
+// Generate a random 20-character string, returned as []byte.
+// With thanks to https://medium.com/@kpbird/golang-generate-fixed-size-random-string-dd6dbd5e63c0
+func getRandomSecretToken() []byte {
+	b := make([]byte, 20)
+	for i := 0; i < 20; {
+		idx := int(src.Int63() & tokenIdxMask)
+		if idx < len(tokenBytes) {
+			b[i] = tokenBytes[idx]
+			i++
+		}
+	}
+	return b
+}
+
+// Convert K8s secret struct into credential struct
+func secretToCredential(secret *corev1.Secret, mask bool) credential {
+	var cred credential
+	if secret.Data["accessToken"] != nil {
+		cred = credential{
+			Name:        secret.GetName(),
+			AccessToken: string(secret.Data["accessToken"]),
+			SecretToken: string(secret.Data["secretToken"]),
+		}
+		if mask {
+			cred.AccessToken = "********"
+		}
+	}
+	return cred
+}
+
+// Checks the Accept header and reads the content into the entityPointer.
+func getQueryEntity(entityPointer interface{}, request *restful.Request, response *restful.Response) (err error) {
+	if err := request.ReadEntity(entityPointer); err != nil {
+		errorMessage := "error parsing request body."
+		utils.RespondMessageAndLogError(response, err, errorMessage, http.StatusBadRequest)
+		return err
+	}
+	return nil
+}
+
+func (r Resource) verifyCredentialParameters(cred credential, response *restful.Response) bool {
+	errorMessage := ""
+	if cred.Name == "" {
+		errorMessage = fmt.Sprintf("error: Name must be specified")
+	} else if cred.AccessToken == "" {
+		errorMessage = fmt.Sprintf("error: AccessToken must be specified")
+	}
+	if errorMessage != "" {
+		utils.RespondErrorMessage(response, errorMessage, http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+// Write Content-Location header within POST methods and set StatusCode to 201
+// Headers MUST be set before writing to body (if any) to succeed
+func writeResponseLocation(request *restful.Request, response *restful.Response, identifier string) {
+	location := request.Request.URL.Path
+	if request.Request.Method == http.MethodPost {
+		location = location + "/" + identifier
+	}
+	response.AddHeader("Content-Location", location)
+	response.WriteHeader(201)
+}
+
+// Returns true if namespace exists. Returns false and logs an HTTP error 400 if it does not.
+func (r Resource) namespaceExists(namespace string, response *restful.Response) bool {
+	_, err := r.K8sClient.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("error: namespace does not exist: '%s'.", namespace)
+		utils.RespondMessageAndLogError(response, err, errorMessage, http.StatusBadRequest)
+		return false
+	}
+	return true
+}

--- a/webhooks-extension/endpoints/credentials_test.go
+++ b/webhooks-extension/endpoints/credentials_test.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoints
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCreateBadAccessToken(t *testing.T) {
+	r := dummyResource()
+	namespace := "default"
+	r.K8sClient.CoreV1().Namespaces().Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+	badAccessToken := credential{
+		Name: "badToken",
+	}
+	expectedError := fmt.Sprintf("error: AccessToken must be specified")
+	createAndCheckCredential(namespace, badAccessToken, expectedError, r, t)
+
+	// Verify no credentials have been created
+	checkCredentials(namespace, []credential{}, "", r, t)
+}
+
+func TestCreateTokenInNamespaceThatDoesNotExist(t *testing.T) {
+	r := dummyResource()
+	namespace := "iDoNotExist"
+	accessToken := credential{
+		Name:        "wrongPlaceToken",
+		AccessToken: "aLongStringOfh3x",
+	}
+	expectedError := fmt.Sprintf("error: namespace does not exist: '%s'", namespace)
+	createAndCheckCredential(namespace, accessToken, expectedError, r, t)
+
+	// Verify no credentials have been created
+	checkCredentials(namespace, []credential{}, "", r, t)
+}
+
+func TestAccessTokenWithSecret(t *testing.T) {
+	r := dummyResource()
+	namespace := "default"
+	r.K8sClient.CoreV1().Namespaces().Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+	accessTokenWithSecret := credential{
+		Name:        "accesstoken-with-secret",
+		AccessToken: "alongstringofcharacters",
+		SecretToken: "thisIsMySecretToken",
+	}
+	createAndCheckCredential(namespace, accessTokenWithSecret, "", r, t)
+}
+
+func TestAccessTokenWithNoSecret(t *testing.T) {
+	r := dummyResource()
+	namespace := "b-namespace"
+	r.K8sClient.CoreV1().Namespaces().Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+
+	accessTokenNoSecret := credential{
+		Name:        "accesstoken-nosecret",
+		AccessToken: "anotherlongstringofcharacters",
+	}
+
+	jsonBody, _ := json.Marshal(accessTokenNoSecret)
+	t.Logf("json body for create cred test: %s", jsonBody)
+	httpReq := dummyHTTPRequest("POST", "http://wwww.dummy.com:8383/webhooks/credentials?namespace=b-namespace", bytes.NewBuffer(jsonBody))
+	req := dummyRestfulRequest(httpReq, namespace, "")
+	httpWriter := httptest.NewRecorder()
+	resp := dummyRestfulResponse(httpWriter)
+	r.createCredential(req, resp)
+
+	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/webhooks/credentials?namespace=b-namespace", bytes.NewBuffer(nil))
+	req = dummyRestfulRequest(httpReq, namespace, "")
+	httpWriter = httptest.NewRecorder()
+	resp = dummyRestfulResponse(httpWriter)
+	r.getAllCredentials(req, resp)
+
+	result := []credential{}
+	b, err := ioutil.ReadAll(httpWriter.Body)
+	if err != nil {
+		t.Fatalf("FAIL: ERROR - reading response body: %s", err.Error())
+	}
+	err = json.Unmarshal(b, &result)
+
+	t.Logf("unmarshalled result '%+v'", result)
+
+	if result[0].Name != accessTokenNoSecret.Name {
+		t.Fatalf("Result came back with name %s but expected %s", result[0].Name, accessTokenNoSecret.Name)
+	}
+	// Finally check that result has a SecretToken set
+	if strings.Count(result[0].SecretToken, "") < 20 {
+		t.Fatalf("Result came back with less than twenty chars of secret token: '%s'", result[0].SecretToken)
+	}
+
+}
+
+func TestDeleteCredential(t *testing.T) {
+	r := dummyResource()
+	namespace := "ns2"
+	r.K8sClient.CoreV1().Namespaces().Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+	accessTokenToDelete := credential{
+		Name:        "accesstokenToDelete",
+		AccessToken: "sdkfhighregusfbliusbbbwhfwiehw8hwefhw938hf497fhw97b47",
+		SecretToken: "provideASecretTokenSoThatCreateAndCheckCredCanDoDeepEquals",
+	}
+	createAndCheckCredential(namespace, accessTokenToDelete, "", r, t)
+
+	httpReq := dummyHTTPRequest("DELETE", "http://wwww.dummy.com:8383/webhooks/credentials/accesstokenToDelete?namespace=ns2", bytes.NewBuffer(nil))
+	req := dummyRestfulRequest(httpReq, namespace, "accesstokenToDelete")
+	httpWriter := httptest.NewRecorder()
+	resp := dummyRestfulResponse(httpWriter)
+	r.deleteCredential(req, resp)
+
+	creds := r.getK8sCredentials(namespace)
+	if len(creds) > 0 {
+		t.Fatalf("Namespace %s should contain no credentials, but we found %+v", namespace, creds)
+	}
+}
+
+func TestDeleteACredentialThatDoesNotExist(t *testing.T) {
+	r := dummyResource()
+	namespace := "ns3"
+	r.K8sClient.CoreV1().Namespaces().Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+	httpReq := dummyHTTPRequest("DELETE", "http://wwww.dummy.com:8383/webhooks/credentials/accesstokenToDelete?namespace=ns3", bytes.NewBuffer(nil))
+	req := dummyRestfulRequest(httpReq, namespace, "accesstokenToDelete")
+	httpWriter := httptest.NewRecorder()
+	resp := dummyRestfulResponse(httpWriter)
+	r.deleteCredential(req, resp)
+	if resp.StatusCode() != http.StatusNotFound {
+		t.Fatalf("Expected 404 deleting non-existent credential but got %d", resp.StatusCode())
+	}
+}
+
+//----------------------------------------
+// end of Tests. Helper functions bbelow.
+//----------------------------------------
+
+// SecretTokens are twenty characters randomly selected from a set of sixty one. 61^20=5.08e35. We should 'never' get the same token twice.
+func TestRandomStringGenerator(t *testing.T) {
+	tokens := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		token := string(getRandomSecretToken())
+		if tokens[token] == true {
+			t.Fatalf("Generated the same token twice in less than a hundred tries! map=%+v", tokens)
+		}
+		tokens[token] = true
+	}
+}
+
+func createAndCheckCredential(namespace string, cred credential, expectError string, r *Resource, t *testing.T) {
+	t.Logf("CREATE credential %+v", cred)
+
+	// Create dummy rest api request and response
+	jsonBody, _ := json.Marshal(cred)
+	t.Logf("json body for create cred test: %s", jsonBody)
+	url := fmt.Sprintf("http://wwww.dummy.com:8383/webbhooks/credentials/?namespace=%s", namespace)
+	httpReq := dummyHTTPRequest("POST", url, bytes.NewBuffer(jsonBody))
+	req := dummyRestfulRequest(httpReq, namespace, "")
+	httpWriter := httptest.NewRecorder()
+	resp := dummyRestfulResponse(httpWriter)
+	r.createCredential(req, resp)
+
+	// Sometimes we expect an error here, in which case no credential will have been created.
+	if expectError != "" {
+		resultCred := credential{}
+		checkResponseError(httpWriter.Body, &resultCred, expectError, t)
+	} else {
+		compareCredentials(r.getK8sCredential(namespace, cred.Name), cred, t)
+	}
+}
+
+func (r Resource) getK8sCredentials(namespace string) (credentials []credential) {
+	secrets, err := r.K8sClient.CoreV1().Secrets(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return
+	}
+	for _, secret := range secrets.Items {
+		credentials = append(credentials, secretToCredential(&secret, false))
+	}
+	return credentials
+}
+
+func (r Resource) getK8sCredential(namespace string, name string) (credential credential) {
+	secret, err := r.K8sClient.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+	return secretToCredential(secret, false)
+}
+
+func compareCredentials(resultCred credential, expectCred credential, t *testing.T) {
+	t.Logf("Result cred: %+v\n", resultCred)
+	t.Logf("Expect cred: %+v\n", expectCred)
+	if !reflect.DeepEqual(resultCred, expectCred) {
+		t.Fatal("Credentials not equal")
+	}
+}
+
+func checkResponseError(body *bytes.Buffer, result interface{}, expectError string, t *testing.T) bool {
+	b, err := ioutil.ReadAll(body)
+	if err != nil {
+		t.Fatalf("FAIL: ERROR - reading response body: %s", err.Error())
+		return false
+	}
+	err = json.Unmarshal(b, result)
+	if err != nil {
+		fmt.Printf("checkResponseError jsonUnmarshal got err '%s' expected '%s' got '%s'", err, expectError, string(b))
+		resultError := string(b)
+		if !strings.HasPrefix(resultError, expectError) {
+			t.Fatalf("FAIL: ERROR - Error message == '%s', want '%s', body: %s", resultError, expectError, body)
+		}
+		return false
+	}
+	if expectError != "" {
+		t.Fatalf("FAIL: ERROR - Result == %+v, want error message '%s'", result, expectError)
+	}
+	return true
+}
+
+func checkCredentials(namespace string, expectCreds []credential, expectError string, r *Resource, t *testing.T) {
+	t.Logf("READ all credentials. Expecting: %+v", expectCreds)
+	// Create dummy REST API request and response
+	url := fmt.Sprintf("http://wwww.dummy.com:8383/v1/webhooks/credentials?namespace=%s", namespace)
+	httpReq := dummyHTTPRequest("GET", url, nil)
+	req := dummyRestfulRequest(httpReq, namespace, "")
+	httpWriter := httptest.NewRecorder()
+	resp := dummyRestfulResponse(httpWriter)
+
+	// Test to get all credentials
+	r.getAllCredentials(req, resp)
+
+	// Look for password "********"
+	accessTokens := []string{}
+	for i, cred := range expectCreds {
+		accessToken := cred.AccessToken
+		accessTokens = append(accessTokens, accessToken)
+		expectCreds[i].AccessToken = "********"
+	}
+	// Read result
+	resultCreds := []credential{}
+	if !checkResponseError(httpWriter.Body, &resultCreds, expectError, t) {
+		return
+	}
+	testCredentials(resultCreds, expectCreds, t)
+	for i := range expectCreds {
+		expectCreds[i].AccessToken = accessTokens[i]
+	}
+
+	// Verify against K8s client
+	testCredentials(r.getK8sCredentials(namespace), expectCreds, t)
+	t.Logf("Done in READ all credentials. Expecting: %+v", expectCreds)
+}
+
+// Compares two lists of credentials
+func testCredentials(result []credential, expectResult []credential, t *testing.T) {
+	if len(result) != len(expectResult) {
+		t.Fatalf("ERROR: Result == %+v, want %+v, different number of credentials", len(result), len(expectResult))
+	}
+	for i := range expectResult {
+		compareCredentials(result[i], expectResult[i], t)
+	}
+}

--- a/webhooks-extension/endpoints/webhook.go
+++ b/webhooks-extension/endpoints/webhook.go
@@ -17,11 +17,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	logging "github.com/tektoncd/experimental/webhooks-extension/pkg/logging"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
+
+	logging "github.com/tektoncd/experimental/webhooks-extension/pkg/logging"
 
 	restful "github.com/emicklei/go-restful"
 	eventapi "github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
@@ -45,6 +46,10 @@ func (r Resource) RegisterEndpoints(container *restful.Container) {
 	ws.Route(ws.GET("/defaults").To(r.getDefaults))
 
 	ws.Route(ws.DELETE("/{name}").To(r.deleteWebhook))
+
+	ws.Route(ws.POST("/credentials").To(r.createCredential))
+	ws.Route(ws.GET("/credentials").To(r.getAllCredentials))
+	ws.Route(ws.DELETE("/credentials/{name}").To(r.deleteCredential))
 
 	container.Add(ws)
 }

--- a/webhooks-extension/pkg/utils/utils.go
+++ b/webhooks-extension/pkg/utils/utils.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"strings"
+
+	restful "github.com/emicklei/go-restful"
+	logging "github.com/tektoncd/dashboard/pkg/logging"
+)
+
+// RespondError - logs and writes an error response with a desired status code
+func RespondError(response *restful.Response, err error, statusCode int) {
+	logging.Log.Error("Error: ", strings.Replace(err.Error(), "/", "", -1))
+	response.AddHeader("Content-Type", "text/plain")
+	response.WriteError(statusCode, err)
+}
+
+// RespondErrorMessage - logs and writes an error message with a desired status code
+func RespondErrorMessage(response *restful.Response, message string, statusCode int) {
+	logging.Log.Debugf("Error message: %s", message)
+	response.AddHeader("Content-Type", "text/plain")
+	response.WriteErrorString(statusCode, message)
+}
+
+// RespondMessageAndLogError - logs and writes an error message with a desired status code and logs the error
+func RespondMessageAndLogError(response *restful.Response, err error, message string, statusCode int) {
+	logging.Log.Error("Error: ", strings.Replace(err.Error(), "/", "", -1))
+	logging.Log.Debugf("Message: %s", message)
+	response.AddHeader("Content-Type", "text/plain")
+	response.WriteErrorString(statusCode, message)
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

As part of https://github.com/tektoncd/dashboard/issues/160 I'm moving support for secrets that are access tokens out of dashboard into webhooks-extension. This PR adds the support to webhooks extension. A second PR will prune down credentials.go in dashboard. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._