### PR TITLE
replace api calls with dashboard's redux selectors & actions

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.fc311844.js"
+    tekton-dashboard-bundle-location: "web/extension.c83f46fd.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
@@ -112,7 +112,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.fc311844.js"
+    tekton-dashboard-bundle-location: "web/extension.c83f46fd.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/src/WebhookApp.js
+++ b/webhooks-extension/src/WebhookApp.js
@@ -26,20 +26,56 @@ class WebhooksApp extends Component {
   }
 
   render() {
-    const { match, namespace } = this.props;
+    const {
+      isFetchingNamespaces,
+      match,
+      namespace,
+      namespaces
+    } = this.props;
 
-      return (
-        <div>
-          <Route exact path={`${match.path}/`} render={props => <WebhookDisplayTable {...props} selectedNamespace={namespace} showNotificationOnTable={this.state.showNotificationOnTable} setshowLastWebhookDeletedNotification={this.setshowLastWebhookDeletedNotification}/>} />
-          <Route path={`${match.path}/create`} render={props => <WebhookCreate {...props} setShowNotificationOnTable={this.setShowNotificationOnTable} setshowLastWebhookDeletedNotification={this.setshowLastWebhookDeletedNotification} showLastWebhookDeletedNotification={this.state.showLastWebhookDeletedNotification}/>} />
-        </div>
-      )
+    return (
+      <div>
+        <Route
+          exact
+          path={`${match.path}/`}
+          render={props => (
+            <WebhookDisplayTable
+              {...props}
+              selectedNamespace={namespace}
+              showNotificationOnTable={this.state.showNotificationOnTable}
+              setshowLastWebhookDeletedNotification={
+                this.setshowLastWebhookDeletedNotification
+              }
+            />
+          )}
+        />
+        <Route
+          path={`${match.path}/create`}
+          render={props => (
+            <WebhookCreate
+              {...props}
+              namespaces={namespaces}
+              isFetchingNamespaces={isFetchingNamespaces}
+              setShowNotificationOnTable={this.setShowNotificationOnTable}
+              setshowLastWebhookDeletedNotification={
+                this.setshowLastWebhookDeletedNotification
+              }
+              showLastWebhookDeletedNotification={
+                this.state.showLastWebhookDeletedNotification
+              }
+            />
+          )}
+        />
+      </div>
+    );
   }
 }
 
 function mapStateToProps(state, props) {
   return {
-    namespace: props.selectors.getSelectedNamespace(state)
+    namespace: props.selectors.getSelectedNamespace(state),
+    namespaces: props.selectors.getNamespaces(state),
+    isFetchingNamespaces: props.selectors.isFetchingNamespaces(state),
   };
 }
 

--- a/webhooks-extension/src/WebhookApp.test.js
+++ b/webhooks-extension/src/WebhookApp.test.js
@@ -43,12 +43,6 @@ const namespaces = {
         name: 'default',
         uid: '32b35d3b-6ce1-11e9-af21-025000000001',
       },
-      spec: {
-        finalizers: ['kubernetes']
-      },
-      status: {
-        phase: 'Active'
-      }
     }
   },
   errorMessage: null,
@@ -101,31 +95,6 @@ const fakeRowSelection = [
   ]}
 ]
 
