### PR TITLE
fix 404 error when refreshing create webhook page

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.bf3a7c70.js"
+    tekton-dashboard-bundle-location: "web/extension.f9d4eab7.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
@@ -112,7 +112,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.bf3a7c70.js"
+    tekton-dashboard-bundle-location: "web/extension.f9d4eab7.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/src/api/index.js
+++ b/webhooks-extension/src/api/index.js
@@ -24,8 +24,8 @@ export function getSelectedRows(selectedRows) {
 
 export function getAPIRoot() {
   const { href, hash } = window.location;
-  let newHash = hash.replace('#/extensions','v1/extensions')
-  let baseURL = href.replace(hash, newHash);
+  let realHash = 'v1/extensions/webhooks-extension';
+  let baseURL = href.replace(hash, realHash);
   if (baseURL.endsWith('/')) {
     baseURL = baseURL.slice(0, -1);
   }


### PR DESCRIPTION
issue: #192 

# Changes
The approach I did was basically to search & remove the keyword `create` that was is not supposed to be present in the api uri call. 
