### PR TITLE
EventBinding creates v1.Service for the Listener it manages

### DIFF
--- a/tekton-listener/pkg/apis/pipelineexperimental/v1alpha1/eventbinding_types.go
+++ b/tekton-listener/pkg/apis/pipelineexperimental/v1alpha1/eventbinding_types.go
@@ -77,6 +77,8 @@ type EventBindingStatus struct {
 	Namespace string `json:"namespace"`
 	// name of the tekton listeners resource
 	ListenerName string `json:"listenername"`
+	// name of the service for the listener
+	ServiceName string `json:"servicename"`
 	// The listener is addressable
 	// +optional
 	Address duckv1alpha1.Addressable `json:"address,omitempty"`

--- a/tekton-listener/pkg/reconciler/eventbinding/reconciler.go
+++ b/tekton-listener/pkg/reconciler/eventbinding/reconciler.go
@@ -42,6 +42,11 @@ import (
 	"github.com/tektoncd/experimental/tekton-listener/pkg/reconciler"
 )
 
+var (
+	servicePort = int32(80)
+	targetPort  = intstr.FromInt(8082)
+)
+
 const controllerAgentName = "eventbinding-controller"
 
 // Reconciler is the controller.Reconciler implementation for eventbinding resources
@@ -227,8 +232,8 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
-					Port:       80,
-					TargetPort: intstr.FromInt(8082),
+					Port:       servicePort,
+					TargetPort: targetPort,
 				},
 			},
 		},


### PR DESCRIPTION
Adds ability for EventBinding to create a corev1.Service for the listener it creates, as an addressable endpoint, when it provisions a TektonListener.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
