### PR TITLE
fix tab indexing & replace tooltips to hoverable ones

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.bae1277c.js"
+    tekton-dashboard-bundle-location: "web/extension.cb445729.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
@@ -55,7 +55,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.bae1277c.js"
+    tekton-dashboard-bundle-location: "web/extension.cb445729.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
+++ b/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
@@ -1,13 +1,14 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 
-import { Button, TextInput, Dropdown, Form, Tooltip, DropdownSkeleton, Modal, InlineNotification } from 'carbon-components-react';
+import { Button, TextInput, Dropdown, Form, Tooltip, DropdownSkeleton, Modal, InlineNotification, TooltipIcon } from 'carbon-components-react';
 import { getNamespaces, getPipelines, getSecrets, getServiceAccounts, createWebhook, createSecret, deleteSecret } from '../../api/index';
 
 import AddAlt20 from '@carbon/icons-react/lib/add--alt/20';
 import SubtractAlt20 from '@carbon/icons-react/lib/subtract--alt/20';
 import ViewFilled from '@carbon/icons-react/lib/view--filled/20';
 import ViewOffFilled from '@carbon/icons-react/lib/view--off--filled/20';
+import Infomation from "@carbon/icons-react/lib/information/16";
 
 import './WebhookCreate.scss';
 
@@ -55,6 +56,16 @@ class WebhookCreatePage extends Component {
       visibleCSS: 'token-visible',
       invisibleCSS: 'token-invisible'
     };
