### PR TITLE
remove warning message when setting state in render method

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.0dbb4841.js"
+    tekton-dashboard-bundle-location: "web/extension.56f5900e.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
@@ -112,7 +112,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.0dbb4841.js"
+    tekton-dashboard-bundle-location: "web/extension.56f5900e.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
+++ b/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
@@ -136,6 +136,24 @@ class WebhookCreatePage extends Component {
     }
   }
 
+  componentDidUpdate() {
+    if (this.props.namespaces) {
+      if (this.state.createSecretDisabled) {
+        if (this.state.newSecretName && this.state.newTokenValue) {
+          this.setState({
+            createSecretDisabled: false
+          })
+        }
+      } else {
+        if (!this.state.newSecretName || !this.state.newTokenValue) {
+          this.setState({
+            createSecretDisabled: true
+          })
+        }
+      }
+    }
+  }
+
   async fetchSecrets() {
     let s;
     try {
@@ -465,22 +483,6 @@ class WebhookCreatePage extends Component {
       this.state.apiSecrets.map(function (secretResource, index) {
         secretItems[index] = secretResource['name'];
       });
-    }
-
-    if (this.props.namespaces) {
-      if (this.state.createSecretDisabled) {
-        if (this.state.newSecretName && this.state.newTokenValue) {
-          this.setState({
-            createSecretDisabled: false
-          })
-        }
-      } else {
-        if (!this.state.newSecretName || !this.state.newTokenValue) {
-          this.setState({
-            createSecretDisabled: true
-          })
-        }
-      }
     }
 
     return (


### PR DESCRIPTION
issue: #170 

# Changes
 
the warning message was removed when the lifecycle method getDerivedStateFromProps was added with the lines that were changing state in the render method. 