### PR TITLE
add yaml highlighting to codeblock

### DIFF
--- a/tekton-listener/README.md
+++ b/tekton-listener/README.md
@@ -54,7 +54,7 @@ The `EventBinding` CRD provides a new high-level means of managing all of the re
 
 An example EventBinding:
 
-```
+```yaml
 apiVersion: tektonexperimental.dev/v1alpha1
 kind: EventBinding
 metadata:


### PR DESCRIPTION
# Changes

This adds a yaml block to the codeblock example so that Github will color the text

