### PR TITLE
Fix issue with secret creation not auto selected (issue #80)

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.f59d5c7f.js"
+    tekton-dashboard-bundle-location: "web/extension.adcd3523.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
+++ b/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
@@ -321,9 +321,7 @@ class WebhookCreatePage extends Component {
     }
     let invert = !this.state.showCreateDialog;
     this.setState({
-      showCreateDialog: invert,
-      newSecretName: '',
-      newTokenValue: '',
+      showCreateDialog: invert
     });
   }
 

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirm.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirm.test.js
@@ -125,6 +125,7 @@ describe('create secret', () => {
     fireEvent.click(document.getElementsByClassName('create-modal').item(0).getElementsByClassName('bx--btn--primary').item(0))
     await waitForElement(() => getByText(/Secret created/i));
     expect(document.getElementsByClassName('notification').item(0).childElementCount).toBe(1);
+    expect(document.getElementById('git').getElementsByClassName('bx--list-box__label').item(0).textContent).toBe("new-secret-foo")
   });
   
 })


### PR DESCRIPTION
# Changes

Problem was caused because on creation of the new secret, the modal was toggled to no longer be shown and as part of that function, the 'newSecretName' was reset to ''.  The subsequent action to then set 'gitsecret' in state, simply set the value to '' and thus it was not shown as the 'selectedItem'.

This change removes the reset of the 'newSecretName' during toggling of the modal.  We do not need to worry about the name being shown again if the user subsequently clicked on the plus icon, as this 'newSecretName' is set to '' after 'gitsecret' has been set in state, after the modal is toggled.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ N/A ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ x ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)