### PR TITLE
Validating Secret in Webhook Create Page

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.ab223fd2.js"
+    tekton-dashboard-bundle-location: "web/extension.1f53135f.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
@@ -164,7 +164,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.ab223fd2.js"
+    tekton-dashboard-bundle-location: "web/extension.1f53135f.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
@@ -266,7 +266,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    tekton-dashboard-bundle-location: web/extension.ab223fd2.js
+    tekton-dashboard-bundle-location: web/extension.1f53135f.js
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: webhooks.web
   labels:

--- a/webhooks-extension/config/openshift/openshift-tekton-webhooks-extension-release.yaml
+++ b/webhooks-extension/config/openshift/openshift-tekton-webhooks-extension-release.yaml
@@ -266,7 +266,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    tekton-dashboard-bundle-location: web/extension.ab223fd2.js
+    tekton-dashboard-bundle-location: web/extension.1f53135f.js
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: webhooks.web
   labels:

--- a/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
+++ b/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
@@ -24,7 +24,7 @@ function validateInputs(value, id) {
       return false;
     }
 
-    if (/[^-.a-z0-9]/.test(trimmed)) {
+    if (!/[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/.test(trimmed)) {
       return false;
     }
   }
@@ -133,24 +133,6 @@ class WebhookCreatePage extends Component {
       document.getElementById(
         "serviceAccounts"
       ).firstElementChild.tabIndex = -1;
-    }
-  }
-
-  componentDidUpdate() {
-    if (this.props.namespaces) {
-      if (this.state.createSecretDisabled) {
-        if (this.state.newSecretName && this.state.newTokenValue) {
-          this.setState({
-            createSecretDisabled: false
-          })
-        }
-      } else {
-        if (!this.state.newSecretName || !this.state.newTokenValue) {
-          this.setState({
-            createSecretDisabled: true
-          })
-        }
-      }
     }
   }
 
@@ -295,6 +277,15 @@ class WebhookCreatePage extends Component {
     }
     return false
   }
+
+  isCreateSecretButtonDisabled = () => {
+    return (
+      !this.state.newSecretName ||
+      !this.state.newTokenValue ||
+      this.state.invalidFields.indexOf('newSecretName') > -1 ||
+      this.state.invalidFields.indexOf('newTokenValue') > -1
+    )
+  };
 
   createButtonIDForCSS = () => {
     if (this.isFormIncomplete()) {
@@ -721,7 +712,7 @@ class WebhookCreatePage extends Component {
               modalLabel=""
               modalHeading=""
               primaryButtonText="Create"
-              primaryButtonDisabled={this.state.createSecretDisabled}
+              primaryButtonDisabled={this.isCreateSecretButtonDisabled()}
               secondaryButtonText="Cancel"
               danger={false}
               onSecondarySubmit={() => this.toggleCreateDialog()}
@@ -750,6 +741,11 @@ class WebhookCreatePage extends Component {
                       onChange={this.handleModalText}
                       hideLabel
                       labelText="Secret Name"
+                      invalid={invalidFields.indexOf('newSecretName') > -1}
+                      invalidText={this.state.newSecretName === ''
+                        ? "Required"
+                        : "Must not start or end with - and be less than 253 characters, contain only lowercase alphanumeric characters or -"
+                      }
                     />
                   </div>
                 </div>

--- a/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirm.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/CreateModalConfirm.test.js
@@ -116,5 +116,26 @@ describe('create secret', () => {
     expect(document.getElementsByClassName('notification').item(0).childElementCount).toBe(1);
     expect(document.getElementById('git').getElementsByClassName('bx--list-box__label').item(0).textContent).toBe("new-secret-foo")
   });
-  
+
+  it('Create Secret validates all empty inputs', async () => {
+    renderWithRouter(
+      <WebhookCreate
+        match={{}}
+        namespaces={namespaces}
+        pipelines={pipelines}
+        fetchPipelines={() => {}}
+        serviceAccounts={serviceAccounts}
+        fetchServiceAccounts={() => {}}
+        setShowNotificationOnTable={() => {}}
+      />
+    );
+
+    fireEvent.click(await waitForElement(() => document.getElementById('create-secret-button')));
+
+    const name = document.getElementById('secretName')
+    fireEvent.change(name, { target: { value: 'T' } });
+
+    expect(name.getAttribute('data-invalid')).toBeTruthy();
+  });
+
 })


### PR DESCRIPTION
issue: #271 

# Changes
The input element for the secret name was missing the `invalid` property. Added that, a test case & also changed the approach when disabling & enabling the `create` button in the modal. 