+  }
+
+  componentDidMount() {
+    if (this.isDisabled()) {
+      document.getElementById("pipeline").firstElementChild.tabIndex = -1;
+      document.getElementById("git").firstElementChild.tabIndex = -1;
+      document.getElementById(
+        "serviceAccounts"
+      ).firstElementChild.tabIndex = -1;
+    }
   }
 
   async fetchNamespaces() {
@@ -235,7 +246,6 @@ class WebhookCreatePage extends Component {
         id="namespace"
         label="select namespace"
         items={namespaceItems}
-        tabIndex={5}
         onChange={this.handleChangeNamespace}
       />
   }
@@ -250,7 +260,6 @@ class WebhookCreatePage extends Component {
       id="pipeline"
       label="select pipeline"
       items={pipelineItems}
-      tabIndex={7}
       disabled={this.isDisabled()}
       onChange={this.handleChangePipeline}
     />
@@ -266,7 +275,6 @@ class WebhookCreatePage extends Component {
       id="git"
       label="select secret"
       items={secretItems}
-      tabIndex={9}
       disabled={this.isDisabled()}
       onChange={this.handleChangeSecret}
       selectedItem={this.state.gitsecret}
@@ -283,7 +291,6 @@ class WebhookCreatePage extends Component {
       id="serviceAccounts"
       label="select service account"
       items={saItems}
-      tabIndex={11}
       disabled={this.isDisabled()}
       onChange={this.handleChangeServiceAcct}
     />
@@ -460,16 +467,16 @@ class WebhookCreatePage extends Component {
           )}
           {this.state.showNotification && window.scrollTo(0,0)}
         </div>
-      
+
         <div className="create-container">
           <Form onSubmit={this.handleSubmit}>
             <div className="title">Create Webhook</div>
 
             <div className="row">
               <div className="help-icon" id="name-tooltip">
-                <Tooltip direction="bottom" triggerText="" tabIndex={0}>
-                  <p>The display name for your webhook in this user interface.</p>
-                </Tooltip>
+                <TooltipIcon tooltipText="The display name for your webhook in this user interface.">
+                  <Infomation />
+                </TooltipIcon>
               </div>
               <div className="item-label">
                 <div className="createLabel">Name</div>
@@ -482,7 +489,6 @@ class WebhookCreatePage extends Component {
                     name="name"
                     value={this.state.name}
                     onChange={this.handleChange}
-                    tabIndex={1}
                     hideLabel
                     labelText="Display Name"
                     data-testid="display-name-entry"
@@ -492,10 +498,10 @@ class WebhookCreatePage extends Component {
             </div>
 
             <div className="row">
-            <div className="help-icon" id="git-tooltip">
-                <Tooltip direction="bottom" triggerText="" tabIndex={2}>
-                  <p>The URL of the git repository to create the webhook on.</p>
-                </Tooltip>
+              <div className="help-icon" id="git-tooltip">
+                <TooltipIcon tooltipText="The URL of the git repository to create the webhook on.">
+                  <Infomation />
+                </TooltipIcon>
               </div>
               <div className="item-label">
                 <div className="createLabel">Repository URL</div>
@@ -508,7 +514,6 @@ class WebhookCreatePage extends Component {
                     name="repository"
                     value={this.state.repo}
                     onChange={this.handleChange}
-                    tabIndex={3}
                     hideLabel
                     labelText="Repository"
                     data-testid="git-url-entry"
@@ -518,10 +523,10 @@ class WebhookCreatePage extends Component {
             </div>
 
             <div className="row">
-            <div className="help-icon" id="namespace-tooltip">
-                <Tooltip direction="bottom" triggerText="" tabIndex={4}>
-                  <p>The namespace to operate in.</p>
-                </Tooltip>
+              <div className="help-icon" id="namespace-tooltip">
+                <TooltipIcon tooltipText="The namespace to operate in.">
+                  <Infomation />
+                </TooltipIcon>
               </div>
               <div className="item-label">
                 <div className="createLabel">Namespace</div>
@@ -534,10 +539,10 @@ class WebhookCreatePage extends Component {
             </div>
 
             <div className="row">
-            <div className="help-icon" id="pipeline-tooltip">
-                <Tooltip direction="bottom" triggerText="" tabIndex={6}>
-                  <p>The pipeline from the selected namespace to run when the webhook is triggered.</p>
-                </Tooltip>
+              <div className="help-icon" id="pipeline-tooltip">
+                <TooltipIcon tooltipText="The pipeline from the selected namespace to run when the webhook is triggered.">
+                  <Infomation />
+                </TooltipIcon>
               </div>
               <div className="item-label">
                 <div className="createLabel">Pipeline</div>
@@ -550,10 +555,10 @@ class WebhookCreatePage extends Component {
             </div>
 
             <div className="row">
-            <div className="help-icon" id="secret-tooltip">
-                <Tooltip direction="bottom" triggerText="" tabIndex={8}>
-                  <p>The kubernetes secret holding access information for the git repository. The credential must have sufficient privileges to create webhooks in the repository.</p>
-                </Tooltip>
+              <div className="help-icon" id="secret-tooltip">
+                <TooltipIcon tooltipText="The kubernetes secret holding access information for the git repository. The credential must have sufficient privileges to create webhooks in the repository.">
+                  <Infomation />
+                </TooltipIcon>
               </div>
               <div className="item-label">
                 <div className="createLabel">Access Token</div>
@@ -568,10 +573,10 @@ class WebhookCreatePage extends Component {
             </div>
 
             <div className="row">
-            <div className="help-icon" id="serviceaccount-tooltip">
-                <Tooltip direction="bottom" triggerText="" tabIndex={10}>
-                  <p>The service account under which to run the pipeline run.</p><br></br><p>The service account needs to be patched with secrets to access both git and docker.</p>
-                </Tooltip>
+              <div className="help-icon" id="serviceaccount-tooltip">
+                <TooltipIcon tooltipText="The service account under which to run the pipeline run. The service account needs to be patched with secrets to access both git and docker.">
+                  <Infomation />
+                </TooltipIcon>
               </div>
               <div className="item-label">
                 <div className="createLabel">Service Account</div>
@@ -585,9 +590,9 @@ class WebhookCreatePage extends Component {
 
             <div className="row">
               <div className="help-icon" id="docker-tooltip">
-                <Tooltip direction="bottom" triggerText="" tabIndex={12}>
-                  <p>The docker registry to push images to.</p>
-                </Tooltip>
+                <TooltipIcon tooltipText="The docker registry to push images to.">
+                  <Infomation />
+                </TooltipIcon>
               </div>
               <div className="item-label">
                 <div className="createLabel">Docker Registry</div>
@@ -618,8 +623,8 @@ class WebhookCreatePage extends Component {
             <div className="help-icon"></div>
               <div className="item-label"></div>
               <div className="entry-field">
-                <Button data-testid="cancel-button" id="cancel" tabIndex={13} onClick={() => { this.returnToTable() }}>Cancel</Button>
-                <Button className="modal-btn" data-testid="create-button" type="submit" tabIndex={14} id={this.createButtonIDForCSS()} disabled={this.isFormIncomplete()}>Create</Button>
+                <Button data-testid="cancel-button" id="cancel" onClick={() => { this.returnToTable() }}>Cancel</Button>
+                <Button className="modal-btn" data-testid="create-button" type="submit" tabIndex={this.isFormIncomplete() ? -1 : 0} id={this.createButtonIDForCSS()} disabled={this.isFormIncomplete()}>Create</Button>
               </div>
             </div>
 
@@ -653,12 +658,12 @@ class WebhookCreatePage extends Component {
               onSecondarySubmit={() => this.toggleCreateDialog()}
               onRequestSubmit={() => this.createAccessTokenSecret()}
               onRequestClose={() => this.toggleCreateDialog()}>
-            
+
               <div className="title">Create Access Token Secret</div>
 
               <div className="modal-row">
                 <div className="modal-row-help-icon">
-                  <Tooltip direction="bottom" triggerText="" tabIndex={15}>
+                  <Tooltip direction="bottom" triggerText="">
                     <p>The name of the secret to create.</p>
                   </Tooltip>
                 </div>
@@ -676,7 +681,6 @@ class WebhookCreatePage extends Component {
                       onChange={this.handleModalText}
                       hideLabel
                       labelText="Secret Name"
-                      tabIndex={16}
                     />
                   </div>
                 </div>
@@ -684,7 +688,7 @@ class WebhookCreatePage extends Component {
 
               <div className="modal-row">
                 <div className="modal-row-help-icon">
-                  <Tooltip direction="bottom" triggerText="" tabIndex={17}>
+                  <Tooltip direction="bottom" triggerText="">
                     <p>The access token.</p>
                   </Tooltip>
                 </div>
@@ -702,7 +706,6 @@ class WebhookCreatePage extends Component {
                       onChange={this.handleModalText}
                       hideLabel
                       labelText="Access Token"
-                      tabIndex={18}
                     />
                     <ViewFilled id="token-visible-svg" className={this.state.visibleCSS} onClick={this.togglePasswordVisibility} />
                     <ViewOffFilled id="token-invisible-svg" className={this.state.invisibleCSS} onClick={this.togglePasswordVisibility} />

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirm.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirm.test.js
@@ -19,6 +19,7 @@ import { WebhookCreate } from '../WebhookCreate';
 import * as API from '../../../api/index';
 import 'jest-dom/extend-expect'
 
+global.scrollTo = jest.fn();
 
 const namespacesResponseMock = {
   "items": [

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirmError.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirmError.test.js
@@ -19,6 +19,7 @@ import { WebhookCreate } from '../WebhookCreate';
 import * as API from '../../../api/index';
 import 'jest-dom/extend-expect'
 
+global.scrollTo = jest.fn();
 
 const namespacesResponseMock = {
   "items": [

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalCancel.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalCancel.test.js
@@ -19,6 +19,7 @@ import { WebhookCreate } from '../WebhookCreate';
 import * as API from '../../../api/index';
 import 'jest-dom/extend-expect'
 
+global.scrollTo = jest.fn();
 
 const namespacesResponseMock = {
   "items": [
@@ -135,23 +136,6 @@ describe('delete secret', () => {
 
   });
 
-  it('modal should be shown to confirm deletion and include selected secret name', async () => {  
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
-    jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
-    jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />); 
-    fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
-    fireEvent.click(await waitForElement(() => getByText(/istio-system/i)));
-    fireEvent.click(await waitForElement(() => getByText(/select secret/i)));
-    fireEvent.click(await waitForElement(() => getByText(/ghe/i)));
-
-    expect(document.getElementById('delete-modal').getAttribute('class')).not.toContain('is-visible');
-    fireEvent.click(document.getElementById('delete-secret-button'));
-    expect(document.getElementById('delete-modal').getAttribute('class')).toContain('is-visible');
-
-  });
-  
   it('cancel button should hide modal', async () => {
 
     jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirmError.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirmError.test.js
@@ -19,6 +19,7 @@ import { WebhookCreate } from '../WebhookCreate';
 import * as API from '../../../api/index';
 import 'jest-dom/extend-expect'
 
+global.scrollTo = jest.fn();
 
 const namespacesResponseMock = {
   "items": [

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalSecretName.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalSecretName.test.js
@@ -70,14 +70,6 @@ const secretsResponseMock = [
   }
 ]
 
-const secretsDeletedMock = [
-  {
-    "name": "git",
-  }
-]
-
-const deleteSecretSuccessMock = {}
-
 const serviceAccountsResponseMock = {
   "items": [
     {
@@ -97,36 +89,28 @@ beforeEach(() => {
   jest.restoreAllMocks
   jest.resetModules()
  });
- 
+
 afterEach(() => {
   jest.clearAllMocks()
   cleanup()
  });
 
 //-----------------------------------//
-describe('confirm deletion success', () => {
-  it('delete button should hide modal, remove secret from listing and reset dropdown', async () => {
+describe('delete modal secret name', () => {
+
+  it('modal should be shown to confirm deletion and include selected secret name', async () => {
     jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
-    jest.spyOn(API, 'deleteSecret').mockImplementation(() => Promise.resolve(deleteSecretSuccessMock));
     const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />);
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)));
-    await waitForElement(() => document.getElementsByClassName('secButtonEnabled'));
     fireEvent.click(await waitForElement(() => getByText(/select secret/i)));
     fireEvent.click(await waitForElement(() => getByText(/ghe/i)));
-    await waitForElement(() => document.getElementsByClassName('secButtonEnabled'));
+
+    expect(document.getElementById('delete-modal').getAttribute('class')).not.toContain('is-visible');
     fireEvent.click(document.getElementById('delete-secret-button'));
     expect(document.getElementById('delete-modal').getAttribute('class')).toContain('is-visible');
-
-    jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsDeletedMock));
-    fireEvent.click(document.getElementById('delete-modal').getElementsByClassName('bx--btn--primary').item(0));
-
-    await waitForElement(() => getByText(/Secret deleted./));
-    expect(document.getElementById('delete-modal').getAttribute('class')).not.toContain('is-visible');
-    await waitForElement(() => getByText(/select secret/i));
   });
-
 })

--- a/webhooks-extension/src/components/WebhookCreate/tests/WebhookCreate.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/WebhookCreate.test.js
@@ -19,7 +19,7 @@ import { WebhookCreate } from '../WebhookCreate';
 import * as API from '../../../api/index';
 import 'jest-dom/extend-expect'
 
-window.scrollTo = jest.fn();
+global.scrollTo = jest.fn();
 
 const namespacesFailResponseMock = {
   response: {
@@ -355,47 +355,47 @@ describe('create button', () => {
 })
 
 describe('tooltips', () => {
-  it('click on name tooltip', async () => {
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}} />);
-    await waitForElement(() => document.getElementById('name-tooltip'))
-    fireEvent.click(document.getElementById('name-tooltip').getElementsByClassName('bx--tooltip__trigger').item(0))
-    await waitForElement(() => getByText(/The display name for your webhook in this user interface./i))
+  it('hover on name tooltip', async () => {
+    const { getByLabelText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}} />);
+    await waitForElement(() => document.getElementById('name-tooltip'));
+    fireEvent.focus(document.getElementById('name-tooltip').getElementsByClassName('bx--tooltip__trigger').item(0));
+    await waitForElement(() => getByLabelText(/The display name for your webhook in this user interface./i));
   });
 
-  it('click on git url tooltip', async () => {
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}} />);
-    await waitForElement(() => document.getElementById('git-tooltip'))
-    fireEvent.click(document.getElementById('git-tooltip').getElementsByClassName('bx--tooltip__trigger').item(0))
-    await waitForElement(() => getByText(/The URL of the git repository to create the webhook on./i))
+  it('hover on git url tooltip', async () => {
+    const { getByLabelText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}} />);
+    await waitForElement(() => document.getElementById('git-tooltip'));
+    fireEvent.focus(document.getElementById('git-tooltip').getElementsByClassName('bx--tooltip__trigger').item(0));
+    await waitForElement(() => getByLabelText(/The URL of the git repository to create the webhook on./i));
   });
-  it('click on pipeline tooltip', async () => {
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}} />);
+  it('hover on pipeline tooltip', async () => {
+    const { getByLabelText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}} />);
     await waitForElement(() => document.getElementById('pipeline-tooltip'))
-    fireEvent.click(document.getElementById('pipeline-tooltip').getElementsByClassName('bx--tooltip__trigger').item(0))
-    await waitForElement(() => getByText(/The pipeline from the selected namespace to run when the webhook is triggered./i))
+    fireEvent.focus(document.getElementById('pipeline-tooltip').getElementsByClassName('bx--tooltip__trigger').item(0))
+    await waitForElement(() => getByLabelText(/The pipeline from the selected namespace to run when the webhook is triggered./i))
   });
-  it('click on namespace tooltip', async () => {
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}} />);
+  it('hover on namespace tooltip', async () => {
+    const { getByLabelText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}} />);
     await waitForElement(() => document.getElementById('namespace-tooltip'))
-    fireEvent.click(document.getElementById('namespace-tooltip').getElementsByClassName('bx--tooltip__trigger').item(0))
-    await waitForElement(() => getByText(/The namespace to operate in./i))
+    fireEvent.focus(document.getElementById('namespace-tooltip').getElementsByClassName('bx--tooltip__trigger').item(0))
+    await waitForElement(() => getByLabelText(/The namespace to operate in./i))
   });
-  it('click on secrets tooltip', async () => {
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}} />);
+  it('hover on secrets tooltip', async () => {
+    const { getByLabelText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}} />);
     await waitForElement(() => document.getElementById('secret-tooltip'))
-    fireEvent.click(document.getElementById('secret-tooltip').getElementsByClassName('bx--tooltip__trigger').item(0))
-    await waitForElement(() => getByText(/The kubernetes secret holding access information for the git repository. The credential must have sufficient privileges to create webhooks in the repository./i))
+    fireEvent.focus(document.getElementById('secret-tooltip').getElementsByClassName('bx--tooltip__trigger').item(0))
+    await waitForElement(() => getByLabelText(/The kubernetes secret holding access information for the git repository. The credential must have sufficient privileges to create webhooks in the repository./i))
   });
-  it('click on service account tooltip', async () => {
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}} />);
+  it('hover on service account tooltip', async () => {
+    const { getByLabelText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}} />);
     await waitForElement(() => document.getElementById('serviceaccount-tooltip'))
-    fireEvent.click(document.getElementById('serviceaccount-tooltip').getElementsByClassName('bx--tooltip__trigger').item(0))
-    await waitForElement(() => getByText(/The service account under which to run the pipeline run./i))
+    fireEvent.focus(document.getElementById('serviceaccount-tooltip').getElementsByClassName('bx--tooltip__trigger').item(0))
+    await waitForElement(() => getByLabelText(/The service account under which to run the pipeline run./i))
   });
-  it('click on docker registry tooltip', async () => {
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}} />);
+  it('hover on docker registry tooltip', async () => {
+    const { getByLabelText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}} />);
     await waitForElement(() => document.getElementById('docker-tooltip'))
-    fireEvent.click(document.getElementById('docker-tooltip').getElementsByClassName('bx--tooltip__trigger').item(0))
-    await waitForElement(() => getByText(/The docker registry to push images to./i))
+    fireEvent.focus(document.getElementById('docker-tooltip').getElementsByClassName('bx--tooltip__trigger').item(0))
+    await waitForElement(() => getByLabelText(/The docker registry to push images to./i))
   });
 })


### PR DESCRIPTION
issue: #66 

#Changes

Fixed the tab indexing by initializing all the values to 0 & leaving the browser do the logical ordering and surprisinly works. But its worth mentioning that I had to cheat a little with plain javascript when trying to skip the disabled components because for some reason their child elements still had `tabIndex set to 0` and was interrupting the order. I also changed the tooltips to "hoverable" ones but only to those that are in the main page and not the modals because for some reason they were not being outputted correctly. Lastly, I had to update the test with some errors regarding the `window.toScroll` & create a new test file to bypass the `'initialFocus' did not return a node` error. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)