### PR TITLE
replace service accounts api call with dashboard's redux selectors & actions

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.f1b5c2fc.js"
+    tekton-dashboard-bundle-location: "web/extension.e947f8fe.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
@@ -112,7 +112,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.f1b5c2fc.js"
+    tekton-dashboard-bundle-location: "web/extension.e947f8fe.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/src/WebhookApp.js
+++ b/webhooks-extension/src/WebhookApp.js
@@ -28,13 +28,17 @@ class WebhooksApp extends Component {
   render() {
     const {
       fetchPipelines,
-      getPipelinesErrorMessage,
+      fetchServiceAccounts,
+      pipelinesErrorMessage,
+      serviceAccountsErrorMessage,
       isFetchingNamespaces,
       isFetchingPipelines,
+      isFetchingServiceAccounts,
       match,
       namespace,
       namespaces,
-      pipelines
+      pipelines,
+      serviceAccounts
     } = this.props;
 
     return (
@@ -60,10 +64,14 @@ class WebhooksApp extends Component {
               {...props}
               namespaces={namespaces}
               pipelines={pipelines}
+              serviceAccounts={serviceAccounts}
               isFetchingNamespaces={isFetchingNamespaces}
               isFetchingPipelines={isFetchingPipelines}
-              getPipelinesErrorMessage={getPipelinesErrorMessage}
+              isFetchingServiceAccounts={isFetchingServiceAccounts}
+              pipelinesErrorMessage={pipelinesErrorMessage}
               fetchPipelines={fetchPipelines}
+              serviceAccountsErrorMessage={serviceAccountsErrorMessage}
+              fetchServiceAccounts={fetchServiceAccounts}
               setShowNotificationOnTable={this.setShowNotificationOnTable}
               setshowLastWebhookDeletedNotification={
                 this.setshowLastWebhookDeletedNotification
@@ -86,13 +94,18 @@ function mapStateToProps(state, props) {
     pipelines: props.selectors.getPipelines(state),
     isFetchingNamespaces: props.selectors.isFetchingNamespaces(state),
     isFetchingPipelines: props.selectors.isFetchingPipelines(state),
-    getPipelinesErrorMessage: props.selectors.getPipelinesErrorMessage(state),
+    pipelinesErrorMessage: props.selectors.getPipelinesErrorMessage(state),
+    serviceAccountsErrorMessage: props.selectors.getServiceAccountsErrorMessage(state),
+    isFetchingServiceAccounts: props.selectors.isFetchingServiceAccounts(state),
+    serviceAccounts: props.selectors.getServiceAccounts(state)
   };
 }
 
 const mapDispatchToProps = (dispatch, props) => ({
   fetchPipelines: namespace =>
-    dispatch(props.actions.fetchPipelines({ namespace }))
+    dispatch(props.actions.fetchPipelines({ namespace })),
+  fetchServiceAccounts: namespace =>
+    dispatch(props.actions.fetchServiceAccounts({ namespace }))
 });
 
 export default connect(

--- a/webhooks-extension/src/WebhookApp.test.js
+++ b/webhooks-extension/src/WebhookApp.test.js
@@ -104,21 +104,6 @@ const secretsResponseMock = [
   }
 ]
 
-const serviceAccountsResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      },
-    },
-    {
-      "metadata": {
-        "name": "testserviceaccount",
-      },
-    }
-  ]
-}
-
 const webhooks = [
   {
     id: '0|namespace',
@@ -149,6 +134,22 @@ const selectors = {
   isFetchingNamespaces: jest.fn(() => false),
   isFetchingPipelines: jest.fn(() => false),
   getPipelinesErrorMessage: jest.fn(() => null),
+  getServiceAccountsErrorMessage: jest.fn(() => null),
+  isFetchingServiceAccounts: jest.fn(() => false),
+  getServiceAccounts: jest.fn(() => [
+    {
+      metadata: {
+        name: "default",
+        namespace: "default"
+      }
+    },
+    {
+      metadata: {
+        name: "second-sa",
+        namespace: "default",
+      },
+    }
+  ])
 };
 
 it('change in components after last webhook deleted', async () => {
@@ -182,7 +183,6 @@ it('change in components after last webhook deleted', async () => {
 
   getWebhooksMock.mockImplementation(() => Promise.resolve([]));
   jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-  jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
 
   await waitForElement(() => getByText('Last webhook deleted successfully.'));
   expect(queryByTestId('table-container')).toBeNull();

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalCancel.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalCancel.test.js
@@ -52,26 +52,26 @@ const secretsResponseMock = [
   }
 ]
 
-const serviceAccountsResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      },
-    },
-    {
-      "metadata": {
-        "name": "testserviceaccount",
-      },
+const serviceAccounts = [
+  {
+    metadata: {
+      name: "default",
+      namespace: "default"
     }
-  ]
-}
+  },
+  {
+    metadata: {
+      name: "testserviceaccount",
+      namespace: "istio-system",
+    },
+  }
+];
 
 beforeEach(() => {
   jest.restoreAllMocks
   jest.resetModules()
  });
- 
+
 afterEach(() => {
   jest.clearAllMocks()
   cleanup()
@@ -83,13 +83,14 @@ describe('create secret', () => {
 
   it('modal should be shown when create secret button clicked, subsequent create button should be disabled', async () => {
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     const { getByText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
         pipelines={pipelines}
         fetchPipelines={() => {}}
+        serviceAccounts={serviceAccounts}
+        fetchServiceAccounts={() => {}}
         setShowNotificationOnTable={() => {}}
       />
     );
@@ -105,13 +106,14 @@ describe('create secret', () => {
 
   it('cancel button should hide modal', async () => {
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     const { getByText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
         pipelines={pipelines}
         fetchPipelines={() => {}}
+        serviceAccounts={serviceAccounts}
+        fetchServiceAccounts={() => {}}
         setShowNotificationOnTable={() => {}}
       />
     );

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirm.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirm.test.js
@@ -53,26 +53,26 @@ const secretsResponseMock = [
   }
 ]
 
-const serviceAccountsResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      },
-    },
-    {
-      "metadata": {
-        "name": "testserviceaccount",
-      },
+const serviceAccounts = [
+  {
+    metadata: {
+      name: "default",
+      namespace: "default"
     }
-  ]
-}
+  },
+  {
+    metadata: {
+      name: "testserviceaccount",
+      namespace: "istio-system",
+    },
+  }
+];
 
 beforeEach(() => {
   jest.restoreAllMocks
   jest.resetModules()
  });
- 
+
 afterEach(() => {
   jest.clearAllMocks()
   cleanup()
@@ -84,7 +84,6 @@ describe('create secret', () => {
 
   it('create should hide modal and return to form with new secret selected', async () => {
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     jest.spyOn(API, 'createSecret').mockImplementation((request) => {
       const expectRequest = { name: 'new-secret-foo', accesstoken: '1234567890bar' };
       expect(request).toStrictEqual(expectRequest);
@@ -96,9 +95,10 @@ describe('create secret', () => {
         match={{}}
         namespaces={namespaces}
         pipelines={pipelines}
-        setShowNotificationOnTable={() => {}}
         fetchPipelines={() => {}}
-        isFetchingPipelines={false}
+        serviceAccounts={serviceAccounts}
+        fetchServiceAccounts={() => {}}
+        setShowNotificationOnTable={() => {}}
       />
     );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirmError.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirmError.test.js
@@ -53,26 +53,26 @@ const secretsResponseMock = [
   }
 ]
 
-const serviceAccountsResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      },
-    },
-    {
-      "metadata": {
-        "name": "testserviceaccount",
-      },
+const serviceAccounts = [
+  {
+    metadata: {
+      name: "default",
+      namespace: "default"
     }
-  ]
-}
+  },
+  {
+    metadata: {
+      name: "testserviceaccount",
+      namespace: "istio-system",
+    },
+  }
+];
 
 beforeEach(() => {
   jest.restoreAllMocks
   jest.resetModules()
  });
- 
+
 afterEach(() => {
   jest.clearAllMocks()
   cleanup()
@@ -84,7 +84,6 @@ describe('create secret', () => {
 
   it('notification shown when error occurs creating secret', async () => {
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     jest.spyOn(API, 'createSecret').mockImplementation((request) => {
       const expectRequest = { name: 'new-secret-foo', accesstoken: '1234567890bar' };
       expect(request).toStrictEqual(expectRequest);
@@ -101,9 +100,10 @@ describe('create secret', () => {
         match={{}}
         namespaces={namespaces}
         pipelines={pipelines}
-        setShowNotificationOnTable={() => {}}
         fetchPipelines={() => {}}
-        isFetchingPipelines={false}
+        serviceAccounts={serviceAccounts}
+        fetchServiceAccounts={() => {}}
+        setShowNotificationOnTable={() => {}}
       />
     );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalVisibilityAndToggle.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalVisibilityAndToggle.test.js
@@ -52,26 +52,26 @@ const secretsResponseMock = [
   }
 ]
 
-const serviceAccountsResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-        },
-      },
-      {
-        "metadata": {
-          "name": "testserviceaccount",
-        },
+const serviceAccounts = [
+  {
+    metadata: {
+      name: "default",
+      namespace: "default"
     }
-  ]
-}
+  },
+  {
+    metadata: {
+      name: "testserviceaccount",
+      namespace: "istio-system",
+    },
+  }
+];
 
 beforeEach(() => {
   jest.restoreAllMocks
   jest.resetModules()
  });
- 
+
 afterEach(() => {
   jest.clearAllMocks()
   cleanup()
@@ -83,13 +83,14 @@ describe('create secret', () => {
 
   it('create button enabled only when name and token complete', async () => {
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     const { getByText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
         pipelines={pipelines}
         fetchPipelines={() => {}}
+        serviceAccounts={serviceAccounts}
+        fetchServiceAccounts={() => {}}
         setShowNotificationOnTable={() => {}}
       />
     );
@@ -116,13 +117,14 @@ describe('create secret', () => {
 
   it('should be able toggle visibility of token', async () => {
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     const { getByText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
         pipelines={pipelines}
         fetchPipelines={() => {}}
+        serviceAccounts={serviceAccounts}
+        fetchServiceAccounts={() => {}}
         setShowNotificationOnTable={() => {}}
       />
     );

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalCancel.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalCancel.test.js
@@ -53,26 +53,26 @@ const secretsResponseMock = [
   }
 ]
 
-const serviceAccountsResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      },
-    },
-    {
-      "metadata": {
-        "name": "testserviceaccount",
-      },
+const serviceAccounts = [
+  {
+    metadata: {
+      name: "default",
+      namespace: "default"
     }
-  ]
-}
+  },
+  {
+    metadata: {
+      name: "testserviceaccount",
+      namespace: "istio-system",
+    },
+  }
+];
 
 beforeEach(() => {
   jest.restoreAllMocks
   jest.resetModules()
  });
- 
+
 afterEach(() => {
   jest.clearAllMocks()
   cleanup()
@@ -83,13 +83,14 @@ describe('delete secret', () => {
 
   it('should display error notification if no secret selected and delete pressed', async () => {
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     const { getByText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
         pipelines={pipelines}
         fetchPipelines={() => {}}
+        serviceAccounts={serviceAccounts}
+        fetchServiceAccounts={() => {}}
         setShowNotificationOnTable={() => {}}
       />
     );
@@ -105,13 +106,14 @@ describe('delete secret', () => {
   it('cancel button should hide modal', async () => {
 
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     const { getByText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
         pipelines={pipelines}
         fetchPipelines={() => {}}
+        serviceAccounts={serviceAccounts}
+        fetchServiceAccounts={() => {}}
         setShowNotificationOnTable={() => {}}
       />
     );

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirm.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirm.test.js
@@ -61,26 +61,26 @@ const secretsDeletedMock = [
 
 const deleteSecretSuccessMock = {}
 
-const serviceAccountsResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      },
-    },
-    {
-      "metadata": {
-        "name": "testserviceaccount",
-      },
+const serviceAccounts = [
+  {
+    metadata: {
+      name: "default",
+      namespace: "default"
     }
-  ]
-}
+  },
+  {
+    metadata: {
+      name: "testserviceaccount",
+      namespace: "istio-system",
+    },
+  }
+];
 
 beforeEach(() => {
   jest.restoreAllMocks
   jest.resetModules()
  });
- 
+
 afterEach(() => {
   jest.clearAllMocks()
   cleanup()
@@ -90,16 +90,16 @@ afterEach(() => {
 describe('confirm deletion success', () => {
   it('delete button should hide modal, remove secret from listing and reset dropdown', async () => {
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     jest.spyOn(API, 'deleteSecret').mockImplementation(() => Promise.resolve(deleteSecretSuccessMock));
     const { getByText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
         pipelines={pipelines}
-        setShowNotificationOnTable={() => {}}
         fetchPipelines={() => {}}
-        isFetchingPipelines={false}
+        serviceAccounts={serviceAccounts}
+        fetchServiceAccounts={() => {}}
+        setShowNotificationOnTable={() => {}}
       />
     );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirmError.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirmError.test.js
@@ -61,26 +61,26 @@ const deleteSecretFailMock = {
   }
 };
 
-const serviceAccountsResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      },
-    },
-    {
-      "metadata": {
-        "name": "testserviceaccount",
-      },
+const serviceAccounts = [
+  {
+    metadata: {
+      name: "default",
+      namespace: "default"
     }
-  ]
-}
+  },
+  {
+    metadata: {
+      name: "testserviceaccount",
+      namespace: "istio-system",
+    },
+  }
+];
 
 beforeEach(() => {
   jest.restoreAllMocks
   jest.resetModules()
  });
- 
+
 afterEach(() => {
   jest.clearAllMocks()
   cleanup()
@@ -91,16 +91,16 @@ describe('confirm deletion errors', () => {
 
   it("error returned from deleteSecret should show notification", async () => {
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
 
     const { getByText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
         pipelines={pipelines}
-        setShowNotificationOnTable={() => {}}
         fetchPipelines={() => {}}
-        isFetchingPipelines={false}
+        serviceAccounts={serviceAccounts}
+        fetchServiceAccounts={() => {}}
+        setShowNotificationOnTable={() => {}}
       />
     );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalSecretName.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalSecretName.test.js
@@ -53,20 +53,20 @@ const secretsResponseMock = [
   }
 ]
 
-const serviceAccountsResponseMock = {
-  "items": [
-    {
-      "metadata": {
-        "name": "default",
-      },
-    },
-    {
-      "metadata": {
-        "name": "testserviceaccount",
-      },
+const serviceAccounts = [
+  {
+    metadata: {
+      name: "default",
+      namespace: "default"
     }
-  ]
-}
+  },
+  {
+    metadata: {
+      name: "testserviceaccount",
+      namespace: "istio-system",
+    },
+  }
+];
 
 beforeEach(() => {
   jest.restoreAllMocks
@@ -83,15 +83,15 @@ describe('delete modal secret name', () => {
 
   it('modal should be shown to confirm deletion and include selected secret name', async () => {
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => Promise.resolve(serviceAccountsResponseMock));
     const { getByText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
         pipelines={pipelines}
-        setShowNotificationOnTable={() => {}}
         fetchPipelines={() => {}}
-        isFetchingPipelines={false}
+        serviceAccounts={serviceAccounts}
+        fetchServiceAccounts={() => {}}
+        setShowNotificationOnTable={() => {}}
       />
     );
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));


### PR DESCRIPTION
removed & replaced the api calls for getting namespaces, service accounts and pipelines with the redux selectors & actions that were passed as props to the extension component. Also updated all necessary tests.

Its worth mentioning that the api call to get webhook secrets was left because at the moment the getSecrets action did not return the secrets created for webhooks.