### PR TITLE
Use tekton-pipelines as namespace for test scripts and docs

### DIFF
--- a/webhooks-extension/cmd/extension/README.md
+++ b/webhooks-extension/cmd/extension/README.md
@@ -29,7 +29,7 @@ Returns HTTP code 200
 
 Example payload response
 {
- "namespace": "default",
+ "namespace": "tekton-pipelines",
  "dockerregistry": "mydockerhubregistry"
 }
 

--- a/webhooks-extension/test/cleanup.sh
+++ b/webhooks-extension/test/cleanup.sh
@@ -9,9 +9,9 @@ source ${test_dir}/util.sh
 if [ $DASHBOARD_INSTALL_NS != "default" ]; then
   kubectl delete ns ${DASHBOARD_INSTALL_NS}
 else
-  kubectl delete deployment tekton-dashboard -n default
-  kubectl delete deployment webhooks-extension -n default
-  kubectl delete githubsource knative-demo-test -n default
+  kubectl delete deployment tekton-dashboard -n ${DASHBOARD_INSTALL_NS}
+  kubectl delete deployment webhooks-extension -n ${DASHBOARD_INSTALL_NS}
+  kubectl delete githubsource knative-demo-test -n ${DASHBOARD_INSTALL_NS}
 fi
 kubectl delete ns tekton-pipelines
 kubectl delete ns knative-eventing

--- a/webhooks-extension/test/config.sh
+++ b/webhooks-extension/test/config.sh
@@ -12,7 +12,7 @@ export ISTIO_SIDECAR_INJECTION="true"
 export GITHUB_TOKEN=''
 
 ##### Dashboard specs
-export DASHBOARD_INSTALL_NS="default"
+export DASHBOARD_INSTALL_NS="tekton-pipelines"
 
 # Note that to receive webhooks, your github must be able to http POST to your Tekton installation. 
 # Our initial testing has used Docker Desktop and GitHub Enterprise. 

--- a/webhooks-extension/test/setup_webhook_simple_test.sh
+++ b/webhooks-extension/test/setup_webhook_simple_test.sh
@@ -52,7 +52,7 @@ post_data='{
     "username": "'"${GITHUB_USERNAME}"'",
     "password": "'"${GITHUB_TOKEN}"'",
     "url": {"tekton.dev/git-0": "'"${GITHUB_URL}"'"},
-    "serviceaccount": "default"
+    "serviceaccount": "tekton-dashboard"
 }'
 curl -X POST --header Content-Type:application/json -d "$post_data" http://localhost:31001/v1/namespaces/${DASHBOARD_INSTALL_NS}/credentials
 echo 'created github-repo-access-secret'
@@ -64,7 +64,7 @@ post_data='{
     "username": "'"${DOCKERHUB_USERNAME}"'",
     "password": "'"${DOCKERHUB_PASSWORD}"'",
     "url": {"tekton.dev/docker-0": "https://index.docker.io/v1/"},
-    "serviceaccount": "default"
+    "serviceaccount": "tekton-dashboard"
 }'
 curl -X POST --header Content-Type:application/json -d "$post_data" http://localhost:31001/v1/namespaces/${DASHBOARD_INSTALL_NS}/credentials
 echo 'created docker-push'


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

For https://github.com/tektoncd/experimental/issues/104. Actually our API docs didn't mention the namespace being default much, so I've looked for places in our test scripts that use `default` and a `default` service account still. Let's see if this works. This also changes the ServiceAccount to be tekton-dashboard for tests.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
