### PR TITLE
Multi-Namespace support for webhook pipelines

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.a16563d1.js"
+    tekton-dashboard-bundle-location: "web/extension.96c06bbb.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
@@ -55,7 +55,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.a16563d1.js"
+    tekton-dashboard-bundle-location: "web/extension.96c06bbb.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/src/api/index.js
+++ b/webhooks-extension/src/api/index.js
@@ -51,8 +51,8 @@ export function createWebhook(data) {
   return post(uri, data);
 }
 
-export function getSecrets(namespace) {
-  const uri = `${apiRoot}/webhooks/credentials?namespace=${namespace}`;
+export function getSecrets() {
+  const uri = `${apiRoot}/webhooks/credentials`;
   return get(uri);
 }
 
@@ -61,8 +61,8 @@ export function createSecret(data) {
   return post(uri, data);
 }
 
-export function deleteSecret(name, namespace) {
-  const uri = `${apiRoot}/webhooks/credentials/${name}?namespace=${namespace}`;
+export function deleteSecret(name) {
+  const uri = `${apiRoot}/webhooks/credentials/${name}`;
   return deleteRequest(uri);
 }
 

--- a/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
+++ b/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
@@ -50,12 +50,14 @@ class WebhookCreatePage extends Component {
       // create secret vars
       newSecretName: '',
       newTokenValue: '',
-      createSecretDisabled: true,
       // toggle access token 'password' or 'text'
       pwType: 'password',
       visibleCSS: 'token-visible',
       invisibleCSS: 'token-invisible'
     };
+
+    this.fetchSecrets();
+    this.fetchNamespaces();
   }
 
   componentDidMount(){
@@ -70,7 +72,6 @@ class WebhookCreatePage extends Component {
     }
     if (this.isDisabled()) {
       document.getElementById("pipeline").firstElementChild.tabIndex = -1;
-      document.getElementById("git").firstElementChild.tabIndex = -1;
       document.getElementById(
         "serviceAccounts"
       ).firstElementChild.tabIndex = -1;
@@ -113,10 +114,10 @@ class WebhookCreatePage extends Component {
     }
   }
   
-  async fetchSecrets(namespace) {
+  async fetchSecrets() {
     let s;
     try {
-      s = await getSecrets(namespace);
+      s = await getSecrets();
       this.setState({apiSecrets: s})
     } catch (error) {
         error.response.text().then((text) => {
@@ -160,17 +161,12 @@ class WebhookCreatePage extends Component {
     this.setState({
       namespace: itemText.selectedItem,
       apiPipelines: '',
-      apiSecrets: '',
       apiServiceAccounts: '',
       pipeline: '',
-      gitsecret: '',
       serviceAccount: '',
     });
     if (!this.state.pipelineFail) {
       this.fetchPipelines(itemText.selectedItem);
-    }
-    if (!this.state.secretsFail) {
-      this.fetchSecrets(itemText.selectedItem);
     }
     if (!this.state.serviceAccountsFail) {
       this.fetchServiceAccounts(itemText.selectedItem);
@@ -275,21 +271,19 @@ class WebhookCreatePage extends Component {
   }
 
   displaySecretDropDown = (secretItems) => {
-    if (!this.isDisabled()) {
-      if (!this.state.apiSecrets) {
-        return <DropdownSkeleton />
-      }
+    if (!this.state.apiSecrets) {
+      return <DropdownSkeleton />
     }
+
     return <Dropdown
       id="git"
       label="select secret"
       items={secretItems}
-      disabled={this.isDisabled()}
       onChange={this.handleChangeSecret}
       selectedItem={this.state.gitsecret}
     />
   }
-
+  
   displayServiceAccountDropDown = (saItems) => {
     if (!this.isDisabled()) {
       if (!this.state.apiServiceAccounts) {
@@ -303,13 +297,6 @@ class WebhookCreatePage extends Component {
       disabled={this.isDisabled()}
       onChange={this.handleChangeServiceAcct}
     />
-  }
-
-  getSecretButtonCSSID = () => {
-    if (this.isDisabled()) {
-      return "secButtonDisabled"
-    }
-    return "secButtonEnabled"
   }
 
   toggleDeleteDialog = () => {
@@ -342,7 +329,7 @@ class WebhookCreatePage extends Component {
   }
 
   deleteAccessTokenSecret = () => {
-    deleteSecret(this.state.gitsecret, this.state.namespace).then(() => {
+    deleteSecret(this.state.gitsecret).then(() => {
       this.toggleDeleteDialog();
       this.setState({
         apiSecrets: '',
@@ -363,17 +350,16 @@ class WebhookCreatePage extends Component {
         });
       });
     }).finally(() => {
-      this.fetchSecrets(this.state.namespace);
+      this.fetchSecrets();
     })
   }
 
   createAccessTokenSecret = () => {
     const requestBody = {
       name: this.state.newSecretName,
-      namespace: this.state.namespace,
       accesstoken: this.state.newTokenValue
     };
-    createSecret(requestBody, this.state.namespace).then(() => {
+    createSecret(requestBody).then(() => {
       this.toggleCreateDialog()
       this.setState({
         gitsecret: this.state.newSecretName,
@@ -397,7 +383,7 @@ class WebhookCreatePage extends Component {
         });
       });
     }).finally(() => {
-      this.fetchSecrets(this.state.namespace);
+      this.fetchSecrets();
     })
   }
 
@@ -425,22 +411,19 @@ class WebhookCreatePage extends Component {
     const secretItems = [];
     const saItems = [];
 
-    if (!this.state.apiNamespaces) {
-      if (!this.state.namespaceFail) {
-        this.fetchNamespaces();
-      }
-    } else {
+    if (this.state.apiSecrets) {
+      this.state.apiSecrets.map(function (secretResource, index) {
+        secretItems[index] = secretResource['name'];
+      });
+    }
+
+    if (this.state.apiNamespaces) {
       this.state.apiNamespaces.items.map(function (namespaceResource, index) {
         namespaceItems[index] = namespaceResource.metadata['name'];
       });
       if (this.state.apiPipelines) {
         this.state.apiPipelines.items.map(function (pipelineResource, index) {
           pipelineItems[index] = pipelineResource.metadata['name'];
-        });
-      }
-      if (this.state.apiSecrets) {
-        this.state.apiSecrets.map(function (secretResource, index) {
-          secretItems[index] = secretResource['name'];
         });
       }
       if (this.state.apiServiceAccounts) {
@@ -482,9 +465,16 @@ class WebhookCreatePage extends Component {
           <Form onSubmit={this.handleSubmit}>
             <div className="title">Create Webhook</div>
 
+            <div className="row" id="sectionTitle">
+              <u>Webhook Settings</u>
+              <div className="sectionDescription">
+                These settings are used for creating the webhook.
+              </div>
+            </div>
+
             <div className="row">
               <div className="help-icon" id="name-tooltip">
-                <TooltipIcon tooltipText="The display name for your webhook in this user interface.">
+                <TooltipIcon tooltipText="The display name for your webhook in this user interface. This name must consist of lower case alphanumeric characters, '-' or '.'">
                   <Infomation />
                 </TooltipIcon>
               </div>
@@ -533,7 +523,33 @@ class WebhookCreatePage extends Component {
             </div>
 
             <div className="row">
-              <div className="help-icon" id="namespace-tooltip">
+              <div className="help-icon" id="secret-tooltip">
+                <TooltipIcon tooltipText="The kubernetes secret holding access information for the git repository. The credential must have sufficient privileges to create webhooks in the repository and the secret must exist in the same namespace as the dashboard.">
+                  <Infomation />
+                </TooltipIcon>
+              </div>
+              <div className="item-label">
+                <div className="createLabel">Access Token</div>
+              </div>
+              <div className="del-sec-btn"><SubtractAlt20 id="delete-secret-button" onClick={() => { this.toggleDeleteDialog() }}/></div>
+              <div className="git-access-drop-down-div">
+                <div className="createDropDown">
+                  {this.displaySecretDropDown(secretItems)}
+                </div>
+              </div>
+              <div className="add-sec-btn"><AddAlt20 id="create-secret-button" onClick={() => { this.toggleCreateDialog() }}/></div>
+            </div>
+
+            <div className="row"/>
+            <div className="row" id="sectionTitle">
+              <u>Target Pipeline Settings</u>
+              <div className="sectionDescription">
+                These settings select and configure the pipeline to execute when the webhook triggers.
+              </div>
+            </div>
+            
+            <div className="row">
+            <div className="help-icon" id="namespace-tooltip">
                 <TooltipIcon tooltipText="The namespace to operate in.">
                   <Infomation />
                 </TooltipIcon>
@@ -565,26 +581,8 @@ class WebhookCreatePage extends Component {
             </div>
 
             <div className="row">
-              <div className="help-icon" id="secret-tooltip">
-                <TooltipIcon tooltipText="The kubernetes secret holding access information for the git repository. The credential must have sufficient privileges to create webhooks in the repository.">
-                  <Infomation />
-                </TooltipIcon>
-              </div>
-              <div className="item-label">
-                <div className="createLabel">Access Token</div>
-              </div>
-              <div className="del-sec-btn"><SubtractAlt20 id="delete-secret-button" className={this.getSecretButtonCSSID()} onClick={() => { this.toggleDeleteDialog() }}/></div>
-              <div className="git-access-drop-down-div">
-                <div className="createDropDown">
-                  {this.displaySecretDropDown(secretItems)}
-                </div>
-              </div>
-              <div className="add-sec-btn"><AddAlt20 id="create-secret-button" className={this.getSecretButtonCSSID()} onClick={() => { this.toggleCreateDialog() }}/></div>
-            </div>
-
-            <div className="row">
               <div className="help-icon" id="serviceaccount-tooltip">
-                <TooltipIcon tooltipText="The service account under which to run the pipeline run. The service account needs to be patched with secrets to access both git and docker.">
+                <TooltipIcon tooltipText="The service account under which to run the pipeline run. The service account needs to be patched with secrets to access both the Git repository and the Docker registry.">
                   <Infomation />
                 </TooltipIcon>
               </div>

--- a/webhooks-extension/src/components/WebhookCreate/WebhookCreate.scss
+++ b/webhooks-extension/src/components/WebhookCreate/WebhookCreate.scss
@@ -14,6 +14,8 @@
     font-size: 150%;
     text-align: center;
     padding-bottom: 3rem;
+    font-weight: bold;
+    margin-bottom: 1.25rem;
   }
 
   .row {  
@@ -21,6 +23,21 @@
     flex-wrap: nowrap;
     align-items: center;
     padding: 1% 0% 1% 15%;
+  }
+
+  #sectionTitle {
+    font-weight: bold;
+    margin-left: 0.5rem;
+    display: block;
+    margin-top: 1.75rem;
+  }
+
+  .sectionDescription {
+    font-style: italic;
+    font-weight: normal;
+    font-size: 80%;
+    margin-top: 0.4rem;
+    margin-bottom: 0.2rem;
   }
 
   .item-label {
@@ -44,16 +61,6 @@
     width: 50%;
   }
   
-  .secButtonEnabled {
-    cursor: pointer;
-  }
-  
-  .secButtonDisabled {
-    cursor: unset;
-    fill: #dcdcdc;
-    pointer-events: none;
-  }
-  
   #pipeline, #namespace, #git, #serviceAccounts {
     margin: 0;
   }
@@ -63,6 +70,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    cursor: pointer;
   }
     
   .add-sec-btn {

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirm.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirm.test.js
@@ -105,7 +105,7 @@ describe('create secret', () => {
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     jest.spyOn(API, 'createSecret').mockImplementation((request) => {
-      const expectRequest = { name: 'new-secret-foo', namespace: 'istio-system', accesstoken: '1234567890bar' };
+      const expectRequest = { name: 'new-secret-foo', accesstoken: '1234567890bar' };
       expect(request).toStrictEqual(expectRequest);
       return Promise.resolve({});
     });

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirmError.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirmError.test.js
@@ -105,7 +105,7 @@ describe('create secret', () => {
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     jest.spyOn(API, 'createSecret').mockImplementation((request) => {
-      const expectRequest = { name: 'new-secret-foo', namespace: 'istio-system', accesstoken: '1234567890bar' };
+      const expectRequest = { name: 'new-secret-foo', accesstoken: '1234567890bar' };
       expect(request).toStrictEqual(expectRequest);
       return Promise.reject({
         response: {

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalCancel.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalCancel.test.js
@@ -95,29 +95,6 @@ afterEach(() => {
   cleanup()
  });
 
-
- //-----------------------------------//
-describe('delete and create secret', () => {
-  it('buttons should be disabled until namespace selected', async () => {   
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
-    jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
-    jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />); 
-    fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
-    await waitForElement(() => document.getElementsByClassName('del-sec-btn'));
-
-    expect(document.getElementById('delete-secret-button').getAttribute('class')).toBe('secButtonDisabled');
-    expect(document.getElementById('create-secret-button').getAttribute('class')).toBe('secButtonDisabled');
-
-    fireEvent.click(await waitForElement(() => getByText(/istio-system/i)));
-    await waitForElement(() => document.getElementsByClassName('secButtonEnabled'));
-
-    expect(document.getElementById('delete-secret-button').getAttribute('class')).toBe('secButtonEnabled');
-    expect(document.getElementById('create-secret-button').getAttribute('class')).toBe('secButtonEnabled');
-    });
-})
-
 //-----------------------------------//
 describe('delete secret', () => {
 

--- a/webhooks-extension/src/components/WebhookCreate/tests/WebhookCreate.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/WebhookCreate.test.js
@@ -115,6 +115,7 @@ afterEach(() => {
 describe('error fetching namespaces should give error notification', () => {
   it('should display create wizard with form properties and error notification', async () => {   
     jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.reject(namespacesFailResponseMock));
+    jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}}/>); 
       await waitForElement(() => getByText(/Mock Error Fetching Namespaces/i));
     });
@@ -124,20 +125,15 @@ describe('error fetching namespaces should give error notification', () => {
 describe('drop downs should be disabled while no namespace selected', () => {
   it('pipelines dropdown should be disabled', async () => {
     jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
+    jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />);
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)))
     expect(document.getElementById("pipeline").getElementsByClassName("bx--list-box__field").item(0).hasAttribute("disabled")).toBe(true)
 
   });
-  it('secrets dropdown should be disabled', async () => {
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />);
-    fireEvent.click(await waitForElement(() => getByText(/select namespace/i)))
-    expect(document.getElementById("git").getElementsByClassName("bx--list-box__field").item(0).hasAttribute("disabled")).toBe(true)
-
-  });
   it('service accounts dropdown should be disabled', async () => {
     jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
+    jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />);
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)))
     expect(document.getElementById("serviceAccounts").getElementsByClassName("bx--list-box__field").item(0).hasAttribute("disabled")).toBe(true)


### PR DESCRIPTION
This change modifies the webhook create panel to add clarity around
the values being provided.  It also ensures the secret selection
for the secret containing the access token is never disabled or
dependant on the namespace.

The changes in the runtime allow pipelineruns to be created in a
specified namespace and ensure all lookups occur in a single
configmap hosted in the install namespace.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [N/A] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
