### PR TITLE
Change data used from webhook payload in pipelineresources

### DIFF
--- a/webhooks-extension/pkg/endpoints/sink.go
+++ b/webhooks-extension/pkg/endpoints/sink.go
@@ -82,7 +82,7 @@ func (r Resource) handleWebhook(request *restful.Request, response *restful.Resp
 		buildInformation.COMMITID = webhookData.HeadCommit.ID
 		buildInformation.REPONAME = webhookData.Repository.Name
 		buildInformation.TIMESTAMP = timestamp
-		buildInformation.BRANCH = extractBranchFromRef(webhookData.Ref)
+		buildInformation.BRANCH = extractBranchFromPushEventRef(webhookData.Ref)
 
 		createPipelineRunsFromWebhookData(buildInformation, r)
 		logging.Log.Debugf("Build information for repository %s:%s: %s.", buildInformation.REPOURL, buildInformation.SHORTID, buildInformation)
@@ -101,9 +101,9 @@ func (r Resource) handleWebhook(request *restful.Request, response *restful.Resp
 		buildInformation.SHORTID = webhookData.PullRequest.Head.Sha[0:7]
 		buildInformation.COMMITID = webhookData.PullRequest.Head.Sha
 		buildInformation.REPONAME = webhookData.Repository.Name
-		buildInformation.PULLURL = strings.Replace(webhookData.PullRequest.URL, "api/v3/repos/", "", 1)
+		buildInformation.PULLURL = webhookData.PullRequest.HTMLURL
 		buildInformation.TIMESTAMP = timestamp
-		buildInformation.BRANCH = extractBranchFromRef(webhookData.PullRequest.Head.Ref)
+		buildInformation.BRANCH = webhookData.PullRequest.Head.Ref
 
 		pipelineruns := createPipelineRunsFromWebhookData(buildInformation, r)
 		logging.Log.Debugf("Build information for repository %s:%s: %s.", buildInformation.REPOURL, buildInformation.SHORTID, buildInformation)
@@ -115,7 +115,7 @@ func (r Resource) handleWebhook(request *restful.Request, response *restful.Resp
 	}
 }
 
-func extractBranchFromRef(ref string) string {
+func extractBranchFromPushEventRef(ref string) string {
 	// ref typically resembles "refs/heads/branchhere", so extract "branchhere" from this string
 	if ref != "" {
 		if strings.Count(ref, "/") == 2 {


### PR DESCRIPTION
Issue #226 
Issue #226 

Changes

The pull request pipeline resource appears to want the HTMLURL from the
GitHub webhooks payload, otherwise the string manipulation fails to find
the pull request number.  Changed the sink to use 
`webhookData.PullRequest.HTMLURL` rather than the current
`strings.Replace(webhookData.PullRequest.URL, "api/v3/repos/", "", 1)`

Additionally, the way the branch name is obtained in the sink needs to
differ between push and pull_request events as the payloads are different.
In the case of the pull_request event we no longer send the ref through
`extractBranchFromRef` and the method itself has been renamed to 
`extractBranchFromPushEventRef`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
