### PR TITLE
Correct default install namespace to tekton-pipelines

### DIFF
--- a/webhooks-extension/config/sink-kservice.yaml
+++ b/webhooks-extension/config/sink-kservice.yaml
@@ -22,4 +22,4 @@ spec:
         # PORT var resolved via containerPort by Knative
         # TODO: Find better way to provide INSTALL_NAMESPACE since Knative does not support Downward API
         - name: INSTALLED_NAMESPACE
-          value: "default"
+          value: "tekton-pipelines"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The default install namespace for the dashboard is now tekton-pipelines, however the config/sink-kservice.yaml lists the INSTALLED_NAMESPACE env var as "default".  This PR corrects this.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [N/A] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
