### PR TITLE
show notification when the last webhook deleted

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.cb445729.js"
+    tekton-dashboard-bundle-location: "web/extension.c526c42e.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
@@ -55,7 +55,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.cb445729.js"
+    tekton-dashboard-bundle-location: "web/extension.c526c42e.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/src/WebhookApp.js
+++ b/webhooks-extension/src/WebhookApp.js
@@ -10,20 +10,27 @@ class WebhooksApp extends Component {
     super(props);
     this.state = {
       showNotificationOnTable: false,
+      showLastWebhookDeletedNotification: false
     }
     this.setShowNotificationOnTable = this.setShowNotificationOnTable.bind(this);
+    this.setshowLastWebhookDeletedNotification = this.setshowLastWebhookDeletedNotification.bind(this);
   }
 
   setShowNotificationOnTable(value) {
     this.setState({showNotificationOnTable: value})
   }
 
+  setshowLastWebhookDeletedNotification(value) {
+    this.setState({showLastWebhookDeletedNotification: value})
+  }
+
   render() {
     const { match } = this.props;
+
       return (
         <div>
-          <Route exact path={`${match.path}/`} render={props => <WebhookDisplayTable {...props} showNotificationOnTable={this.state.showNotificationOnTable} />} />
-          <Route path={`${match.path}/create`} render={props => <WebhookCreate {...props} setShowNotificationOnTable={this.setShowNotificationOnTable} />} />
+          <Route exact path={`${match.path}/`} render={props => <WebhookDisplayTable {...props} showNotificationOnTable={this.state.showNotificationOnTable} setshowLastWebhookDeletedNotification={this.setshowLastWebhookDeletedNotification}/>} />
+          <Route path={`${match.path}/create`} render={props => <WebhookCreate {...props} setShowNotificationOnTable={this.setShowNotificationOnTable} setshowLastWebhookDeletedNotification={this.setshowLastWebhookDeletedNotification} showLastWebhookDeletedNotification={this.state.showLastWebhookDeletedNotification}/>} />
         </div>
       )
   }

--- a/webhooks-extension/src/WebhookApp.test.js
+++ b/webhooks-extension/src/WebhookApp.test.js
@@ -1,0 +1,182 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { waitForElement, cleanup, fireEvent } from 'react-testing-library';
+import WebhookApp from './WebhookApp'
+import * as API from './api';
+import { renderWithRouter } from './test/utils/test'
+import 'react-testing-library/cleanup-after-each';
+
+global.scrollTo = jest.fn();
+
+beforeEach(() => {
+  jest.restoreAllMocks
+  jest.resetModules()
+});
+
+afterEach(() => {
+  jest.clearAllMocks()
+  cleanup()
+});
+
+function fakeDeleteWebhooksSuccess() {
+  return {
+    data: {},
+    status: 204,
+    statusText: 'OK',
+    headers: {}
+  };
+}
+
+const fakeRowSelection = [
+  {
+    "id":"mywebhook|default",
+    "isSelected":true,
+    "isExpanded":false,
+    "cells":[
+      {
+        "id":"mywebhook|default:name","value":"mywebhook","isEditable":false,"isEditing":false,"isValid":true,"errors":null,"info":
+        {
+          "header":"name"
+        }
+      },
+      {
+        "id":"mywebhook|default:repository","value":"https://github.com/foo/bar","isEditable":false,"isEditing":false,"isValid":true,"errors":null,"info":
+        {
+          "header":"repository"
+        }
+      },
+      {
+        "id":"mywebhook|default:pipeline","value":"simple-helm-pipeline-insecure","isEditable":false,"isEditing":false,"isValid":true,"errors":null,"info":
+        {
+          "header":"pipeline"
+        }
+      },
+      {"id":"mywebhook|default:namespace","value":"default","isEditable":false,"isEditing":false,"isValid":true,"errors":null,"info":
+      {
+        "header":"namespace"
+      }
+    }
+  ]}
+]
+
+const namespacesResponseMock = {
+  "items": [
+    {
+      "metadata": {
+        "name": "default",
+      }
+    },
+    {
+      "metadata": {
+        "name": "docker",
+      }
+    },
+    {
+      "metadata": {
+        "name": "istio-system",
+      },
+    },
+    {
+      "metadata": {
+        "name": "knative-eventing",
+      },
+    }
+  ]
+};
+
+const pipelinesResponseMock = {
+  "items": [
+    {
+      "metadata": {
+        "name": "simple-helm-pipeline",
+      }
+    },
+    {
+      "metadata": {
+        "name": "simple-helm-pipeline-insecure",
+      }
+    },
+  ]
+}
+
+const secretsResponseMock = [
+  {
+    "name": "ghe",
+  },
+  {
+    "name": "git",
+  }
+]
+
+const serviceAccountsResponseMock = {
+  "items": [
+    {
+      "metadata": {
+        "name": "default",
+      },
+    },
+    {
+      "metadata": {
+        "name": "testserviceaccount",
+      },
+    }
+  ]
+}
+
+const webhooks = [
+  {
+    id: '0|namespace',
+    name: 'first test webhook',
+    gitrepositoryurl: 'repo1',
+    pipeline: 'pipeline1',
+    namespace: 'namespace1'
+  }
+];
+
+it('change in components after last webhook deleted', async () => {
+  let getWebhooksMock = jest.spyOn(API, "getWebhooks").mockImplementation(() => Promise.resolve(webhooks));
+  let getRowsMock = jest.spyOn(API, "getSelectedRows").mockImplementation(() => fakeRowSelection);
+  let deleteWebhooksMock = jest.spyOn(API, "deleteWebhooks").mockImplementation(() => Promise.resolve(fakeDeleteWebhooksSuccess));
+
+  const { getByText, queryByTestId } = renderWithRouter(<WebhookApp match={{}} />);
+
+  await waitForElement(() => getByText('first test webhook'));
+  expect(queryByTestId('table-container')).not.toBeNull();
+  expect(queryByTestId('webhook-create')).toBeNull();
+
+  const foundDeleteButton = document.getElementById('delete-btn');
+  await waitForElement(() => foundDeleteButton);
+
+  fireEvent.click(foundDeleteButton);
+
+  const foundDeleteButtonOnModal = document.getElementById('webhook-delete-modal').getElementsByClassName('bx--btn bx--btn--danger').item(0);
+  await waitForElement(() => foundDeleteButtonOnModal);
+
+  fireEvent.click(foundDeleteButtonOnModal);
+
+  expect(getWebhooksMock).toHaveBeenCalled();
+  expect(getRowsMock).toHaveBeenCalled();
+  expect(deleteWebhooksMock).toHaveBeenCalled();
+
+  getWebhooksMock.mockImplementation(() => Promise.resolve([]));
+  jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
+  jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
+  jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
+  jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
+
+  await waitForElement(() => getByText('Last webhook deleted successfully.'));
+  expect(queryByTestId('table-container')).toBeNull();
+  expect(queryByTestId('webhook-create')).not.toBeNull();
+});

