### PR TITLE
View Branches when Webhook Clicked

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.305e4e36.js"
+    tekton-dashboard-bundle-location: "web/extension.3d20fced.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
@@ -119,7 +119,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.305e4e36.js"
+    tekton-dashboard-bundle-location: "web/extension.3d20fced.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
@@ -212,7 +212,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    tekton-dashboard-bundle-location: web/extension.305e4e36.js
+    tekton-dashboard-bundle-location: web/extension.3d20fced.js
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: webhooks.web
   labels:

--- a/webhooks-extension/src/WebhookApp.js
+++ b/webhooks-extension/src/WebhookApp.js
@@ -30,6 +30,7 @@ class WebhooksApp extends Component {
   render() {
     const {
       fetchPipelines,
+      fetchPipelineRuns,
       fetchServiceAccounts,
       pipelinesErrorMessage,
       serviceAccountsErrorMessage,
@@ -56,6 +57,7 @@ class WebhooksApp extends Component {
               setshowLastWebhookDeletedNotification={
                 this.setshowLastWebhookDeletedNotification
               }
+              fetchPipelineRuns={fetchPipelineRuns}
             />
           )}
         />
@@ -107,7 +109,9 @@ const mapDispatchToProps = (dispatch, props) => ({
   fetchPipelines: namespace =>
     dispatch(props.actions.fetchPipelines({ namespace })),
   fetchServiceAccounts: namespace =>
-    dispatch(props.actions.fetchServiceAccounts({ namespace }))
+    dispatch(props.actions.fetchServiceAccounts({ namespace })),
+  fetchPipelineRuns: (namespace, filters) =>
+    dispatch(props.actions.fetchPipelineRuns({namespace, filters}))
 });
 
 export default connect(

--- a/webhooks-extension/src/components/WebhookBranches/WebhookBranches.js
+++ b/webhooks-extension/src/components/WebhookBranches/WebhookBranches.js
@@ -1,0 +1,236 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { Component } from 'react';
+import { Modal } from 'carbon-components-react';
+
+import './WebhookBranches.scss';
+
+import {
+  DataTable,
+  DataTableSkeleton,
+  InlineNotification
+} from 'carbon-components-react';
+
+const {
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableBody,
+  TableCell,
+  TableHeader
+} = DataTable;
+
+export class WebhookBranches extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      rows: [],
+      loading: true,
+      error: null
+    };
+  }
+
+  componentDidMount() {
+    let { url, namespace, pipeline } = this.props.webhook;
+    let [server, org, repo] = url
+      .toLowerCase()
+      .replace(/https?:\/\//, "")
+      .split("/");
+
+    this.props
+      .fetchPipelineRuns(
+        namespace,
+        [
+          `gitOrg=${org}`,
+          `gitServer=${server}`,
+          `gitRepo=${repo}`,
+          `tekton.dev/pipeline=${pipeline}`
+        ]
+      )
+      .then(pipelineRuns => {
+        let branches = [];
+        const rows = pipelineRuns
+          .sort(
+            (a, b) =>
+              new Date(
+                b.status.conditions[
+                  b.status.conditions.length - 1
+                ].lastTransitionTime
+              ) -
+              new Date(
+                a.status.conditions[
+                  a.status.conditions.length - 1
+                ].lastTransitionTime
+              )
+          )
+          .reduce((result, pipelineRun) => {
+            if (
+              branches.indexOf(pipelineRun.metadata.labels.gitBranch) === -1
+            ) {
+              branches.push(pipelineRun.metadata.labels.gitBranch);
+              const time = new Date(
+                pipelineRun.status.conditions[
+                  pipelineRun.status.conditions.length - 1
+                ].lastTransitionTime
+              );
+              result.push({
+                id: `${pipelineRun.metadata.labels.gitBranch}-branch`,
+                branch: pipelineRun.metadata.labels.gitBranch,
+                time: `${time.toLocaleDateString()} - ${time.toLocaleTimeString()}`,
+                status:
+                  pipelineRun.status.conditions[
+                    pipelineRun.status.conditions.length - 1
+                  ].reason
+              });
+            }
+            return result;
+          }, []);
+
+        this.setState({
+          rows,
+          loading: false
+        });
+      })
+      .catch(error => {
+        error.response.text().then(text => {
+          this.setState({
+            error: text,
+            rows: [],
+            loading: false
+          });
+        });
+      });
+  }
+
+  render() {
+    const { close } = this.props;
+    const { rows, loading, error } = this.state;
+
+    const headers = [
+      {
+        key: 'branch',
+        header: 'Branch'
+      },
+      {
+        key: 'time',
+        header: 'Last Build Time'
+      },
+      {
+        key: 'status',
+        header: 'Status'
+      }
+    ];
+
+    return (
+      <Modal
+        open
+        id="webhook-branches-modal"
+        modalHeading="Latest PipelineRuns By Branch:"
+        passiveModal
+        onRequestClose={close}
+      >
+        {error && (
+          <InlineNotification
+            kind="error"
+            subtitle={error}
+            title="Error:"
+            lowContrast
+          />
+        )}
+        <div className="WebhookDetails">
+          <p>
+            <span>Webhook Name: </span>
+            {this.props.webhook.name}
+          </p>
+          <p>
+            <span>Repository: </span>
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href={this.props.webhook.url}
+            >
+              {this.props.webhook.url}
+            </a>
+          </p>
+          <p>
+            <span>Pipeline: </span>
+            {this.props.webhook.pipeline}
+          </p>
+          <p>
+            <span>Namespace: </span>
+            {this.props.webhook.namespace}
+          </p>
+        </div>
+        <DataTable
+          useZebraStyles
+          rows={rows}
+          headers={headers}
+          render={({ rows, headers, getHeaderProps, getRowProps }) => (
+            <TableContainer>
+              {loading ? (
+                <DataTableSkeleton
+                  rowCount={1}
+                  columnCount={headers.length}
+                  data-testid="loading-table"
+                />
+              ) : (
+                <Table>
+                  <TableHead>
+                    <TableRow>
+                      {headers.map(header => (
+                        <TableHeader
+                          key={header.id}
+                          {...getHeaderProps({ header })}
+                          isSortable
+                          isSortHeader
+                        >
+                          {header.header}
+                        </TableHeader>
+                      ))}
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {rows.map(row => (
+                      <TableRow {...getRowProps({ row })} key={row.id}>
+                        {row.cells.map((cell, index) => (
+                          <TableCell
+                            className="cellText"
+                            key={cell.id}
+                            data-status={
+                              index === row.cells.length - 1 ? cell.value : null
+                            }
+                          >
+                            {cell.value}
+                          </TableCell>
+                        ))}
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </TableContainer>
+          )}
+        />
+        {rows.length === 0 && !loading && (
+          <div className="noBranches">
+            <p>
+              Unable to identify any PipelineRuns initiated by this webhook.
+            </p>
+          </div>
+        )}
+      </Modal>
+    );
+  }
+}

--- a/webhooks-extension/src/components/WebhookBranches/WebhookBranches.scss
+++ b/webhooks-extension/src/components/WebhookBranches/WebhookBranches.scss
@@ -1,0 +1,53 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import "~carbon-components/scss/globals/scss/vars";
+
+#webhook-branches-modal {
+
+  .WebhookDetails span{
+    font-weight: bold;
+  }
+
+  .bx--data-table tbody td.cellText {
+    padding-left: 22.5px;
+    &[data-status] {
+      background-color: $inverse-support-01;
+      color: black;
+    }
+
+    &[data-status="Succeeded"] {
+      background-color: $inverse-support-02;
+      color: black;
+    }
+
+    &[data-status="Running"],
+    &[data-status="Unknown"] {
+      background-color: $support-03;
+      color: black;
+    }
+  }
+
+  .noBranches {
+    width: 100%;
+    text-align: center;
+    margin-top: 5px;
+    font-style: italic;
+    font-size: 1rem;
+  }
+
+  .bx--data-table tr th,
+  .bx--data-table tr th button {
+    background: #7190c1;
+  }
+}

--- a/webhooks-extension/src/components/WebhookBranches/index.js
+++ b/webhooks-extension/src/components/WebhookBranches/index.js
@@ -1,0 +1,14 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export { WebhookBranches } from './WebhookBranches';

--- a/webhooks-extension/src/components/WebhookBranches/tests/WebhookBranches.test.js
+++ b/webhooks-extension/src/components/WebhookBranches/tests/WebhookBranches.test.js
@@ -1,0 +1,90 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { waitForElement } from 'react-testing-library';
+import { WebhookBranches } from '../WebhookBranches';
+import { renderWithRouter } from '../../../test/utils/test';
+import 'react-testing-library/cleanup-after-each';
+
+beforeEach(jest.restoreAllMocks);
+
+const webhook = {
+  url: "https://githuub.com/someUser/someRepo",
+  namespace: "default",
+  pipeline: "pipeline1"
+};
+
+const pipelineRuns = [
+  {
+    metadata: {
+      labels: {
+        gitBranch: "master"
+      }
+    },
+    status: {
+      conditions: [
+        {
+          lastTransitionTime: "2019-09-23T18:27:57Z",
+          reason: "Failed"
+        }
+      ]
+    }
+  },
+  {
+    metadata: {
+      labels: {
+        gitBranch: "branch1"
+      }
+    },
+    status: {
+      conditions: [
+        {
+          lastTransitionTime: "2019-09-23T18:27:57Z",
+          reason: "Success"
+        }
+      ]
+    }
+  }
+];
+
+const fetchBranchFailMock = {
+  response: {
+    text: () => {
+      return Promise.resolve("Mock Error Fetching Branch");
+    }
+  }
+};
+
+it("display branches", async () => {
+  const { getByText } = renderWithRouter(
+    <WebhookBranches
+      fetchPipelineRuns={jest.fn(() => Promise.resolve(pipelineRuns))}
+      close={() => {}}
+      webhook={webhook}
+    />
+  );
+  await waitForElement(() => getByText(/master/i));
+  await waitForElement(() => getByText(/branch1/i));
+});
+
+it("display notification when error occurs", async () => {
+  const { getByText } = renderWithRouter(
+    <WebhookBranches
+      fetchPipelineRuns={jest.fn(() => Promise.reject(fetchBranchFailMock))}
+      close={() => {}}
+      webhook={webhook}
+    />
+  );
+  await waitForElement(() => getByText(/Mock Error Fetching Branch/i));
+});

--- a/webhooks-extension/src/components/WebhookDisplayTable/WebhookDisplayTable.js
+++ b/webhooks-extension/src/components/WebhookDisplayTable/WebhookDisplayTable.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import React, { Component } from 'react';
 import './WebhookDisplayTable.scss';
 import Delete from '@carbon/icons-react/lib/delete/16';
@@ -5,7 +18,8 @@ import AddAlt16 from '@carbon/icons-react/lib/add--alt/16';
 import { Modal, Checkbox } from 'carbon-components-react';
 import { getWebhooks, deleteWebhooks, getSelectedRows } from '../../api';
 
-import { Link, Redirect } from 'react-router-dom'; 
+import { Link, Redirect } from 'react-router-dom';
+import { WebhookBranches } from '../WebhookBranches';
 
 import {
   Button,
@@ -48,6 +62,7 @@ export class WebhookDisplayTable extends Component {
     notificationMessage: "",
     notificationStatus: 'success',
     notificationStatusMsgShort: 'Webhook created successfully.',
+    selectedWebhook: null
   };
 
   formatCellContent(id, value) {
@@ -175,7 +190,19 @@ export class WebhookDisplayTable extends Component {
   togglePipelineRunClicked = () => {
 		this.setState({
       checked: !this.state.checked
-		});	
+		});
+  }
+
+  viewBranches = value => {
+    this.setState({
+      selectedWebhook: value
+    })
+  }
+
+  closeBranches = () => {
+    this.setState({
+      selectedWebhook: null
+    })
   }
 
   render() {
@@ -186,7 +213,7 @@ export class WebhookDisplayTable extends Component {
           <Redirect to={this.props.match.url + "/create"} />
         )
       } else {
-        const { selectedNamespace } = this.props;
+        const { selectedNamespace, fetchPipelineRuns } = this.props;
         // There are webhooks so display table
         const headers = [
           {
@@ -297,8 +324,29 @@ export class WebhookDisplayTable extends Component {
                             {rows.map(row => (
                               <TableRow {...getRowProps({ row })} key={row.id}>
                                 <TableSelectRow {...getSelectionProps({ row })} />
-                                {row.cells.map(cell => (
-                                  <TableCell key={cell.id}>{this.formatCellContent(cell.id, cell.value)}</TableCell>
+                                {row.cells.map((cell, index) => (
+                                  <TableCell
+                                    onClick={
+                                      index === 0
+                                        ? () => {
+                                            this.viewBranches({
+                                              name: row.cells[0].value,
+                                              url: row.cells[1].value,
+                                              namespace: selectedNamespace === ALL_NAMESPACES ? row.cells[3].value : selectedNamespace,
+                                              pipeline: row.cells[2].value
+                                            });
+                                          }
+                                        : null
+                                    }
+                                    className={
+                                      index === 0
+                                        ? "clickableNameURL"
+                                        : null
+                                    }
+                                    key={cell.id}
+                                  >
+                                    {this.formatCellContent(cell.id, cell.value)}
+                                  </TableCell>
                                 ))}
                               </TableRow>
                             ))}
@@ -348,6 +396,7 @@ export class WebhookDisplayTable extends Component {
                 </fieldset>
               </Modal>
             </div>
+            {this.state.selectedWebhook && <WebhookBranches fetchPipelineRuns={fetchPipelineRuns} webhook={this.state.selectedWebhook} close={this.closeBranches}/>}
           </div>
         );
       }

--- a/webhooks-extension/src/components/WebhookDisplayTable/WebhookDisplayTable.scss
+++ b/webhooks-extension/src/components/WebhookDisplayTable/WebhookDisplayTable.scss
@@ -115,6 +115,11 @@
     max-width: 100%;
   }
 
+  .clickableNameURL {
+     cursor: pointer;
+     color: #0062ff;
+     text-decoration: underline;
+  }
 }
 
 .modal-delete {

--- a/webhooks-extension/src/components/WebhookDisplayTable/tests/WebhookTable.test.js
+++ b/webhooks-extension/src/components/WebhookDisplayTable/tests/WebhookTable.test.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { waitForElement, } from 'react-testing-library';
+import { waitForElement, fireEvent } from 'react-testing-library';
 import { WebhookDisplayTable } from '../WebhookDisplayTable'
 import * as API from '../../../../src/api/index';
 import { renderWithRouter } from '../../../test/utils/test'
@@ -84,5 +84,16 @@ describe('with webhooks', () => {
     jest.spyOn(API, 'getWebhooks').mockImplementation(() => Promise.resolve(webhooks));
     const { getByText } = renderWithRouter(<WebhookDisplayTable match={{}} selectedNamespace="default"/>);
     await waitForElement(() => getByText("No webhooks created under namespace 'default', click 'Add Webhook' button to add a new one."));
+  });
+
+  it('display branch modal when table row clicked', async () => {
+    jest.spyOn(API, 'getWebhooks').mockImplementation(() => Promise.resolve(webhooks));
+    const { getByText } = renderWithRouter(<WebhookDisplayTable fetchPipelineRuns={jest.fn(() => Promise.resolve([]))} match={{}} selectedNamespace="*"/>);
+
+    await waitForElement(() => getByText(/first-test-webhook/i));
+
+    fireEvent.click(getByText(/first-test-webhook/i));
+    expect(getByText("Latest PipelineRuns By Branch:")).not.toBeNull();
+
   });
 });


### PR DESCRIPTION
as per epic #37, issues #48 & #50  are implemented in this PR

# Changes
In the `WebhookDisplayTable` container I added a "passive" modal component that will display the branches within a simple sortable table. It uses the GitHub API to fetch the branches & saves the data in the component's state rather than the redux store. Lastly, I added the necessary test cases as well.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)