### PR TITLE
fix bug where after closing initial notification, the next ones were not appearing

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.43e66c5a.js"
+    tekton-dashboard-bundle-location: "web/extension.2366ed4a.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
@@ -112,7 +112,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.43e66c5a.js"
+    tekton-dashboard-bundle-location: "web/extension.2366ed4a.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
+++ b/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
@@ -404,6 +404,12 @@ class WebhookCreatePage extends Component {
     });
   };
 
+  handleNotificationClose = () => {
+    this.setState({
+      showNotification: false
+    });
+  }
+
   render() {
 
     const namespaceItems = [];
@@ -455,7 +461,9 @@ class WebhookCreatePage extends Component {
               kind={this.state.notificationStatus}
               subtitle={this.state.notificationMessage}
               title={this.state.notificationStatusMsgShort}
-              lowContrast>
+              lowContrast
+              onCloseButtonClick={this.handleNotificationClose}
+            >
             </InlineNotification>
           )}
           {this.state.showNotification && window.scrollTo(0,0)}


### PR DESCRIPTION
issue: #151 

# Changes

A bug with the inline notification component where after closing it the first time, was remaining hidden  when more errors occurred afterwards. Adding a handler to set the `showNotification` state  to `false` every time it was dismissed fixed the problem. 