--- a/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
+++ b/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
@@ -58,7 +58,16 @@ class WebhookCreatePage extends Component {
     };
   }
 
-  componentDidMount() {
+  componentDidMount(){
+    if(this.props.showLastWebhookDeletedNotification){
+      this.setState({
+        notificationMessage: "Last webhook deleted successfully.",
+        notificationStatus: 'success',
+        notificationStatusMsgShort: 'Success:',
+        showNotification: true
+      });
+      this.props.setshowLastWebhookDeletedNotification(false);
+    }
     if (this.isDisabled()) {
       document.getElementById("pipeline").firstElementChild.tabIndex = -1;
       document.getElementById("git").firstElementChild.tabIndex = -1;
@@ -455,8 +464,8 @@ class WebhookCreatePage extends Component {
     }
 
     return (
-      
-      <div className="webhook-create">
+
+      <div className="webhook-create" data-testid="webhook-create">
         <div className="notification">
           {this.state.showNotification && (
             <InlineNotification

--- a/webhooks-extension/src/components/WebhookDisplayTable/WebhookDisplayTable.js
+++ b/webhooks-extension/src/components/WebhookDisplayTable/WebhookDisplayTable.js
@@ -131,13 +131,18 @@ export class WebhookDisplayTable extends Component {
 
     Promise.all(deletePromises).then( () => {
       this.fetchWebhooksForTable();
-      this.setState({
-        showNotificationOnTable: true,
-        showDeleteDialog: false,
-        notificationStatus: 'success',
-        notificationStatusMsgShort: 'Webhook(s) deleted successfully.',
-        notificationMessage: '',
-      });
+      if(this.state.webhooks.length - 1 === 0){
+        this.props.setshowLastWebhookDeletedNotification(true);
+      }
+      else {
+        this.setState({
+          showNotificationOnTable: true,
+          showDeleteDialog: false,
+          notificationStatus: 'success',
+          notificationStatusMsgShort: 'Webhook(s) deleted successfully.',
+          notificationMessage: '',
+        });
+      }
      }).catch( () => {
       this.setState({
         showNotificationOnTable: true,
@@ -197,12 +202,12 @@ export class WebhookDisplayTable extends Component {
             namespace: webhook['namespace'],
           }
         })
-        
+
         return (
           <div>
-            <div className="table-container">
+            <div className="table-container" data-testid="table-container">
 
-              {(this.props.showNotificationOnTable || this.state.showNotificationOnTable) && (              
+              {(this.props.showNotificationOnTable || this.state.showNotificationOnTable) && (
                 <InlineNotification
                   data-testid='webhook-notification'
                   kind={this.state.notificationStatus}

--- a/webhooks-extension/src/components/WebhookDisplayTable/tests/WebhookDeleteNotifications.test.js
+++ b/webhooks-extension/src/components/WebhookDisplayTable/tests/WebhookDeleteNotifications.test.js
@@ -86,6 +86,13 @@ const webhooks = [
     gitrepositoryurl: 'repo1',
     pipeline: 'pipeline1',
     namespace: 'namespace1'
+  },
+  {
+    id: '1|namespace',
+    name: 'second test webhook',
+    gitrepositoryurl: 'repo2',
+    pipeline: 'pipeline1',
+    namespace: 'namespace1'
   }
 ];
 


### PR DESCRIPTION
issue: #102 

# Changes

shows a notification in create webhook component when the last webhook was deleted from the webhook table component. This was possible by declaring a state in the parent container, WebhookApp, & passed to both child components, WebhookCreate & WebhookDisplayTable, where when the last webhook is deleted in the table component, this variable's state is changed and when the app changes to the create form component, the variable is noticed and consequently shows the notification message. 

Lastly, the were some test updates done & added one to test this behavior in the parent component.  

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
