### PR TITLE
Fix issue with user supplying repo with .git suffix

### DIFF
--- a/webhooks-extension/pkg/endpoints/webhook.go
+++ b/webhooks-extension/pkg/endpoints/webhook.go
@@ -381,7 +381,7 @@ func (r Resource) getGitHubWebhook(gitRepoURL string, namespace string) (webhook
 		return webhook{}, err
 	}
 	for _, source := range sources {
-		if source.GitRepositoryURL == gitRepoURL {
+		if strings.TrimSuffix(strings.ToLower(source.GitRepositoryURL), ".git") == strings.TrimSuffix(strings.ToLower(gitRepoURL), ".git") {
 			return source, nil
 		}
 	}


### PR DESCRIPTION
If a user supplies a repository URL that ends with .git the sink will
not find a match for the actual webhook.  The actual webhook's payload
does not have the .git suffix and so does not match the one stored in
the config map.

# Changes

When examining the config map to retrieve the settings needed to create the pipeline run, we now ignore the case and the .git suffix when comparing the repo URL.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [N/A ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
