### PR TITLE
Add branch to pipelinerun label from webhooks

### DIFF
--- a/webhooks-extension/package-lock.json
+++ b/webhooks-extension/package-lock.json
@@ -4496,8 +4496,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4518,14 +4517,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4540,20 +4537,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4670,8 +4664,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4683,7 +4676,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4698,7 +4690,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4706,14 +4697,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4732,7 +4721,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4813,8 +4801,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4826,7 +4813,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4912,8 +4898,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4949,7 +4934,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4969,7 +4953,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5013,14 +4996,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/webhooks-extension/pkg/endpoints/sink.go
+++ b/webhooks-extension/pkg/endpoints/sink.go
@@ -31,10 +31,12 @@ import (
 const gitServerLabel = "gitServer"
 const gitOrgLabel = "gitOrg"
 const gitRepoLabel = "gitRepo"
+const gitBranchLabel = "gitBranch"
 const githubEventParameter = "Ce-Github-Event"
 
 // BuildInformation - information required to build a particular commit from a Git repository.
 type BuildInformation struct {
+	BRANCH         string
 	REPOURL        string
 	SHORTID        string
 	COMMITID       string
@@ -78,6 +80,7 @@ func (r Resource) handleWebhook(request *restful.Request, response *restful.Resp
 		buildInformation.COMMITID = webhookData.HeadCommit.ID
 		buildInformation.REPONAME = webhookData.Repository.Name
 		buildInformation.TIMESTAMP = timestamp
+		buildInformation.BRANCH = extractBranchFromRef(webhookData.Ref)
 
 		createPipelineRunFromWebhookData(buildInformation, r)
 		logging.Log.Debugf("Build information for repository %s:%s: %s.", buildInformation.REPOURL, buildInformation.SHORTID, buildInformation)
@@ -97,6 +100,7 @@ func (r Resource) handleWebhook(request *restful.Request, response *restful.Resp
 		buildInformation.COMMITID = webhookData.PullRequest.Head.Sha
 		buildInformation.REPONAME = webhookData.Repository.Name
 		buildInformation.TIMESTAMP = timestamp
+		buildInformation.BRANCH = extractBranchFromRef(webhookData.PullRequest.Head.Ref)
 
 		createPipelineRunFromWebhookData(buildInformation, r)
 		logging.Log.Debugf("Build information for repository %s:%s: %s.", buildInformation.REPOURL, buildInformation.SHORTID, buildInformation)
@@ -104,6 +108,20 @@ func (r Resource) handleWebhook(request *restful.Request, response *restful.Resp
 	} else {
 		logging.Log.Errorf("error: event wasn't a push, pull, or ping event, no action will be taken. Request is: %+v.", request)
 	}
+}
+
+func extractBranchFromRef(ref string) string {
+	// ref typically resembles "refs/heads/branchhere", so extract "branchhere" from this string
+	if ref != "" {
+		if strings.Count(ref, "/") == 2 {
+			lastIndex := strings.LastIndex(ref, "/")
+			toReturn := ref[lastIndex+1:]
+			logging.Log.Debugf("Determined branch from ref field: %s", toReturn)
+			return toReturn
+		}
+	}
+	logging.Log.Warnf("Couldn't determine the branch from ref field: %s", ref)
+	return ""
 }
 
 // This is the main flow that handles building and deploying: given everything we need to kick off a build, do so
@@ -214,7 +232,7 @@ func createPipelineRunFromWebhookData(buildInformation BuildInformation, r Resou
 	}
 
 	// PipelineRun yml defines the references to the above named resources.
-	pipelineRunData, err := definePipelineRun(generatedPipelineRunName, pipelineNs, saName, buildInformation.REPOURL,
+	pipelineRunData, err := definePipelineRun(generatedPipelineRunName, pipelineNs, saName, buildInformation.REPOURL, buildInformation.BRANCH,
 		pipeline, v1alpha1.PipelineTriggerTypeManual, resources, params)
 
 	logging.Log.Infof("Creating a new PipelineRun named %s in the namespace %s using the service account %s.", generatedPipelineRunName, pipelineNs, saName)
@@ -257,7 +275,7 @@ func definePipelineResource(name, namespace string, params []v1alpha1.Param, res
 
 /* Create a new PipelineRun - repoUrl, resourceBinding and params can be nill depending on the Pipeline
 each PipelineRun has a 1 hour timeout: */
-func definePipelineRun(pipelineRunName, namespace, saName, repoURL string,
+func definePipelineRun(pipelineRunName, namespace, saName, repoURL, branch string,
 	pipeline v1alpha1.Pipeline,
 	triggerType v1alpha1.PipelineTriggerType,
 	resourceBinding []v1alpha1.PipelineResourceBinding,
@@ -282,6 +300,7 @@ func definePipelineRun(pipelineRunName, namespace, saName, repoURL string,
 				gitServerLabel: gitServer,
 				gitOrgLabel:    gitOrg,
 				gitRepoLabel:   gitRepo,
+				gitBranchLabel: branch,
 			},
 		},
 
@@ -295,6 +314,7 @@ func definePipelineRun(pipelineRunName, namespace, saName, repoURL string,
 			Params:         params,
 		},
 	}
+
 	pipelineRunPointer := &pipelineRunData
 	return pipelineRunPointer, nil
 }


### PR DESCRIPTION
For https://github.com/tektoncd/experimental/issues/140
# Changes
Adds gitBranch label to PipelineRuns created through webhooks, using the `Ref` field and string extraction

```
adams-mbp:dashboard aroberts$ k get pipelinerun -o yaml
apiVersion: v1
items:
- apiVersion: tekton.dev/v1alpha1
  kind: PipelineRun
  metadata:
    creationTimestamp: 2019-07-11T15:18:09Z
    generation: 1
    labels:
      app: tekton-webhook-handler
      gitBranch: master
      gitOrg: aroberts
      gitRepo: icp-nodejs-sample
      gitServer: github.ibm.com
````

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
