### PR TITLE
align show password icon with invalid icon in access token text input

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.3cd6665f.js"
+    tekton-dashboard-bundle-location: "web/extension.bf3a7c70.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
@@ -112,7 +112,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.3cd6665f.js"
+    tekton-dashboard-bundle-location: "web/extension.bf3a7c70.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
+++ b/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
@@ -6,8 +6,6 @@ import { getSecrets, createWebhook, createSecret, deleteSecret } from '../../api
 
 import AddAlt20 from '@carbon/icons-react/lib/add--alt/20';
 import SubtractAlt20 from '@carbon/icons-react/lib/subtract--alt/20';
-import ViewFilled from '@carbon/icons-react/lib/view--filled/20';
-import ViewOffFilled from '@carbon/icons-react/lib/view--off--filled/20';
 import Infomation from "@carbon/icons-react/lib/information/16";
 
 import './WebhookCreate.scss';
@@ -90,10 +88,6 @@ class WebhookCreatePage extends Component {
       // create secret vars
       newSecretName: '',
       newTokenValue: '',
-      // toggle access token 'password' or 'text'
-      pwType: 'password',
-      visibleCSS: 'token-visible',
-      invisibleCSS: 'token-invisible',
       //array storing invalid inputs
       invalidFields: []
     };
@@ -470,14 +464,6 @@ class WebhookCreatePage extends Component {
     }
   }
 
-  togglePasswordVisibility = () => {
-    this.setState({
-      pwType: this.state.pwType === 'password' ? 'text' : 'password',
-      visibleCSS: this.state.visibleCSS === 'token-visible' ? 'token-invisible' : 'token-visible',
-      invisibleCSS: this.state.invisibleCSS === 'token-invisible' ? 'token-visible' : 'token-invisible',
-    });
-  };
-
   handleNotificationClose = () => {
     this.setState({
       showNotification: false
@@ -752,11 +738,10 @@ class WebhookCreatePage extends Component {
                 </div>
                 <div className="modal-row-entry-field">
                   <div className="token">
-                    <TextInput
+                    <TextInput.PasswordInput
                       id="tokenValue"
                       placeholder="Enter access token here"
                       name="newTokenValue"
-                      type={this.state.pwType}
                       value={this.state.newTokenValue}
                       onChange={this.handleModalText}
                       hideLabel
@@ -764,8 +749,6 @@ class WebhookCreatePage extends Component {
                       invalid={invalidFields.indexOf('newTokenValue') > -1}
                       invalidText="Required."
                     />
-                    <ViewFilled id="token-visible-svg" className={this.state.visibleCSS} onClick={this.togglePasswordVisibility} />
-                    <ViewOffFilled id="token-invisible-svg" className={this.state.invisibleCSS} onClick={this.togglePasswordVisibility} />
                   </div>
                 </div>
               </div>

--- a/webhooks-extension/src/components/WebhookCreate/WebhookCreate.scss
+++ b/webhooks-extension/src/components/WebhookCreate/WebhookCreate.scss
@@ -140,6 +140,8 @@
     width: 100%;
     padding-left: 1rem;
     padding-right: 1rem;
+    padding-bottom: 1.5rem;
+    margin: 0;
   }
 
   .bx--modal-content > * {

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalVisibilityAndToggle.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalVisibilityAndToggle.test.js
@@ -117,7 +117,7 @@ describe('create secret', () => {
 
   it('should be able toggle visibility of token', async () => {
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsResponseMock));
-    const { getByText } = renderWithRouter(
+    const { getByText, getByLabelText } = renderWithRouter(
       <WebhookCreate
         match={{}}
         namespaces={namespaces}
@@ -131,19 +131,18 @@ describe('create secret', () => {
     fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
     fireEvent.click(await waitForElement(() => getByText(/istio-system/i)));
 
-    expect(document.getElementById('tokenValue').getAttribute('type')).toBe('password')
-    expect(document.getElementById('token-visible-svg').getAttribute('class')).toContain('token-visible')
-    expect(document.getElementById('token-invisible-svg').getAttribute('class')).toContain('token-invisible')
+    const tokenInput = document.getElementById('tokenValue');
 
-    fireEvent.click(document.getElementById('token-visible-svg'))
+    expect(tokenInput.getAttribute('type')).toBe('password')
 
-    expect(document.getElementById('token-visible-svg').getAttribute('class')).toContain('token-invisible')
-    expect(document.getElementById('token-invisible-svg').getAttribute('class')).toContain('token-visible')
+    fireEvent.click(getByLabelText('Show password'));
 
-    fireEvent.click(document.getElementById('token-visible-svg'))
+    expect(tokenInput.getAttribute('type')).toBe('text')
 
-    expect(document.getElementById('token-visible-svg').getAttribute('class')).toContain('token-visible')
-    expect(document.getElementById('token-invisible-svg').getAttribute('class')).toContain('token-invisible')
+    fireEvent.click(getByLabelText('Hide password'));
+
+    expect(tokenInput.getAttribute('type')).toBe('password')
+
 
   });
 


### PR DESCRIPTION
issue: #186 

# Changes
Changed the component to use Carbon Design's password text input which ultimately ended up not using declared state variables & handlers. Added some padding to the content modal so the tooltip text (appears when password icon is hovered) can be seen. Lastly, updated test case.