### PR TITLE
Replace 'npm install' with 'npm ci' for installing webhooks-extension

### DIFF
--- a/webhooks-extension/DEVELOPMENT.md
+++ b/webhooks-extension/DEVELOPMENT.md
@@ -4,6 +4,8 @@ Involved development scripts and instructions can be found in the [development i
 
 ## UI development
 
+Use `npm ci` when installing from source to install with a clean set of dependencies, if a node_modules folder is already present in the project root it will be automatically removed before install.
+
 If modifying the UI code and wanting to deploy your updated version:
 
 1) Run `npm run build` this will create a new file in the dist directory

--- a/webhooks-extension/test/README.md
+++ b/webhooks-extension/test/README.md
@@ -17,7 +17,7 @@ You must install these tools:
 - ko: For development. ko version v0.1 or higher is required for pipeline to work correctly.
 - kubectl: For interacting with your kube cluster
 - helm: Templating is used to install Istio according to [Knative docs](https://knative.dev/docs/install/installing-istio/)
-- npm: For building the user interface
+- [Node.js & npm](https://nodejs.org/): For building and running the frontend locally. _Node.js 10.x is strongly recommended_
 
 ## Dependency Versioning
 The installation script installs the latest version of Istio and known compatible versions of Knative as per values in the version section of [config.sh](https://github.com/tektoncd/experimental/blob/master/webhooks-extension/test/config.sh). Knative Serving 0.6 has made considerable changes to the service definition so levels below this are not supported.

--- a/webhooks-extension/test/util.sh
+++ b/webhooks-extension/test/util.sh
@@ -175,7 +175,7 @@ function install_webhooks_extension() {
   fi 
   namespace=$1
   docker login
-  npm install
+  npm ci
   npm rebuild node-sass
   npm run build_ko
   dep ensure -v


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Changed the docs to recommend 'npm ci' instead of 'npm install' and to recommend version 10 of node.js

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
