### PR TITLE
data table skeleton when in loading state

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.8fc66494.js"
+    tekton-dashboard-bundle-location: "web/extension.a16563d1.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
@@ -55,7 +55,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.8fc66494.js"
+    tekton-dashboard-bundle-location: "web/extension.a16563d1.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/src/components/WebhookDisplayTable/WebhookDisplayTable.js
+++ b/webhooks-extension/src/components/WebhookDisplayTable/WebhookDisplayTable.js
@@ -10,6 +10,7 @@ import { Link, Redirect } from 'react-router-dom';
 import {
   Button,
   DataTable,
+  DataTableSkeleton,
   TableSelectAll,
   TableSelectRow,
   TableToolbar,
@@ -17,7 +18,6 @@ import {
   TableBatchActions,
   TableBatchAction,
   TableToolbarSearch,
-  Loading,
   InlineNotification,
 } from 'carbon-components-react';
 
@@ -164,8 +164,7 @@ export class WebhookDisplayTable extends Component {
 
   render() {
 
-    if (this.state.isLoaded) {
-      if (!this.state.webhooks.length) {
+      if (this.state.webhooks.length === 0 && this.state.isLoaded) {
         return (
           // There are no webhooks, so redirect to the create panel
           <Redirect to={this.props.match.url + "/create"} />
@@ -237,10 +236,10 @@ export class WebhookDisplayTable extends Component {
                     </div>
                       <TableToolbarContent>
                         <div className="search-bar">
-                          <TableToolbarSearch onChange={onInputChange} />
+                          <TableToolbarSearch disabled={!this.state.isLoaded} onChange={onInputChange} />
                         </div>
                         <div className="add-div">
-                          <Button kind="ghost" as={Link} id="add-btn" to={this.props.match.url + "/create"}>
+                          <Button disabled={!this.state.isLoaded} kind="ghost" as={Link} id="add-btn" to={this.props.match.url + "/create"}>
                             <div className="add-icon-div">
                               <AddAlt16 className="add-icon"/>
                             </div>
@@ -254,27 +253,32 @@ export class WebhookDisplayTable extends Component {
                         <TableBatchAction id="delete-btn" renderIcon={Delete} onClick={() => {this.showDeleteDialogHandlerVisible(selectedRows)}}>Delete</TableBatchAction>
                       </TableBatchActions>
                     </TableToolbar>
-          
-                    <Table className="bx--data-table--zebra">
-                      <TableHead>
-                        <TableRow>
-                          <TableSelectAll {...getSelectionProps()} />
-                          {headers.map(header => (
-                            <TableHeader key={header.id} {...getHeaderProps({ header })} isSortable={true} isSortHeader={true}>{header.header}</TableHeader>
-                          ))}
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {rows.map(row => (
-                          <TableRow {...getRowProps({ row })} key={row.id}>
-                            <TableSelectRow {...getSelectionProps({ row })} />
-                            {row.cells.map(cell => (
-                              <TableCell key={cell.id}>{this.formatCellContent(cell.id, cell.value)}</TableCell>
+                    {
+                      !this.state.isLoaded ? (
+                        <DataTableSkeleton rowCount={1} columnCount={headers.length} data-testid="loading-table"/>
+                      ) : (
+                        <Table className="bx--data-table--zebra">
+                          <TableHead>
+                            <TableRow>
+                              <TableSelectAll {...getSelectionProps()} />
+                              {headers.map(header => (
+                                <TableHeader key={header.id} {...getHeaderProps({ header })} isSortable={true} isSortHeader={true}>{header.header}</TableHeader>
+                              ))}
+                            </TableRow>
+                          </TableHead>
+                          <TableBody>
+                            {rows.map(row => (
+                              <TableRow {...getRowProps({ row })} key={row.id}>
+                                <TableSelectRow {...getSelectionProps({ row })} />
+                                {row.cells.map(cell => (
+                                  <TableCell key={cell.id}>{this.formatCellContent(cell.id, cell.value)}</TableCell>
+                                ))}
+                              </TableRow>
                             ))}
-                          </TableRow>
-                        ))}
-                      </TableBody>
-                    </Table>
+                          </TableBody>
+                        </Table>
+                      )
+                    }
                   </TableContainer>
                 )}
               />
@@ -308,10 +312,5 @@ export class WebhookDisplayTable extends Component {
           </div>
         );
       }
-    } else {
-      return(
-        <div className="spinner-div"><Loading withOverlay={false} active className="loading-spinner" /></div>
-      )
     }
   }
-}

--- a/webhooks-extension/src/components/WebhookDisplayTable/tests/WebhookTable.test.js
+++ b/webhooks-extension/src/components/WebhookDisplayTable/tests/WebhookTable.test.js
@@ -24,9 +24,9 @@ describe('without webhooks', () => {
   const noWebhooks = [ {} ];
   it('should display Loading when loading', () => {
     jest.spyOn(API, 'getWebhooks').mockImplementation(() => Promise.resolve([noWebhooks]));
-    const { queryByText, queryByTestId } = renderWithRouter(<WebhookDisplayTable match={{}} />);
+    const { queryByTestId } = renderWithRouter(<WebhookDisplayTable match={{}} />);
     expect(queryByTestId('webhook-notification')).toBeNull();
-    expect(queryByText(/Loading/i)).toBeTruthy();
+    expect(queryByTestId("loading-table")).toBeTruthy();
   });
 }); 
 


### PR DESCRIPTION
Switched the current loading spinner to the data table skeleton when the page is loading & updated the necessary test case.