### PR TITLE
Remove Successfully Deleted Webhooks when Attempting to Delete Multiples

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.732ab41e.js"
+    tekton-dashboard-bundle-location: "web/extension.f7de3a6e.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
@@ -164,7 +164,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.732ab41e.js"
+    tekton-dashboard-bundle-location: "web/extension.f7de3a6e.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
@@ -266,7 +266,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    tekton-dashboard-bundle-location: web/extension.732ab41e.js
+    tekton-dashboard-bundle-location: web/extension.f7de3a6e.js
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: webhooks.web
   labels:

--- a/webhooks-extension/config/openshift-development/openshift-tekton-webhooks-extension-development.yaml
+++ b/webhooks-extension/config/openshift-development/openshift-tekton-webhooks-extension-development.yaml
@@ -268,7 +268,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    tekton-dashboard-bundle-location: web/extension.732ab41e.js
+    tekton-dashboard-bundle-location: web/extension.f7de3a6e.js
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: webhooks.web
   labels:

--- a/webhooks-extension/config/openshift/openshift-tekton-webhooks-extension-release.yaml
+++ b/webhooks-extension/config/openshift/openshift-tekton-webhooks-extension-release.yaml
@@ -266,7 +266,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    tekton-dashboard-bundle-location: web/extension.732ab41e.js
+    tekton-dashboard-bundle-location: web/extension.f7de3a6e.js
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: webhooks.web
   labels:

--- a/webhooks-extension/src/WebhookApp.test.js
+++ b/webhooks-extension/src/WebhookApp.test.js
@@ -63,96 +63,6 @@ function fakeDeleteWebhooksSuccess() {
   };
 }
 
-const fakeRowsSelection = [
-  {
-    "id":"mywebhook|default",
-    "isSelected":true,
-    "isExpanded":false,
-    "cells":[
-      {
-        "id":"mywebhook|default:name","value":"mywebhook","isEditable":false,"isEditing":false,"isValid":true,"errors":null,"info":
-        {
-          "header":"name"
-        }
-      },
-      {
-        "id":"mywebhook|default:repository","value":"https://github.com/foo/bar","isEditable":false,"isEditing":false,"isValid":true,"errors":null,"info":
-        {
-          "header":"repository"
-        }
-      },
-      {
-        "id":"mywebhook|default:pipeline","value":"simple-helm-pipeline-insecure","isEditable":false,"isEditing":false,"isValid":true,"errors":null,"info":
-        {
-          "header":"pipeline"
-        }
-      },
-      {"id":"mywebhook|default:namespace","value":"default","isEditable":false,"isEditing":false,"isValid":true,"errors":null,"info":
-      {
-        "header":"namespace"
-      }
-    }
-  ]},
-  {
-    "id":"mywebhook2|default",
-    "isSelected":true,
-    "isExpanded":false,
-    "cells":[
-      {
-        "id":"mywebhook2|default:name","value":"mywebhook2","isEditable":false,"isEditing":false,"isValid":true,"errors":null,"info":
-        {
-          "header":"name"
-        }
-      },
-      {
-        "id":"mywebhook2|default:repository","value":"https://github.com/foo/bar","isEditable":false,"isEditing":false,"isValid":true,"errors":null,"info":
-        {
-          "header":"repository"
-        }
-      },
-      {
-        "id":"mywebhook2|default:pipeline","value":"simple-helm-pipeline-insecure","isEditable":false,"isEditing":false,"isValid":true,"errors":null,"info":
-        {
-          "header":"pipeline"
-        }
-      },
-      {"id":"mywebhook2|default:namespace","value":"default","isEditable":false,"isEditing":false,"isValid":true,"errors":null,"info":
-      {
-        "header":"namespace"
-      }
-    }
-  ]},
-  {
-    "id":"mywebhook3|default",
-    "isSelected":true,
-    "isExpanded":false,
-    "cells":[
-      {
-        "id":"mywebhook3|default:name","value":"mywebhook3","isEditable":false,"isEditing":false,"isValid":true,"errors":null,"info":
-        {
-          "header":"name"
-        }
-      },
-      {
-        "id":"mywebhook3|default:repository","value":"https://github.com/foo/bar","isEditable":false,"isEditing":false,"isValid":true,"errors":null,"info":
-        {
-          "header":"repository"
-        }
-      },
-      {
-        "id":"mywebhook3|default:pipeline","value":"simple-helm-pipeline-insecure","isEditable":false,"isEditing":false,"isValid":true,"errors":null,"info":
-        {
-          "header":"pipeline"
-        }
-      },
-      {"id":"mywebhook3|default:namespace","value":"default","isEditable":false,"isEditing":false,"isValid":true,"errors":null,"info":
-      {
-        "header":"namespace"
-      }
-    }
-  ]}
-]
-
 const secretsResponseMock = [
   {
     "name": "ghe",
@@ -225,9 +135,8 @@ const selectors = {
 };
 
 describe("change in components after last webhook(s) deleted & shows notification", () => {
-  const test = async (webhooks, fakeRowsSelected) => {
+  const test = async (webhooks) => {
     let getWebhooksMock = jest.spyOn(API, "getWebhooks").mockImplementation(() => Promise.resolve(webhooks));
-    let getRowsMock = jest.spyOn(API, "getSelectedRows").mockImplementation(() => fakeRowsSelected);
     let deleteWebhooksMock = jest.spyOn(API, "deleteWebhooks").mockImplementation(() => Promise.resolve(fakeDeleteWebhooksSuccess));
 
     const { getByText, queryByTestId } = renderWithRouter(
@@ -251,7 +160,6 @@ describe("change in components after last webhook(s) deleted & shows notificatio
     fireEvent.click(foundDeleteButtonOnModal);
 
     expect(getWebhooksMock).toHaveBeenCalled();
-    expect(getRowsMock).toHaveBeenCalled();
     expect(deleteWebhooksMock).toHaveBeenCalled();
 
     getWebhooksMock.mockImplementation(() => Promise.resolve([]));
@@ -263,14 +171,14 @@ describe("change in components after last webhook(s) deleted & shows notificatio
   }
 
   it('# of webhooks: 1', () => {
-    test([webhooks[0]], [fakeRowsSelection[0]]);
+    test([webhooks[0]]);
   });
 
   it('# of webhooks: 2', () => {
-    test(webhooks.slice(0,2), fakeRowsSelection.slice(0,2));
+    test(webhooks.slice(0,2));
   });
 
   it('# of webhooks: 3', () => {
-    test(webhooks, fakeRowsSelection);
+    test(webhooks);
   });
 });

--- a/webhooks-extension/src/api/index.js
+++ b/webhooks-extension/src/api/index.js
@@ -16,12 +16,6 @@ import { get, post, deleteRequest } from './comms';
 const apiRoot = getAPIRoot();
 const dashboardAPIRoot = getDashboardAPIRoot();
 
-// Defined here for ease of mocking to test: would be great to remove
-// perhaps using enzyme and mocking state?
-export function getSelectedRows(selectedRows) {
-  return selectedRows
-}
-
 export function getAPIRoot() {
   const { href, hash } = window.location;
   let realHash = 'v1/extensions/webhooks-extension';


### PR DESCRIPTION
issue: #268 

# Changes
Tried a couple of approaches, but mapping each promise by itself & then calling `Promise.all` seemed to worked the best.

Bonus:
I also made the table unselect the rows `when` the delete modal appears. Which means that if the user decides to cancel the delete call, the modal disappears and the page will look like it was refreshed. Let me know how you feel about this.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