-const namespacesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      }
-    },
-    {
-      "metadata": {
-        "name": "docker",
-      }
-    },
-    {
-      "metadata": {
-        "name": "istio-system",
-      },
-    },
-    {
-      "metadata": {
-        "name": "knative-eventing",
-      },
-    }
-  ]
-};
-
 const pipelinesResponseMock = {
   "items": [
     {
@@ -175,16 +144,20 @@ const webhooks = [
   }
 ];
 
+const selectors = {
+  getSelectedNamespace: jest.fn(() => "default"),
+  getNamespaces: jest.fn(() => ["default", "namespace2", "namespace3"]),
+  isFetchingNamespaces: jest.fn(() => false),
+}
+
 it('change in components after last webhook deleted', async () => {
   let getWebhooksMock = jest.spyOn(API, "getWebhooks").mockImplementation(() => Promise.resolve(webhooks));
   let getRowsMock = jest.spyOn(API, "getSelectedRows").mockImplementation(() => fakeRowSelection);
   let deleteWebhooksMock = jest.spyOn(API, "deleteWebhooks").mockImplementation(() => Promise.resolve(fakeDeleteWebhooksSuccess));
 
-  const selectors = {getSelectedNamespace: jest.fn(() => "default")};
-
   const { getByText, queryByTestId } = renderWithRouter(
     <Provider store={store}>
-      <WebhookApp match={{}} namespace="default" selectors={selectors}/>
+      <WebhookApp match={{}} selectors={selectors}/>
     </Provider>);
 
 
@@ -207,7 +180,6 @@ it('change in components after last webhook deleted', async () => {
   expect(deleteWebhooksMock).toHaveBeenCalled();
 
   getWebhooksMock.mockImplementation(() => Promise.resolve([]));
-  jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
   jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
   jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
   jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));

--- a/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
+++ b/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 
 import { Button, TextInput, Dropdown, Form, Tooltip, DropdownSkeleton, Modal, InlineNotification, TooltipIcon } from 'carbon-components-react';
-import { getNamespaces, getPipelines, getSecrets, getServiceAccounts, createWebhook, createSecret, deleteSecret } from '../../api/index';
+import { getPipelines, getSecrets, getServiceAccounts, createWebhook, createSecret, deleteSecret } from '../../api/index';
 
 import AddAlt20 from '@carbon/icons-react/lib/add--alt/20';
 import SubtractAlt20 from '@carbon/icons-react/lib/subtract--alt/20';
@@ -26,8 +26,6 @@ class WebhookCreatePage extends Component {
 
   constructor(props) {
     super(props);
-    // turn off webhook created message
-    this.props.setShowNotificationOnTable(false);
 
     this.state = {
       // variables to stop re-attempts to load
@@ -44,7 +42,6 @@ class WebhookCreatePage extends Component {
       serviceAccount: '',
       dockerRegistry: '',
       // fetched data from api calls
-      apiNamespaces: '',
       apiPipelines: '',
       apiSecrets: '',
       apiServiceAccounts: '',
@@ -65,12 +62,12 @@ class WebhookCreatePage extends Component {
       visibleCSS: 'token-visible',
       invisibleCSS: 'token-invisible'
     };
-
-    this.fetchSecrets();
-    this.fetchNamespaces();
   }
 
   componentDidMount(){
+    // turn off webhook created message
+    this.props.setShowNotificationOnTable(false);
+    this.fetchSecrets();
     if(this.props.showLastWebhookDeletedNotification){
       this.setState({
         notificationMessage: "Last webhook deleted successfully.",
@@ -85,24 +82,6 @@ class WebhookCreatePage extends Component {
       document.getElementById(
         "serviceAccounts"
       ).firstElementChild.tabIndex = -1;
-    }
-  }
-
-  async fetchNamespaces() {
-    let ns;
-    try {
-      ns = await getNamespaces();
-      this.setState({apiNamespaces: ns})
-    } catch (error) {
-        error.response.text().then((text) => {
-          this.setState({
-            namespaceFail: true,
-            notificationMessage: "Failed to get namespaces, error returned was : " + text,
-            notificationStatus: 'error',
-            notificationStatusMsgShort: 'Error:',
-            showNotification: true,
-          });
-        });
     }
   }
 
@@ -253,14 +232,14 @@ class WebhookCreatePage extends Component {
     return "submit"
   }
 
-  displayNamespaceDropDown = (namespaceItems) => {
-    if (!this.state.apiNamespaces) {
+  displayNamespaceDropDown = () => {
+    if (this.props.isFetchingNamespaces) {
       return <DropdownSkeleton/>
     }
     return <Dropdown
         id="namespace"
         label="select namespace"
-        items={namespaceItems}
+        items={this.props.namespaces}
         onChange={this.handleChangeNamespace}
       />
   }
@@ -422,7 +401,6 @@ class WebhookCreatePage extends Component {
 
   render() {
 
-    const namespaceItems = [];
     const pipelineItems = [];
     const secretItems = [];
     const saItems = [];
@@ -433,10 +411,7 @@ class WebhookCreatePage extends Component {
       });
     }
 
-    if (this.state.apiNamespaces) {
-      this.state.apiNamespaces.items.map(function (namespaceResource, index) {
-        namespaceItems[index] = namespaceResource.metadata['name'];
-      });
+    if (this.props.namespaces) {
       if (this.state.apiPipelines) {
         this.state.apiPipelines.items.map(function (pipelineResource, index) {
           pipelineItems[index] = pipelineResource.metadata['name'];
@@ -569,7 +544,7 @@ class WebhookCreatePage extends Component {
               </div>
               <div className="entry-field">
                 <div className="createDropDown">
-                  {this.displayNamespaceDropDown(namespaceItems)}
+                  {this.displayNamespaceDropDown()}
                 </div>
               </div>
             </div>

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalCancel.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalCancel.test.js
@@ -20,31 +20,7 @@ import * as API from '../../../api/index';
 import 'jest-dom/extend-expect'
 
 
-const namespacesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-        }
-      },
-    {
-      "metadata": {
-        "name": "docker",
-      }
-    },
-    {
-      "metadata": {
-        "name": "istio-system",
-      },
-    },
-    {
-      "metadata": {
-        "name": "knative-eventing",
-      },
-    }
-  ]
-
-};
+const namespaces = ["default", "istio-system", "namespace3"];
 
 const pipelinesResponseMock = {
   "items": [
@@ -99,12 +75,17 @@ afterEach(() => {
 //-----------------------------------//
 describe('create secret', () => {
 
-  it('modal should be shown when create secret button clicked, subsequent create button should be disabled', async () => {  
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
+  it('modal should be shown when create secret button clicked, subsequent create button should be disabled', async () => {
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />); 
+    const { getByText } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)));
 
@@ -116,11 +97,16 @@ describe('create secret', () => {
   });
   
   it('cancel button should hide modal', async () => {
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />); 
+    const { getByText } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)));
 

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirm.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirm.test.js
@@ -21,30 +21,7 @@ import 'jest-dom/extend-expect'
 
 global.scrollTo = jest.fn();
 
-const namespacesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      }
-    },
-    {
-      "metadata": {
-        "name": "docker",
-      }
-    },
-    {
-      "metadata": {
-        "name": "istio-system",
-      },
-    },
-    {
-      "metadata": {
-        "name": "knative-eventing",
-      },
-    }
-  ]
-};
+const namespaces = ["default", "istio-system", "namespace3"];
 
 const pipelinesResponseMock = {
   "items": [
@@ -100,7 +77,6 @@ afterEach(() => {
 describe('create secret', () => {
 
   it('create should hide modal and return to form with new secret selected', async () => {
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
@@ -110,7 +86,13 @@ describe('create secret', () => {
       return Promise.resolve({});
     });
 
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />); 
+    const { getByText } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    ); 
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)));
     fireEvent.click(await waitForElement(() => document.getElementById('create-secret-button')));

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirmError.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirmError.test.js
@@ -21,30 +21,7 @@ import 'jest-dom/extend-expect'
 
 global.scrollTo = jest.fn();
 
-const namespacesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      }
-    },
-    {
-      "metadata": {
-        "name": "docker",
-      }
-    },
-    {
-      "metadata": {
-        "name": "istio-system",
-      },
-    },
-    {
-      "metadata": {
-        "name": "knative-eventing",
-      },
-    }
-  ]
-};
+const namespaces = ["default", "istio-system", "namespace3"];
 
 const pipelinesResponseMock = {
   "items": [
@@ -99,8 +76,7 @@ afterEach(() => {
 //-----------------------------------//
 describe('create secret', () => {
 
-  it('notification shown when error occurs creating secret', async () => {  
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
+  it('notification shown when error occurs creating secret', async () => {
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
@@ -109,13 +85,19 @@ describe('create secret', () => {
       expect(request).toStrictEqual(expectRequest);
       return Promise.reject({
         response: {
-        text() {
+        text: () => {
           return Promise.resolve("Mock Error Creating Secret")
         }
       }});
     });
 
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />); 
+    const { getByText } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)));
     fireEvent.click(await waitForElement(() => document.getElementById('create-secret-button')));

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalVisibilityAndToggle.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalVisibilityAndToggle.test.js
@@ -20,30 +20,7 @@ import * as API from '../../../api/index';
 import 'jest-dom/extend-expect'
 
 
-const namespacesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      }
-    },
-    {
-      "metadata": {
-        "name": "docker",
-      }
-    },
-    {
-      "metadata": {
-        "name": "istio-system",
-      },
-    },
-    {
-      "metadata": {
-        "name": "knative-eventing",
-      },
-    }
-  ]
-};
+const namespaces = ["default", "istio-system", "namespace3"];
 
 const pipelinesResponseMock = {
   "items": [
@@ -98,12 +75,17 @@ afterEach(() => {
 //-----------------------------------//
 describe('create secret', () => {
 
-  it('create button enabled only when name and token complete', async () => {  
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
+  it('create button enabled only when name and token complete', async () => {
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />); 
+    const { getByText } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)));
 
@@ -124,13 +106,18 @@ describe('create secret', () => {
     expect(document.getElementsByClassName('create-modal').item(0).getElementsByClassName('bx--btn--primary').item(0).getAttributeNames()).toContain('disabled')
 
   });
-  
-  it('should be able toggle visibility of token', async () => {  
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
+
+  it('should be able toggle visibility of token', async () => {
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />); 
+    const { getByText } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)));
 

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalCancel.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalCancel.test.js
@@ -21,30 +21,7 @@ import 'jest-dom/extend-expect'
 
 global.scrollTo = jest.fn();
 
-const namespacesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      }
-    },
-    {
-      "metadata": {
-        "name": "docker",
-      }
-    },
-    {
-      "metadata": {
-        "name": "istio-system",
-      },
-    },
-    {
-      "metadata": {
-        "name": "knative-eventing",
-      },
-    }
-  ]
-};
+const namespaces = ["default", "istio-system", "namespace3"];
 
 const pipelinesResponseMock = {
   "items": [
@@ -98,12 +75,17 @@ afterEach(() => {
 //-----------------------------------//
 describe('delete secret', () => {
 
-  it('should display error notification if no secret selected and delete pressed', async () => {   
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
+  it('should display error notification if no secret selected and delete pressed', async () => {
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />); 
+    const { getByText } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)));
 
@@ -115,11 +97,16 @@ describe('delete secret', () => {
 
   it('cancel button should hide modal', async () => {
 
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />);
+    const { getByText } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)));
     await waitForElement(() => document.getElementsByClassName('secButtonEnabled'));

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirm.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirm.test.js
@@ -21,30 +21,7 @@ import 'jest-dom/extend-expect'
 
 global.scrollTo = jest.fn();
 
-const namespacesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      }
-    },
-    {
-      "metadata": {
-        "name": "docker",
-      }
-    },
-    {
-      "metadata": {
-        "name": "istio-system",
-      },
-    },
-    {
-      "metadata": {
-        "name": "knative-eventing",
-      },
-    }
-  ]
-};
+const namespaces = ["default", "istio-system", "namespace3"];
 
 const pipelinesResponseMock = {
   "items": [
@@ -106,12 +83,17 @@ afterEach(() => {
 //-----------------------------------//
 describe('confirm deletion success', () => {
   it('delete button should hide modal, remove secret from listing and reset dropdown', async () => {
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     jest.spyOn(API, 'deleteSecret').mockImplementation(() => Promise.resolve(deleteSecretSuccessMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />);
+    const { getByText } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)));
     await waitForElement(() => document.getElementsByClassName('secButtonEnabled'));

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirmError.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirmError.test.js
@@ -21,30 +21,7 @@ import 'jest-dom/extend-expect'
 
 global.scrollTo = jest.fn();
 
-const namespacesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      }
-    },
-    {
-      "metadata": {
-        "name": "docker",
-      }
-    },
-    {
-      "metadata": {
-        "name": "istio-system",
-      },
-    },
-    {
-      "metadata": {
-        "name": "knative-eventing",
-      },
-    }
-  ]
-};
+const namespaces = ["default", "istio-system", "namespace3"];
 
 const pipelinesResponseMock = {
   "items": [
@@ -72,7 +49,7 @@ const secretsResponseMock = [
 
 const deleteSecretFailMock = {
   response: {
-    text() {
+    text: () => {
       return Promise.resolve("Mock Error Deleting Secret")
     }
   }
@@ -107,12 +84,17 @@ afterEach(() => {
 describe('confirm deletion errors', () => {
   
   it("error returned from deleteSecret should show notification", async () => {
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
 
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />);
+    const { getByText } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)));
     await waitForElement(() => document.getElementsByClassName('secButtonEnabled'));

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalSecretName.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalSecretName.test.js
@@ -21,30 +21,7 @@ import 'jest-dom/extend-expect'
 
 global.scrollTo = jest.fn();
 
-const namespacesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      }
-    },
-    {
-      "metadata": {
-        "name": "docker",
-      }
-    },
-    {
-      "metadata": {
-        "name": "istio-system",
-      },
-    },
-    {
-      "metadata": {
-        "name": "knative-eventing",
-      },
-    }
-  ]
-};
+const namespaces = ["default", "istio-system", "namespace3"];
 
 const pipelinesResponseMock = {
   "items": [
@@ -99,11 +76,16 @@ afterEach(() => {
 describe('delete modal secret name', () => {
 
   it('modal should be shown to confirm deletion and include selected secret name', async () => {
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />);
+    const { getByText } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)));
     fireEvent.click(await waitForElement(() => getByText(/select secret/i)));

--- a/webhooks-extension/src/components/WebhookCreate/tests/WebhookCreate.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/WebhookCreate.test.js
@@ -21,46 +21,15 @@ import 'jest-dom/extend-expect'
 
 global.scrollTo = jest.fn();
 
-const namespacesFailResponseMock = {
-  response: {
-    text() {
-      return Promise.resolve("Mock Error Fetching Namespaces")
-    }
-  }
-};
-
 const WebhookCreationFailMock = {
   response: {
-    text() {
+    text: () => {
       return Promise.resolve("Mock Error Creating Webhook")
     }
   }
 };
 
-const namespacesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      }
-    },
-    {
-      "metadata": {
-        "name": "docker",
-      }
-    },
-    {
-      "metadata": {
-        "name": "istio-system",
-      },
-    },
-    {
-      "metadata": {
-        "name": "knative-eventing",
-      },
-    }
-  ]
-};
+const namespaces = ["default", "istio-system", "namespace3"];
 
 const pipelinesResponseMock = {
   "items": [
@@ -105,36 +74,36 @@ beforeEach(() => {
   jest.restoreAllMocks
   jest.resetModules()
  });
- 
+
 afterEach(() => {
   jest.clearAllMocks()
   cleanup()
  });
 
 //-----------------------------------//
-describe('error fetching namespaces should give error notification', () => {
-  it('should display create wizard with form properties and error notification', async () => {   
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.reject(namespacesFailResponseMock));
-    jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}}/>); 
-      await waitForElement(() => getByText(/Mock Error Fetching Namespaces/i));
-    });
-})
-
-//-----------------------------------//
 describe('drop downs should be disabled while no namespace selected', () => {
   it('pipelines dropdown should be disabled', async () => {
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />);
+    const { getByText } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)))
     expect(document.getElementById("pipeline").getElementsByClassName("bx--list-box__field").item(0).hasAttribute("disabled")).toBe(true)
 
   });
   it('service accounts dropdown should be disabled', async () => {
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />);
+    const { getByText } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)))
     expect(document.getElementById("serviceAccounts").getElementsByClassName("bx--list-box__field").item(0).hasAttribute("disabled")).toBe(true)
 
@@ -144,32 +113,47 @@ describe('drop downs should be disabled while no namespace selected', () => {
 //-----------------------------------//
 describe('drop downs should be enabled when a namespace is selected', () => {
   it('pipelines dropdown should be enabled', async () => {
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />);
+    const { getByText } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)))
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)))
     await wait(() => expect(document.getElementById("pipeline").getElementsByClassName("bx--list-box__field").item(0).hasAttribute("disabled")).toBe(false))
   });
   it('secrets dropdown should be enabled', async () => {
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />);
+    const { getByText } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)))
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)))
     await wait(() => expect(document.getElementById("git").getElementsByClassName("bx--list-box__field").item(0).hasAttribute("disabled")).toBe(false))
 
   });
   it('service accounts dropdown should be enabled', async () => {
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
-    const { getByText } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />);
+    const { getByText } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)))
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)))
     await wait(() => expect(document.getElementById("serviceAccounts").getElementsByClassName("bx--list-box__field").item(0).hasAttribute("disabled")).toBe(false))
@@ -182,15 +166,20 @@ describe('create button enablement', () => {
   // Increase timeout as lots involved in this test
   jest.setTimeout(15000);
   it('create button should be enabled only when all fields complete', async () => {
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
-    const { getByText, getByTestId } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />);
-    
+    const { getByText, getByTestId } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
+
     fireEvent.click(await waitForElement(() => getByTestId('display-name-entry')));
     await wait(() => expect(getByTestId('create-button')).toBeDisabled())
-    
+
     const name = getByTestId('display-name-entry')
     fireEvent.change(name, { target: { value: 'test-webhook-name' } });
     await wait(() => expect(getByTestId('create-button')).toBeDisabled())
@@ -244,16 +233,21 @@ describe('create button enablement', () => {
 //-----------------------------------//
 describe('create button', () => {
   it('create failure should return notification', async () => {
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     jest.spyOn(API, 'createWebhook').mockImplementation(() => Promise.reject(WebhookCreationFailMock));
-    const { getByText, getByTestId } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => { }} />);
-    
+    const { getByText, getByTestId } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
+
     fireEvent.click(await waitForElement(() => getByTestId('display-name-entry')));
     await wait(() => expect(getByTestId('create-button')).toBeDisabled())
-    
+
     const name = getByTestId('display-name-entry')
     fireEvent.change(name, { target: { value: 'test-webhook-name' } });
     await wait(() => expect(getByTestId('create-button')).toBeDisabled())
@@ -291,7 +285,6 @@ describe('create button', () => {
   }, 15000)
 
   it('success should set showNotification and call returnToTable', async () => {
-    jest.spyOn(API, 'getNamespaces').mockImplementation(() => Promise.resolve(namespacesResponseMock));
     jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
@@ -309,11 +302,17 @@ describe('create button', () => {
       return Promise.resolve({})
     });
 
-    const { getByText, getByTestId } = renderWithRouter(<WebhookCreate match={{}} setShowNotificationOnTable={() => {}} />);
-    
+    const { getByText, getByTestId } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
+
     fireEvent.click(await waitForElement(() => getByTestId('display-name-entry')));
     await wait(() => expect(getByTestId('create-button')).toBeDisabled())
-    
+
     const name = getByTestId('display-name-entry')
     fireEvent.change(name, { target: { value: 'test-webhook-name' } });
     await wait(() => expect(getByTestId('create-button')).toBeDisabled())


### PR DESCRIPTION
issue: #137 

# Changes
removed & replaced the api calls for getting namespaces, service accounts and pipelines with the redux selectors & actions that were passed as props to the extension component. Also updated all necessary tests. 

Its worth mentioning that the api call to get webhook secrets was left because at the moment the getSecrets action did not return the secrets created for webhooks. 