### PR TITLE
Add script to publish experimental images

### DIFF
--- a/tekton-listener/test/publish-images.sh
+++ b/tekton-listener/test/publish-images.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script runs at the postsubmit phase; it is started by prow when a push event
+# happens on master, via a PR merge for example.
+
+set -e
+
+dep ensure
+
+# It's Stretch and https://github.com/tektoncd/dashboard/blob/master/package.json
+# denotes the Node.js and npm versions
+apt-get update
+apt-get install -y curl
+curl -O https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-x64.tar.xz
+tar xf node-v10.15.3-linux-x64.tar.xz
+export PATH=$PATH:$(pwd)/node-v10.15.3-linux-x64/bin
+
+mkdir ~/.npm-global
+npm config set prefix '~/.npm-global'
+export PATH=$PATH:$HOME/.npm-global/bin
+npm ci
+npm run build_ko
+
+export KO_DOCKER_REPO=gcr.io/tekton-nightly
+
+for img in controller tekton-listener; do
+    # Publish the image
+    IMAGE=$(ko publish ./cmd/${img} 2>&1 | grep "Published ${KO_DOCKER_REPO}/${img}" | sed -n -r '/[0-9]+\/[0-9]+\/[0-9]+ [0-9]+:[0-9]+:[0-9]+.*Published/ { s/.*Published //;p}')
+
+    # Tag it
+    gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+    gcloud -q container images add-tag ${IMAGE} ${KO_DOCKER_REPO}/${img}:latest
+done

--- a/test/publish-images.sh
+++ b/test/publish-images.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script runs at the postsubmit phase; it is started by prow when a push event
+# happens on master, via a PR merge for example.
+
+./webhooks-extension/publish-images.sh
+./tekton-listener/publish-images.sh

--- a/webhooks-extension/test/publish-images.sh
+++ b/webhooks-extension/test/publish-images.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script runs at the postsubmit phase; it is started by prow when a push event
+# happens on master, via a PR merge for example.
+
+set -e
+
+dep ensure
+
+# It's Stretch and https://github.com/tektoncd/dashboard/blob/master/package.json
+# denotes the Node.js and npm versions
+apt-get update
+apt-get install -y curl
+curl -O https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-x64.tar.xz
+tar xf node-v10.15.3-linux-x64.tar.xz
+export PATH=$PATH:$(pwd)/node-v10.15.3-linux-x64/bin
+
+mkdir ~/.npm-global
+npm config set prefix '~/.npm-global'
+export PATH=$PATH:$HOME/.npm-global/bin
+npm ci
+npm run build_ko
+
+export KO_DOCKER_REPO=gcr.io/tekton-nightly
+
+for img in extension sink; do
+    # Publish the image
+    IMAGE=$(ko publish ./cmd/${img} 2>&1 | grep "Published ${KO_DOCKER_REPO}/${img}" | sed -n -r '/[0-9]+\/[0-9]+\/[0-9]+ [0-9]+:[0-9]+:[0-9]+.*Published/ { s/.*Published //;p}')
+
+    # Tag it
+    gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+    gcloud -q container images add-tag ${IMAGE} ${KO_DOCKER_REPO}/${img}:latest
+done


### PR DESCRIPTION
# Changes

It will call all project's `publish-images.sh` script.
- tekton-listener publishes `controller` and `tekton-listener` images
- webhooks-extension publishes `sink` and `extension` images

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @iancoffey @mnuttall @bobcatfish 

Companion PR is https://github.com/tektoncd/plumbing/pull/40

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
