### PR TITLE
publish-images.sh: use the real correct path to call sub scripts 🤕

### DIFF
--- a/test/publish-images.sh
+++ b/test/publish-images.sh
@@ -17,5 +17,5 @@
 # This script runs at the postsubmit phase; it is started by prow when a push event
 # happens on master, via a PR merge for example.
 
-../webhooks-extension/publish-images.sh
-../tekton-listener/publish-images.sh
+$(dirname $0)/../webhooks-extension/publish-images.sh
+$(dirname $0)/../tekton-listener/publish-images.sh


### PR DESCRIPTION
# Changes

Let's make sure we are targeting the right path using `dirname` and
absolute path.

I am so sorry :bowing_man: :man_facepalming: 

/cc @mnuttall 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
