### PR TITLE
Update README with quickstart install instructions

### DIFF
--- a/webhooks-extension/DEVELOPMENT.md
+++ b/webhooks-extension/DEVELOPMENT.md
@@ -1,5 +1,9 @@
 # Developing
 
+Involved development scripts and instructions can be found in the [development installation guide](https://github.com/tektoncd/experimental/blob/master/webhooks-extension/test/README.md#scripting)
+
+## UI development
+
 If modifying the UI code and wanting to deploy your updated version:
 
 1) Run `npm run build` this will create a new file in the dist directory
@@ -9,8 +13,48 @@ If modifying the UI code and wanting to deploy your updated version:
 
 3) Reinstall (If not re-installing the main dashboard, you will need to kill the dashboard pod after the new extension pod starts.  This only needs doing until https://github.com/tektoncd/dashboard/issues/215 is completed.)
 
-### Linting
+## Linting
 
 Run `npm run lint` to execute the linter. This will ensure code follows the conventions and standards used by the project.
 
 Run `npm run lint:fix` to automatically fix a number of types of problem including code style.
+
+## Running tests
+
+```bash
+docker build -f cmd/extension/Dockerfile_test .
+```
+
+## API Definitions
+
+- [Extension API definitions](cmd/extension/README.md)
+  - The extension API endpoints can be accessed through the dashboard.
+- [Sink API definitions](cmd/sink/README.md)
+
+### Example creating a webhook
+
+We would recommend using the extension via the Tekton Dashboard UI - however, for development purposes you can create your webhook using curl:
+
+```bash
+data='{
+  "name": "go-hello-world",
+  "namespace": "green",
+  "gitrepositoryurl": "https://github.com/ncskier/go-hello-world",
+  "accesstoken": "github-secret",
+  "pipeline": "simple-pipeline",
+  "dockerregistry": "mydockerregistry"
+}'
+curl -d "${data}" -H "Content-Type: application/json" -X POST http://localhost:8080/webhooks
+```
+
+When curling through the dashboard, use the same endpoints; for example, assuming the dashboard is at `localhost:9097`:
+
+```bash
+curl -d "${data}" -H "Content-Type: application/json" -X POST http://localhost:9097/webhooks
+```
+
+Reference the [Knative eventing GitHub source sample](https://knative.dev/docs/eventing/samples/github-source/) to properly create the `accesstoken` secret. This is the secret that is used to create GitHub webhooks.
+
+## Architecture information
+
+Each webhook that the user creates will store its configuration information in a config map in the install namespace. This information is used by the sink to create `PipelineRuns` for webhook events.

--- a/webhooks-extension/README.md
+++ b/webhooks-extension/README.md
@@ -1,72 +1,72 @@
 # Webhooks Extension
+
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/kubernetes/experimental/blob/master/LICENSE)
 
-The Webhooks Extension for Tekton allows users to set up Git webhooks that will trigger Tekton PipelineRuns and TaskRuns. An initial implementation will use Knative Eventing but we're closely following the eventing discussion in  [Tekton Pipeline](https://github.com/tektoncd/pipeline) to minimize necessary componentry.
+The Webhooks Extension for Tekton allows users to set up GitHub webhooks that will trigger Tekton `PipelineRuns` and associated `TaskRuns`.
+
+This initial implementation utilises Knative Eventing but there is discussion and work in [Tekton Pipelines](https://github.com/tektoncd/pipeline) to minimize necessary componentry in future.
 
 In addition to Tekton/Knative Eventing glue, it includes an extension to the Tekton Dashboard.
 
-## Runtime Dependencies
-- [Tekton](https://github.com/tektoncd/pipeline) & [Tekton Dashboard](https://github.com/tektoncd/dashboard)
-- Knative [eventing](https://knative.dev/docs/eventing/), [eventing sources](https://knative.dev/docs/eventing/sources/), & [serving](https://knative.dev/docs/serving/)
+## Prerequisites
 
-## Install
-Please see the [development installation guide](https://github.com/tektoncd/experimental/blob/master/webhooks-extension/test/README.md#scripting)
+- Install [Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) and the [Tekton Dashboard](https://github.com/tektoncd/dashboard)
 
-_Note: The main dashboard user interface (UI) finds registered extension UIs when the main dashboard pod starts.  If you have installed this extension after you installed the dashboard you will need to restart the dashboard pod (`kubectl delete pod -l app=tekton-dashboard`). This only needs doing until https://github.com/tektoncd/dashboard/issues/215 is completed such that the dashboard dynamically finds extensions._
+- Install Istio - for a quickstart install, for example of version 1.1.8 run `./scripts/install_istio.sh 1.1.8` _or_ follow https://knative.dev/docs/install/installing-istio/ for a more customised install _(Istio version 1.1.8 is recommended)_
 
-## Running tests
+- Install Knative Eventing, Eventing Sources & Serving - for a quickstart install, for example of version 0.6.0 run `./scripts/install_knative.sh v0.6.0`, for more detailed instructions see the [Knative docs](https://knative.dev/docs/install/index.html) _(Knative version 0.6.0 is recommended)_
 
-```bash
-docker build -f cmd/extension/Dockerfile_test .
+*If running on Docker for Desktop*
+
+- Knative requires a Kubernetes cluster running version v.1.11 or greater. Currently this requires the edge version of Docker for Desktop. Your cluster must also be supplied with sufficient resources _(6 CPUs, 10GiB Memory & 2.5GiB swap is known good)_.
+
+## Install Quickstart
+
+### Domain setup for Knative Serving
+
+Set your own domain and selectors following the [configuring Knative Serving docs](https://github.com/knative/serving/blob/master/install/CONFIG.md) which outline setting up routes in the `config-domain` ConfigMap in the `knative-serving` namespace
+
+On Docker Desktop, you can retrieve your IP and patch it to the ConfigMap by running:
+
+`ip=$(ifconfig | grep netmask | sed -n 2p | cut -d ' ' -f2)`
+
+```
+kubectl patch configmap config-domain --namespace knative-serving --type='json' \
+  --patch '[{"op": "add", "path": "/data/'"${ip}.nip.io"'", "value": ""}]'
 ```
 
-## API Definitions
+### Install the Webhooks Extension 
 
-- [Extension API definitions](cmd/extension/README.md)
-  - The extension API endpoints can be accessed through the dashboard.
-- [Sink API definitions](cmd/sink/README.md)
+The Tekton Webhooks Extension has hosted images located at `gcr.io/tekton-nightly/extension:latest` and `gcr.io/tekton-nightly/extension:latest`, to install the latest extension and sink using these images:
 
-### Example creating a webhook
+`kubectl apply -f config/release/gcr-tekton-webhooks-extension.yaml`
 
-You should be able to use the extension via the Tekton Dashboard UI - however, until the UI is coded or if you would prefer to interact with REST endpoint directly, you can create your webhook using curl:
+### Access the Extension through the Dashboard UI 
 
-```bash
-data='{
-  "name": "go-hello-world",
-  "namespace": "green",
-  "gitrepositoryurl": "https://github.com/ncskier/go-hello-world",
-  "accesstoken": "github-secret",
-  "pipeline": "simple-pipeline",
-  "dockerregistry": "mydockerregistry"
-}'
-curl -d "${data}" -H "Content-Type: application/json" -X POST http://localhost:8080/webhooks
-```
+Restart the dashboard to register the extension:
 
-When curling through the dashboard, use the same endpoints; for example, assuming the dashboard is at `localhost:9097`:
+`kubectl delete pod -l app=tekton-dashboard`
 
-```bash
-curl -d "${data}" -H "Content-Type: application/json" -X POST http://localhost:9097/webhooks
-```
+Access the Dashboard through its ClusterIP Service by running `kubectl proxy`. Assuming tekton-pipelines is the install namespace for the dashboard, you can access the web UI at localhost:8001/api/v1/namespaces/tekton-pipelines/services/tekton-dashboard:http/proxy/ 
 
-Reference the [Knative eventing GitHub source sample](https://knative.dev/docs/eventing/samples/github-source/) to properly create the `accesstoken` secret. This is the secret that is used to create GitHub webhooks.
+Navigate to `Webhooks`, listed in the navigation under `Extensions`
+
+## Uninstall
+
+`kubectl delete -f config/release/gcr-tekton-webhooks-extension.yaml`
 
 ## Limitations
 
-- Only Git Hub webhooks are currently supported.
-- Only `push` and `pull_request` events are supported at the moment. The webhook is currently only created with both `push` and `pull_request` events.
-- All knative event sources are created in the namespace into which the dashboard and this extension are installed.
-- Only one webhook can be created for each git repository, so each repository will only be able to trigger a PipelineRun from one webhook.
-
-- Three pipeline definitions are currently supported.
-
-  - [simple-pipeline](https://github.com/pipeline-hotel/example-pipelines/blob/master/config/pipeline.yaml)
-  - [simple-helm-pipeline](https://github.com/pipeline-hotel/example-pipelines/blob/master/config/helm-pipeline.yaml) (requires a secret to talk to a secure Tiller)
-  - [simple-helm-pipeline-insecure](https://github.com/pipeline-hotel/example-pipelines/blob/master/config/helm-insecure-pipeline.yaml.yaml)
-
-## Architecture information
-
-Each webhook that the user creates will store its configuration information as a configmap in the install namespace. The information is used later by the sink to create PipelineRuns for webhook events.
+- Only GitHub webhooks are currently supported.
+- Only `push` and `pull_request` events are currently supported, these are the events defined on the webhook.
+- Only one webhook can be created for each Git repository, so each repository will only be able to trigger a `PipelineRun` from one webhook.
 
 ## Want to get involved
 
 Visit the [Tekton Community](https://github.com/tektoncd/community) project for an overview of our processes.
+
+## For developers
+
+If you are looking to develop or contribute to this repository please see the [development docs](https://github.com/tektoncd/experimental/blob/master/webhooks-extension/DEVELOPMENT.md)
+
+For more involved development scripts please see the [development installation guide](https://github.com/tektoncd/experimental/blob/master/webhooks-extension/test/README.md#scripting)

--- a/webhooks-extension/cmd/extension/Dockerfile
+++ b/webhooks-extension/cmd/extension/Dockerfile
@@ -16,14 +16,11 @@ RUN dep ensure -vendor-only
 
 RUN npm install
 RUN npm rebuild node-sass
-RUN ls -l
 RUN cat ./build-it.sh
 RUN npm run build
 
 # # Build the extension command inside the container.
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /app github.com/tektoncd/experimental/webhooks-extension/cmd/extension
-
-
 
 FROM scratch
 COPY --from=builder /app .

--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.207ec985.js"
+    tekton-dashboard-bundle-location: "web/extension.bac9f2ac.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
@@ -1,0 +1,87 @@
+# ------------------- Extension Deployment ------------------- #
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webhooks-extension
+  labels:
+    app: webhooks-extension
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: webhooks-extension
+  template:
+    metadata:
+      labels:
+        app: webhooks-extension
+    spec:
+      containers:
+        - name: webhooks-extension
+          image: "gcr.io/tekton-nightly/extension:latest"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 8080
+          env:
+          - name: PORT
+            value: "8080"
+          - name: INSTALLED_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: DOCKER_REGISTRY_LOCATION
+            value: DOCKER_REPO
+          - name: WEB_RESOURCES_DIR
+            value: web
+---
+# ------------------- Extension Service ------------------- #
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhooks-extension
+  labels:
+    app: webhooks-extension
+    tekton-dashboard-extension: "true"
+  annotations:
+    tekton-dashboard-display-name: Webhooks
+    tekton-dashboard-endpoints: "webhooks.web"
+    tekton-dashboard-bundle-location: "web/extension.bac9f2ac.js"
+spec:
+  type: NodePort
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: webhooks-extension
+---
+# ------------------- Sink Knative Service ------------------- #
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: webhooks-extension-sink
+  labels:
+    app: webhooks-extension-sink
+spec:
+  template:
+    spec:
+      containers:
+      - image: "gcr.io/tekton-nightly/sink:latest"
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /liveness
+        readinessProbe:
+          httpGet:
+            path: /readiness
+        env:
+        - name: INSTALLED_NAMESPACE
+          value: tekton-pipelines

--- a/webhooks-extension/pkg/endpoints/webhook.go
+++ b/webhooks-extension/pkg/endpoints/webhook.go
@@ -502,18 +502,21 @@ func (r Resource) RegisterWeb(container *restful.Container) {
 	var handler http.Handler
 	webResourcesDir := os.Getenv("WEB_RESOURCES_DIR")
 	koDataPath := os.Getenv("KO_DATA_PATH")
-	if _, err := os.Stat(webResourcesDir); err != nil {
+	_, err := os.Stat(webResourcesDir)
+	if err != nil {
 		if os.IsNotExist(err) {
 			if koDataPath != "" {
 				logging.Log.Warnf("WEB_RESOURCES_DIR %s not found, serving static content from KO_DATA_PATH instead.", webResourcesDir)
 				handler = http.FileServer(http.Dir(koDataPath))
 			} else {
-				logging.Log.Errorf("WEB_RESOURCES %s not found and KO_DATA_PATH not found, static resource (UI) problems to be expected.")
+				logging.Log.Errorf("WEB_RESOURCES_DIR %s not found and KO_DATA_PATH not found, static resource (UI) problems to be expected.", webResourcesDir)
 			}
 		} else {
-			logging.Log.Infof("Serving static files from WEB_RESOURCES_DIR: %s", webResourcesDir)
-			handler = http.FileServer(http.Dir(webResourcesDir))
+			logging.Log.Errorf("error returned while checking for WEB_RESOURCES_DIR %s", webResourcesDir)
 		}
+	} else {
+		logging.Log.Infof("Serving static files from WEB_RESOURCES_DIR: %s", webResourcesDir)
+		handler = http.FileServer(http.Dir(webResourcesDir))
 	}
 	container.Handle("/web/", http.StripPrefix("/web/", handler))
 }

--- a/webhooks-extension/scripts/install_istio.sh
+++ b/webhooks-extension/scripts/install_istio.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Knative does not bundle Istio as of 0.6
+# Installation instructions: https://knative.dev/docs/install/installing-istio/
+
+# Download and unpack Istio
+export ISTIO_VERSION=$1
+curl -L https://git.io/getLatestIstio | sh -
+cd istio-${ISTIO_VERSION}
+
+for i in install/kubernetes/helm/istio-init/files/crd*yaml; do kubectl apply -f $i; done
+
+sleep 5
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+  labels:
+    istio-injection: disabled
+EOF
+
+# A lighter template, with just pilot/gateway.
+# Based on install/kubernetes/helm/istio/values-istio-minimal.yaml
+helm template --namespace=istio-system \
+--set prometheus.enabled=false \
+--set mixer.enabled=false \
+--set mixer.policy.enabled=false \
+--set mixer.telemetry.enabled=false \
+`# Pilot doesn't need a sidecar.` \
+--set pilot.sidecar=false \
+`# Disable galley (and things requiring galley).` \
+--set galley.enabled=false \
+--set global.useMCP=false \
+`# Disable security / policy.` \
+--set security.enabled=false \
+--set global.disablePolicyChecks=true \
+`# Disable sidecar injection.` \
+--set sidecarInjectorWebhook.enabled=false \
+--set global.proxy.autoInject=disabled \
+--set global.omitSidecarInjectorConfigMap=true \
+`# Set gateway pods to 1 to sidestep eventual consistency / readiness problems.` \
+--set gateways.istio-ingressgateway.autoscaleMin=1 \
+--set gateways.istio-ingressgateway.autoscaleMax=1 \
+`# Set pilot trace sampling to 100%` \
+--set pilot.traceSampling=100 \
+install/kubernetes/helm/istio \
+> ./istio-lean.yaml
+
+kubectl apply -f istio-lean.yaml

--- a/webhooks-extension/scripts/install_knative.sh
+++ b/webhooks-extension/scripts/install_knative.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+function install_knative_serving() {
+  if [ -z "$1" ]; then
+      echo "Usage ERROR for function: install_knative_serving [version]"
+      echo "Missing [version]"
+      exit 1
+  fi
+  version="$1"
+  curl -L https://github.com/knative/serving/releases/download/${version}/serving.yaml \
+  | kubectl apply --filename -
+  # Wait until all the pods come up
+  wait_for_ready_pods knative-serving 180 20
+}
+
+function install_knative_eventing() {
+  if [ -z "$1" ]; then
+      echo "Usage ERROR for function: install_knative_eventing [version]"
+      echo "Missing [version]"
+      exit 1
+  fi
+  version="$1"
+  kubectl apply --filename https://github.com/knative/eventing/releases/download/${version}/release.yaml
+  # Wait until all the pods come up
+  wait_for_ready_pods knative-eventing 180 20
+}
+
+# Note that eventing-sources.yaml was renamed from release.yaml in the v0.5.0 release, so this won't work for earlier releases as-is. 
+function install_knative_eventing_sources() {
+  if [ -z "$1" ]; then
+      echo "Usage ERROR for function: install_knative_eventing_sources [version]"
+      echo "Missing [version]"
+      exit 1
+  fi
+  version="$1"
+  kubectl apply --filename https://github.com/knative/eventing-sources/releases/download/${version}/eventing-sources.yaml
+  # Wait until all the pods come up
+  wait_for_ready_pods knative-sources 180 20
+}
+
+# Loops until duration (car) is exceeded or command (cdr) returns success
+# Lifted from https://github.com/openshift-cloud-functions/knative-operators/blob/master/etc/scripts/installation-functions.sh
+function timeout() {
+  SECONDS=0; TIMEOUT=$1; shift
+  until eval $*; do
+    sleep 5
+    [[ $SECONDS -gt $TIMEOUT ]] && echo "ERROR: Timed out" && exit 1
+  done
+}
+
+# Wait until all pods in a namespace are Running or Complete
+# wait_for_ready [namespace] [timeout] <sleepTime>
+# <sleepTime> is optional
+function wait_for_ready_pods() {
+  if [ -z "$1" ] || [ -z "$2" ]; then
+      echo "Usage ERROR for function: wait_for_ready_pods [namespace] [timeout] <sleepTime>"
+      [ -z "$1" ] && echo "Missing [namespace]"
+      [ -z "$2" ] && echo "Missing [timeout]"
+      exit 1
+  fi
+  namespace=$1
+  timeout_period=$2
+  timeout ${timeout_period} "kubectl get pods -n ${namespace} && [[ \$(kubectl get pods -n ${namespace} --no-headers 2>&1 | grep -c -v -E '(Running|Completed|Terminating)') -eq 0 ]]"
+}
+
+install_knative_serving $1
+install_knative_eventing $1
+install_knative_eventing_sources $1

--- a/webhooks-extension/test/README.md
+++ b/webhooks-extension/test/README.md
@@ -19,7 +19,6 @@ You must install these tools:
 - helm: Templating is used to install Istio according to [Knative docs](https://knative.dev/docs/install/installing-istio/)
 - npm: For building the user interface
 
-
 ## Dependency Versioning
 The installation script installs the latest version of Istio and known compatible versions of Knative as per values in the version section of [config.sh](https://github.com/tektoncd/experimental/blob/master/webhooks-extension/test/config.sh). Knative Serving 0.6 has made considerable changes to the service definition so levels below this are not supported.
 


### PR DESCRIPTION
Update the README for the webhooks extension with trivial install instructions for users to get started quickly, additionally add simplified scripts to a /scripts directory. Add a fix in the Go code for the extension to allow for docker build only method over Ko

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
