### PR TITLE
input validation when creating a webhook

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.b29ef14b.js"
+    tekton-dashboard-bundle-location: "web/extension.f1b5c2fc.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
@@ -112,7 +112,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.b29ef14b.js"
+    tekton-dashboard-bundle-location: "web/extension.f1b5c2fc.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/src/components/WebhookCreate/tests/WebhookCreate.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/WebhookCreate.test.js
@@ -87,6 +87,45 @@ afterEach(() => {
  });
 
 //-----------------------------------//
+describe('input validation', () => {
+  it('wrong character typed', async () => {
+    jest.spyOn(API, "getSecrets").mockImplementation(() => Promise.resolve(secretsResponseMock));
+    jest.spyOn(API, "getServiceAccounts").mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
+    const { getByTestId } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        pipelines={pipelines}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
+    await waitForElement(() => getByTestId("display-name-entry"));
+    fireEvent.change(getByTestId("display-name-entry"), {
+      target: { value: "secret[]-" }
+    });
+    expect(getByTestId("display-name-entry").getAttribute('data-invalid')).toBeTruthy();
+  });
+
+  it('left input blank', async () => {
+    jest.spyOn(API, "getSecrets").mockImplementation(() => Promise.resolve(secretsResponseMock));
+    jest.spyOn(API, "getServiceAccounts").mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
+    const { getByTestId } = renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        pipelines={pipelines}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
+    await waitForElement(() => getByTestId("display-name-entry"));
+    fireEvent.change(getByTestId("docker-reg-entry"), {
+      target: { value: "  " }
+    });
+    expect(getByTestId("docker-reg-entry").getAttribute('data-invalid')).toBeTruthy();
+  });
+})
+
+//-----------------------------------//
 describe('drop downs should be disabled while no namespace selected', () => {
   it('pipelines dropdown should be disabled', async () => {
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));


### PR DESCRIPTION
issue: #64 

# Changes

Added input validation for text inputs in the web hook create page. For some fields they are validated to be k8s resources while others check if they are not blank. Finally, added two test cases verifying the expected behavior.

