### PR TITLE
replace pipelines api call with dashboard's redux selectors & actions

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.73344527.js"
+    tekton-dashboard-bundle-location: "web/extension.b29ef14b.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
@@ -112,7 +112,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.73344527.js"
+    tekton-dashboard-bundle-location: "web/extension.b29ef14b.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/src/WebhookApp.js
+++ b/webhooks-extension/src/WebhookApp.js
@@ -27,10 +27,14 @@ class WebhooksApp extends Component {
 
   render() {
     const {
+      fetchPipelines,
+      getPipelinesErrorMessage,
       isFetchingNamespaces,
+      isFetchingPipelines,
       match,
       namespace,
-      namespaces
+      namespaces,
+      pipelines
     } = this.props;
 
     return (
@@ -55,7 +59,11 @@ class WebhooksApp extends Component {
             <WebhookCreate
               {...props}
               namespaces={namespaces}
+              pipelines={pipelines}
               isFetchingNamespaces={isFetchingNamespaces}
+              isFetchingPipelines={isFetchingPipelines}
+              getPipelinesErrorMessage={getPipelinesErrorMessage}
+              fetchPipelines={fetchPipelines}
               setShowNotificationOnTable={this.setShowNotificationOnTable}
               setshowLastWebhookDeletedNotification={
                 this.setshowLastWebhookDeletedNotification
@@ -75,10 +83,19 @@ function mapStateToProps(state, props) {
   return {
     namespace: props.selectors.getSelectedNamespace(state),
     namespaces: props.selectors.getNamespaces(state),
+    pipelines: props.selectors.getPipelines(state),
     isFetchingNamespaces: props.selectors.isFetchingNamespaces(state),
+    isFetchingPipelines: props.selectors.isFetchingPipelines(state),
+    getPipelinesErrorMessage: props.selectors.getPipelinesErrorMessage(state),
   };
 }
 
+const mapDispatchToProps = (dispatch, props) => ({
+  fetchPipelines: namespace =>
+    dispatch(props.actions.fetchPipelines({ namespace }))
+});
+
 export default connect(
-  mapStateToProps
+  mapStateToProps,
+  mapDispatchToProps
 )(withRouter(WebhooksApp));

--- a/webhooks-extension/src/WebhookApp.test.js
+++ b/webhooks-extension/src/WebhookApp.test.js
@@ -95,21 +95,6 @@ const fakeRowSelection = [
   ]}
 ]
 
-const pipelinesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline",
-      }
-    },
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline-insecure",
-      }
-    },
-  ]
-}
-
 const secretsResponseMock = [
   {
     "name": "ghe",
@@ -147,8 +132,24 @@ const webhooks = [
 const selectors = {
   getSelectedNamespace: jest.fn(() => "default"),
   getNamespaces: jest.fn(() => ["default", "namespace2", "namespace3"]),
+  getPipelines: jest.fn(() => [
+    {
+      metadata: {
+        name: "pipeline0",
+        namespace: "default"
+      }
+    },
+    {
+      metadata: {
+        name: "simple-pipeline",
+        namespace: "default"
+      }
+    }
+  ]),
   isFetchingNamespaces: jest.fn(() => false),
-}
+  isFetchingPipelines: jest.fn(() => false),
+  getPipelinesErrorMessage: jest.fn(() => null),
+};
 
 it('change in components after last webhook deleted', async () => {
   let getWebhooksMock = jest.spyOn(API, "getWebhooks").mockImplementation(() => Promise.resolve(webhooks));
@@ -180,7 +181,6 @@ it('change in components after last webhook deleted', async () => {
   expect(deleteWebhooksMock).toHaveBeenCalled();
 
   getWebhooksMock.mockImplementation(() => Promise.resolve([]));
-  jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
   jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
   jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
 

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalCancel.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalCancel.test.js
@@ -22,20 +22,26 @@ import 'jest-dom/extend-expect'
 
 const namespaces = ["default", "istio-system", "namespace3"];
 
-const pipelinesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline",
-      }
+const pipelines = [
+  {
+    metadata: {
+      name: "pipeline0",
+      namespace: "default",
     },
-    {
-      "metadata": {
-         "name": "simple-helm-pipeline-insecure",
-      }
+  },
+  {
+    metadata: {
+      name: "simple-pipeline",
+      namespace: "default",
     },
-  ]
-}
+  },
+  {
+    metadata: {
+      name: "simple-helm-pipeline-insecure",
+      namespace: "istio-system",
+    }
+  }
+];
 
 const secretsResponseMock = [
   {
@@ -76,13 +82,14 @@ afterEach(() => {
 describe('create secret', () => {
 
   it('modal should be shown when create secret button clicked, subsequent create button should be disabled', async () => {
-    jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     const { getByText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
+        pipelines={pipelines}
+        fetchPipelines={() => {}}
         setShowNotificationOnTable={() => {}}
       />
     );
@@ -95,15 +102,16 @@ describe('create secret', () => {
     expect(document.getElementsByClassName('create-modal').item(0).getElementsByClassName('bx--btn--primary').item(0).getAttributeNames()).toContain('disabled')
 
   });
-  
+
   it('cancel button should hide modal', async () => {
-    jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     const { getByText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
+        pipelines={pipelines}
+        fetchPipelines={() => {}}
         setShowNotificationOnTable={() => {}}
       />
     );

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirm.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirm.test.js
@@ -23,20 +23,26 @@ global.scrollTo = jest.fn();
 
 const namespaces = ["default", "istio-system", "namespace3"];
 
-const pipelinesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline",
-      }
+const pipelines = [
+  {
+    metadata: {
+      name: "pipeline0",
+      namespace: "default",
     },
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline-insecure",
-      }
+  },
+  {
+    metadata: {
+      name: "simple-pipeline",
+      namespace: "default",
     },
-  ]
-}
+  },
+  {
+    metadata: {
+      name: "simple-helm-pipeline-insecure",
+      namespace: "istio-system",
+    }
+  }
+];
 
 const secretsResponseMock = [
   {
@@ -77,7 +83,6 @@ afterEach(() => {
 describe('create secret', () => {
 
   it('create should hide modal and return to form with new secret selected', async () => {
-    jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     jest.spyOn(API, 'createSecret').mockImplementation((request) => {
@@ -90,9 +95,12 @@ describe('create secret', () => {
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
+        pipelines={pipelines}
         setShowNotificationOnTable={() => {}}
+        fetchPipelines={() => {}}
+        isFetchingPipelines={false}
       />
-    ); 
+    );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)));
     fireEvent.click(await waitForElement(() => document.getElementById('create-secret-button')));

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirmError.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirmError.test.js
@@ -23,20 +23,26 @@ global.scrollTo = jest.fn();
 
 const namespaces = ["default", "istio-system", "namespace3"];
 
-const pipelinesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline",
-      }
+const pipelines = [
+  {
+    metadata: {
+      name: "pipeline0",
+      namespace: "default",
     },
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline-insecure",
-      }
+  },
+  {
+    metadata: {
+      name: "simple-pipeline",
+      namespace: "default",
     },
-  ]
-}
+  },
+  {
+    metadata: {
+      name: "simple-helm-pipeline-insecure",
+      namespace: "istio-system",
+    }
+  }
+];
 
 const secretsResponseMock = [
   {
@@ -77,7 +83,6 @@ afterEach(() => {
 describe('create secret', () => {
 
   it('notification shown when error occurs creating secret', async () => {
-    jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     jest.spyOn(API, 'createSecret').mockImplementation((request) => {
@@ -95,7 +100,10 @@ describe('create secret', () => {
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
+        pipelines={pipelines}
         setShowNotificationOnTable={() => {}}
+        fetchPipelines={() => {}}
+        isFetchingPipelines={false}
       />
     );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalVisibilityAndToggle.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalVisibilityAndToggle.test.js
@@ -22,20 +22,26 @@ import 'jest-dom/extend-expect'
 
 const namespaces = ["default", "istio-system", "namespace3"];
 
-const pipelinesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline",
-      }
+const pipelines = [
+  {
+    metadata: {
+      name: "pipeline0",
+      namespace: "default",
     },
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline-insecure",
-      }
+  },
+  {
+    metadata: {
+      name: "simple-pipeline",
+      namespace: "default",
     },
-  ]
-}
+  },
+  {
+    metadata: {
+      name: "simple-helm-pipeline-insecure",
+      namespace: "istio-system",
+    }
+  }
+];
 
 const secretsResponseMock = [
   {
@@ -76,13 +82,14 @@ afterEach(() => {
 describe('create secret', () => {
 
   it('create button enabled only when name and token complete', async () => {
-    jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     const { getByText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
+        pipelines={pipelines}
+        fetchPipelines={() => {}}
         setShowNotificationOnTable={() => {}}
       />
     );
@@ -108,13 +115,14 @@ describe('create secret', () => {
   });
 
   it('should be able toggle visibility of token', async () => {
-    jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     const { getByText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
+        pipelines={pipelines}
+        fetchPipelines={() => {}}
         setShowNotificationOnTable={() => {}}
       />
     );

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalCancel.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalCancel.test.js
@@ -23,20 +23,26 @@ global.scrollTo = jest.fn();
 
 const namespaces = ["default", "istio-system", "namespace3"];
 
-const pipelinesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline",
-      }
+const pipelines = [
+  {
+    metadata: {
+      name: "pipeline0",
+      namespace: "default",
     },
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline-insecure",
-      }
+  },
+  {
+    metadata: {
+      name: "simple-pipeline",
+      namespace: "default",
     },
-  ]
-}
+  },
+  {
+    metadata: {
+      name: "simple-helm-pipeline-insecure",
+      namespace: "istio-system",
+    }
+  }
+];
 
 const secretsResponseMock = [
   {
@@ -76,13 +82,14 @@ afterEach(() => {
 describe('delete secret', () => {
 
   it('should display error notification if no secret selected and delete pressed', async () => {
-    jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     const { getByText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
+        pipelines={pipelines}
+        fetchPipelines={() => {}}
         setShowNotificationOnTable={() => {}}
       />
     );
@@ -97,13 +104,14 @@ describe('delete secret', () => {
 
   it('cancel button should hide modal', async () => {
 
-    jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     const { getByText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
+        pipelines={pipelines}
+        fetchPipelines={() => {}}
         setShowNotificationOnTable={() => {}}
       />
     );

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirm.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirm.test.js
@@ -23,20 +23,26 @@ global.scrollTo = jest.fn();
 
 const namespaces = ["default", "istio-system", "namespace3"];
 
-const pipelinesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline",
-      }
+const pipelines = [
+  {
+    metadata: {
+      name: "pipeline0",
+      namespace: "default",
     },
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline-insecure",
-      }
+  },
+  {
+    metadata: {
+      name: "simple-pipeline",
+      namespace: "default",
     },
-  ]
-}
+  },
+  {
+    metadata: {
+      name: "simple-helm-pipeline-insecure",
+      namespace: "istio-system",
+    }
+  }
+];
 
 const secretsResponseMock = [
   {
@@ -83,7 +89,6 @@ afterEach(() => {
 //-----------------------------------//
 describe('confirm deletion success', () => {
   it('delete button should hide modal, remove secret from listing and reset dropdown', async () => {
-    jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     jest.spyOn(API, 'deleteSecret').mockImplementation(() => Promise.resolve(deleteSecretSuccessMock));
@@ -91,7 +96,10 @@ describe('confirm deletion success', () => {
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
+        pipelines={pipelines}
         setShowNotificationOnTable={() => {}}
+        fetchPipelines={() => {}}
+        isFetchingPipelines={false}
       />
     );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirmError.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirmError.test.js
@@ -23,20 +23,26 @@ global.scrollTo = jest.fn();
 
 const namespaces = ["default", "istio-system", "namespace3"];
 
-const pipelinesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline",
-      }
+const pipelines = [
+  {
+    metadata: {
+      name: "pipeline0",
+      namespace: "default",
     },
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline-insecure",
-      }
+  },
+  {
+    metadata: {
+      name: "simple-pipeline",
+      namespace: "default",
     },
-  ]
-}
+  },
+  {
+    metadata: {
+      name: "simple-helm-pipeline-insecure",
+      namespace: "istio-system",
+    }
+  }
+];
 
 const secretsResponseMock = [
   {
@@ -82,9 +88,8 @@ afterEach(() => {
 
 //-----------------------------------//
 describe('confirm deletion errors', () => {
-  
+
   it("error returned from deleteSecret should show notification", async () => {
-    jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
 
@@ -92,7 +97,10 @@ describe('confirm deletion errors', () => {
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
+        pipelines={pipelines}
         setShowNotificationOnTable={() => {}}
+        fetchPipelines={() => {}}
+        isFetchingPipelines={false}
       />
     );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalSecretName.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalSecretName.test.js
@@ -23,20 +23,26 @@ global.scrollTo = jest.fn();
 
 const namespaces = ["default", "istio-system", "namespace3"];
 
-const pipelinesResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline",
-      }
+const pipelines = [
+  {
+    metadata: {
+      name: "pipeline0",
+      namespace: "default",
     },
-    {
-      "metadata": {
-        "name": "simple-helm-pipeline-insecure",
-      }
+  },
+  {
+    metadata: {
+      name: "simple-pipeline",
+      namespace: "default",
     },
-  ]
-}
+  },
+  {
+    metadata: {
+      name: "simple-helm-pipeline-insecure",
+      namespace: "istio-system",
+    }
+  }
+];
 
 const secretsResponseMock = [
   {
@@ -76,14 +82,16 @@ afterEach(() => {
 describe('delete modal secret name', () => {
 
   it('modal should be shown to confirm deletion and include selected secret name', async () => {
-    jest.spyOn(API, 'getPipelines').mockImplementation(() => Promise.resolve(pipelinesResponseMock));
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
     jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     const { getByText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
+        pipelines={pipelines}
         setShowNotificationOnTable={() => {}}
+        fetchPipelines={() => {}}
+        isFetchingPipelines={false}
       />
     );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));


### PR DESCRIPTION
issue: #137 

# Changes
removed & replaced the api calls for getting namespaces, service accounts and pipelines with the redux selectors & actions that were passed as props to the extension component. Also updated all necessary tests. 

Its worth mentioning that the api call to get webhook secrets was left because at the moment the getSecrets action did not return the secrets created for webhooks. 