### PR TITLE
Add Tekton Task and TaskRun to create and delete GitHub webhooks

### DIFF
--- a/webhooks-extension/config/triggers_prototype/README.md
+++ b/webhooks-extension/config/triggers_prototype/README.md
@@ -33,3 +33,42 @@ To test the Ingress set up, use the following `curl` command:
 and you should see a response back from the running EventListener pod.
 
 In this case, `-k` is to allow a self-signed certificate to be used, `-L` is to follow redirects and `-d` specifies the data to be sent.
+
+# GitHub Webhooks
+
+You can create or delete GitHub webhooks using the provided Task and TaskRun.
+
+- Apply the Task definition:
+`kubectl apply -f config/triggers_prototype/github/webhook.yaml`
+
+- Create a GitHub secret, for example with the Tekton Webhooks Extension or through `kubectl`. You will refer to the secret's name in the next step.
+
+If you opt to use `kubectl`, create the following file (for example named `secret.yaml`):
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: basic-user-pass
+  annotations:
+    tekton.dev/git-0: https://github.com
+type: kubernetes.io/basic-auth
+stringData:
+  accessToken: <your access token used to access the Git provider>
+  secretToken: <anything here - it's used to validate the webhook>
+```
+
+then do `kubectl create -f secret.yaml`.
+
+Modify the TaskRun definition, replacing the parameters accordingly.
+
+To create a webhook, set `Mode` to `create`. To delete a webhook, set this to `delete`.
+
+- Apply the TaskRun definition, thus running the Task:
+`kubectl create -f config/triggers_prototype/github/webhook-run.yaml`
+
+For deleting, you'll need to specify the WebhookName parameter and can omit the ExternalUrl.
+
+To use an access token, you can specify GithubUserNameKey as "".
+
+Note that in order to not receive 503 service unavailable errors from the webhook when trying to reach your Ingress, you should ensure your Ingress is correctly configured (for example, check that the service name and port matches that of the EventListener you are using it with).

--- a/webhooks-extension/config/triggers_prototype/test/webhook-run.yaml
+++ b/webhooks-extension/config/triggers_prototype/test/webhook-run.yaml
@@ -1,0 +1,24 @@
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  generateName: webhook-run-
+spec:
+  taskRef:
+    name: webhook-task
+  inputs:
+    params:
+    - name: Mode
+      value: create
+    - name: ExternalUrl
+      value: replaceme
+    - name: GitHubOwner
+      value: replaceme
+    - name: GitHubUserNameKey
+      value: ""
+    - name: GitHubRepo     
+      value: replaceme
+    - name: GitHubSecretName
+      value: replaceme
+    - name: GitHubUrl
+      value: replaceme
+  timeout: 30s

--- a/webhooks-extension/config/triggers_prototype/webhook.yaml
+++ b/webhooks-extension/config/triggers_prototype/webhook.yaml
@@ -1,0 +1,93 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: webhook-task
+  namespace: tekton-pipelines
+spec:
+  inputs:
+    params:
+    - name: Mode
+      description: Whether or not to create or delete the webhook
+      default: "create"
+    - name: ExternalUrl
+      description: Use the Ingress external URL that's infront of the EventListener
+      default: "replacemeip.nip.io"
+    - name: GitHubOwner
+      description: The GitHub owner name (used for creating and deleting the webhook)
+      default: "owner"
+    - name: GitHubRepo
+      description: The GitHub repository name (used for creating and deleting the webhook)
+      default: "repository"
+    - name: GitHubSecretName
+      description: The secret name for GitHub (used for creating and deleting the webhook)
+      default: "githubsecret"
+    - name: GitHubAccessTokenKey
+      description: The key name in the secret for the access token (used for creating and deleting the webhook)
+      default: "accessToken"
+    - name: GitHubUserNameKey
+      description: The key name in the secret for the user name (used for creating and deleting the webhook)
+      type: string
+    - name: GitHubSecretStringKey
+      description: The key name for the GitHub secret string (used for creating and deleting the webhook)
+      default: "secretToken"
+    - name: GitHubUrl
+      description: The URL of the GitHub server (used for creating and deleting the webhook)
+      default: "github.com"
+    - name: WebhookName
+      description: The webhook name to delete (as available at (your repository/hooks/<number here>)
+      default: "1234567"
+  steps:  
+  - name: create-or-delete-webhook
+    image: curlimages/curl:latest
+    command:
+    - sh
+    args:
+    - -ce
+    - |
+      set -e
+      if [ $(inputs.params.Mode) = "create" ] ; then
+        if [ $(inputs.params.GitHubUrl) = "github.com" ] ; then
+          echo "Assuming GitHub.com and not GitHub Enterprise"
+          if [ -z $(inputs.params.GitHubUserNameKey) ] ; then
+            echo "No GitHub username key found so assuming this is an access token"
+            curl -d "{\"name\": \"web\",\"active\": true,\"events\": [\"push\",\"pull_request\"],\"config\": {\"url\": \"https://$(inputs.params.ExternalUrl)/\",\"content_type\": \"json\",\"insecure_ssl\": \"1\" ,\"secret\": \"$(cat /var/secret/$(inputs.params.GitHubSecretStringKey))\"}}" -X POST -u token:$(cat /var/secret/$(inputs.params.GitHubAccessTokenKey)) -L https://api.github.com/repos/$(inputs.params.GitHubOwner)/$(inputs.params.GitHubRepo)/hooks
+          else          
+            echo "GitHub username key found so assuming this is a username and password"
+            curl -d "{\"name\": \"web\",\"active\": true,\"events\": [\"push\",\"pull_request\"],\"config\": {\"url\": \"https://$(inputs.params.ExternalUrl)/\",\"content_type\": \"json\",\"insecure_ssl\": \"1\" ,\"secret\": \"$(cat /var/secret/$(inputs.params.GitHubSecretStringKey))\"}}" -X POST -u $(cat /var/secret/$(inputs.params.GitHubUserNameKey)):$(cat /var/secret/$(inputs.params.GitHubAccessTokenKey)) -L https://api.github.com/repos/$(inputs.params.GitHubOwner)/$(inputs.params.GitHubRepo)/hooks
+          fi
+        else
+          echo "Assuming GitHub Enterprise"
+          if [ -z $(inputs.params.GitHubUserNameKey) ] ; then
+            echo "No GitHub Enterprise username key found so assuming this is an access token"
+            curl -d "{\"name\": \"web\",\"active\": true,\"events\": [\"push\",\"pull_request\"],\"config\": {\"url\": \"https://$(inputs.params.ExternalUrl)/\",\"content_type\": \"json\",\"insecure_ssl\": \"1\" ,\"secret\": \"$(cat /var/secret/$(inputs.params.GitHubSecretStringKey))\"}}" -X POST -u token:$(cat /var/secret/$(inputs.params.GitHubAccessTokenKey)) -L https://$(inputs.params.GitHubUrl)/api/v3/repos/$(inputs.params.GitHubOwner)/$(inputs.params.GitHubRepo)/hooks        
+          else 
+            echo "GitHub Enterprise username key found $(inputs.params.GitHubUserNameKey) so assuming this is a username and password"
+            curl -d "{\"name\": \"web\",\"active\": true,\"events\": [\"push\",\"pull_request\"],\"config\": {\"url\": \"https://$(inputs.params.ExternalUrl)/\",\"content_type\": \"json\",\"insecure_ssl\": \"1\" ,\"secret\": \"$(cat /var/secret/$(inputs.params.GitHubSecretStringKey))\"}}" -X POST -u $(cat /var/secret/$(inputs.params.GitHubUserNameKey)):$(cat /var/secret/$(inputs.params.GitHubAccessTokenKey)) -L https://$(inputs.params.GitHubUrl)/api/v3/repos/$(inputs.params.GitHubOwner)/$(inputs.params.GitHubRepo)/hooks
+          fi
+        fi
+      fi
+      
+      if [ $(inputs.params.Mode) = "delete" ] ; then
+        if [ $(inputs.params.GitHubUrl) = "github.com" ] ; then
+          if [ -z $(inputs.params.GitHubUserNameKey) ] ; then
+            echo "No GitHub username key found so assuming this is an access token"
+            curl -d "{\"name\": \"web\",\"active\": true,\"events\": [\"push\",\"pull_request\"],\"config\": {\"url\": \"https://$(inputs.params.ExternalUrl)/\",\"content_type\": \"json\",\"insecure_ssl\": \"1\" ,\"secret\": \"$(cat /var/secret/$(inputs.params.GitHubSecretStringKey))\"}}" -X DELETE -u token:$(cat /var/secret/$(inputs.params.GitHubAccessTokenKey)) -L https://api.github.com/repos/$(inputs.params.GitHubOwner)/$(inputs.params.GitHubRepo)/hooks/$(inputs.params.WebhookName)
+          else
+            curl -d "{\"name\": \"web\",\"active\": true,\"events\": [\"push\",\"pull_request\"],\"config\": {\"url\": \"https://$(inputs.params.ExternalUrl)/\",\"content_type\": \"json\",\"insecure_ssl\": \"1\" ,\"secret\": \"$(cat /var/secret/$(inputs.params.GitHubSecretStringKey))\"}}" -X POST -u $(cat /var/secret/$(inputs.params.GitHubUserNameKey)):$(cat /var/secret/$(inputs.params.GitHubAccessTokenKey)) -L https://api.github.com/repos/$(inputs.params.GitHubOwner)/$(inputs.params.GitHubRepo)/hooks/$(inputs.params.WebhookName)
+            curl -d "{\"name\": \"web\",\"active\": true,\"events\": [\"push\",\"pull_request\"],\"config\": {\"url\": \"https://$(inputs.params.ExternalUrl)/\",\"content_type\": \"json\",\"insecure_ssl\": \"1\" ,\"secret\": \"$(cat /var/secret/$(inputs.params.GitHubSecretStringKey))\"}}" -X DELETE -u $(cat /var/secret/$(inputs.params.GitHubUserNameKey)):$(cat /var/secret/$(inputs.params.GitHubAccessTokenKey)) -L https://api.github.com/repos/$(inputs.params.GitHubOwner)/$(inputs.params.GitHubRepo)/hooks/$(inputs.params.WebhookName)
+          fi
+        elif [ -z $(inputs.params.GitHubUserNameKey) ] ; then
+          echo "No GitHub Enterprise username key found so assuming this is an access token"
+          curl -d "{\"name\": \"web\",\"active\": true,\"events\": [\"push\",\"pull_request\"],\"config\": {\"url\": \"https://$(inputs.params.ExternalUrl)/\",\"content_type\": \"json\",\"insecure_ssl\": \"1\" ,\"secret\": \"$(cat /var/secret/$(inputs.params.GitHubSecretStringKey))\"}}" -X DELETE -u token:$(cat /var/secret/$(inputs.params.GitHubAccessTokenKey)) -L https://$(inputs.params.GitHubUrl)/api/v3/repos/$(inputs.params.GitHubOwner)/$(inputs.params.GitHubRepo)/hooks/$(inputs.params.WebhookName)
+        else
+          echo "GitHub Enterprise username key found $(inputs.params.GitHubUserNameKey) so assuming this is a username and password"
+          curl -d "{\"name\": \"web\",\"active\": true,\"events\": [\"push\",\"pull_request\"],\"config\": {\"url\": \"https://$(inputs.params.ExternalUrl)/\",\"content_type\": \"json\",\"insecure_ssl\": \"1\" ,\"secret\": \"$(cat /var/secret/$(inputs.params.GitHubSecretStringKey))\"}}" -X DELETE -u $(cat /var/secret/$(inputs.params.GitHubUserNameKey)):$(cat /var/secret/$(inputs.params.GitHubAccessTokenKey)) -L https://$(inputs.params.GitHubUrl)/api/v3/repos/$(inputs.params.GitHubOwner)/$(inputs.params.GitHubRepo)/hooks/$(inputs.params.WebhookName)
+        fi
+      fi
+    volumeMounts:
+    - name: github-secret
+      mountPath: /var/secret
+  volumes:
+    - name: github-secret
+      secret:
+        secretName: $(inputs.params.GitHubSecretName)


### PR DESCRIPTION
Tested this with github.com and github.ibm.com using PATs and secrets created through the Tekton Dashboard's Webhook Extension.

This is for https://github.com/tektoncd/experimental/issues/241

# Changes

Credits to @akihikokuroda for the create webhook work this is largely based on 😄 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
