### PR TITLE
Use correct PipelineRun URL in status table for OpenShift

### DIFF
--- a/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/release/gcr-tekton-webhooks-extension.yaml
@@ -245,7 +245,7 @@ spec:
               pr = pr.strip()
               namespace = namespace.strip()
               pipeline = pipeline.strip()
-              link = pipelineRunURLPrefix + "/#namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
+              link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
               print("Checking pipelinerun " + pr + " in namespace " + namespace)
               output = api_instance.get_namespaced_custom_object("tekton.dev", "v1alpha1", namespace, "pipelineruns", pr)
               if output["status"]["conditions"][0]["status"] == u'True' and output["status"]["conditions"][0]["type"] == u'Succeeded':
@@ -274,7 +274,7 @@ spec:
           namespace = namespace.strip()
           pipeline = pipeline.strip()
           print("Still Running - pipelinerun " + pr + " in namespace " + namespace)
-          link = pipelineRunURLPrefix + "/#namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
+          link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
           runsIncomplete.append("[**??????**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
       results = runsPassed + runsFailed + runsIncomplete
       comment = ("## Tekton Status Report \n\n"

--- a/webhooks-extension/config/release/openshift-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/release/openshift-tekton-webhooks-extension.yaml
@@ -230,6 +230,8 @@ spec:
           value: tekton-pipelines
         - name: SERVICEACCOUNT
           value: tekton-webhooks-extension
+        - name: PLATFORM
+          value: openshift
         image: "gcr.io/tekton-nightly/sink:latest"
         imagePullPolicy: Always
         livenessProbe:
@@ -341,7 +343,7 @@ spec:
               pr = pr.strip()
               namespace = namespace.strip()
               pipeline = pipeline.strip()
-              link = pipelineRunURLPrefix + "/#namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
+              link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
               print("Checking pipelinerun " + pr + " in namespace " + namespace)
               output = api_instance.get_namespaced_custom_object("tekton.dev", "v1alpha1", namespace, "pipelineruns", pr)
               if output["status"]["conditions"][0]["status"] == u'True' and output["status"]["conditions"][0]["type"] == u'Succeeded':
@@ -370,7 +372,7 @@ spec:
           namespace = namespace.strip()
           pipeline = pipeline.strip()
           print("Still Running - pipelinerun " + pr + " in namespace " + namespace)
-          link = pipelineRunURLPrefix + "/#namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
+          link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
           runsIncomplete.append("[**??????**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
       results = runsPassed + runsFailed + runsIncomplete
       comment = ("## Tekton Status Report \n\n"

--- a/webhooks-extension/config/task-monitor-result.yaml
+++ b/webhooks-extension/config/task-monitor-result.yaml
@@ -96,7 +96,7 @@ spec:
               pr = pr.strip()
               namespace = namespace.strip()
               pipeline = pipeline.strip()
-              link = pipelineRunURLPrefix + "/#namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
+              link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
               print("Checking pipelinerun " + pr + " in namespace " + namespace)
               output = api_instance.get_namespaced_custom_object("tekton.dev", "v1alpha1", namespace, "pipelineruns", pr)
               if output["status"]["conditions"][0]["status"] == u'True' and output["status"]["conditions"][0]["type"] == u'Succeeded':
@@ -125,7 +125,7 @@ spec:
           namespace = namespace.strip()
           pipeline = pipeline.strip()
           print("Still Running - pipelinerun " + pr + " in namespace " + namespace)
-          link = pipelineRunURLPrefix + "/#namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
+          link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
           runsIncomplete.append("[**??????**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
       results = runsPassed + runsFailed + runsIncomplete
       comment = ("## Tekton Status Report \n\n"

--- a/webhooks-extension/pkg/endpoints/sink.go
+++ b/webhooks-extension/pkg/endpoints/sink.go
@@ -261,7 +261,13 @@ func getDashboardURL(r Resource, installNs string) string {
 	}
 
 	toReturn := "http://localhost:9097/"
-	services, err := r.K8sClient.CoreV1().Services(installNs).List(metav1.ListOptions{LabelSelector: "app=tekton-dashboard"})
+
+	labelLookup := "app=tekton-dashboard"
+	if "openshift" == os.Getenv("PLATFORM") {
+		labelLookup = "app=tekton-dashboard-internal"
+	}
+
+	services, err := r.K8sClient.CoreV1().Services(installNs).List(metav1.ListOptions{LabelSelector: labelLookup})
 	if err != nil {
 		logging.Log.Errorf("could not find the dashboard's service: %s", err.Error())
 		return toReturn


### PR DESCRIPTION
# Changes

The status table added to the pull request after pipelineruns have completed, includes a link to the pipelinerun from the table.  On openshift this link does not appear to be obtaining the correct route - this change uses the internal dashboard service rather than the https dashboard service to exploit using the endpoint REST endpoint to get the correct external route to the dashboard.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
