### PR TITLE
Add Tekton Task and TaskRun to create and delete Routes

### DIFF
--- a/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
@@ -12,6 +12,14 @@ metadata:
   name: tekton-webhooks-extension-minimal
   namespace: tekton-pipelines
 rules:
+- apiGroups: 
+  - route.openshift.io
+  resources: 
+  - routes
+  verbs:
+  - get
+  - create
+  - delete
 - apiGroups:
   - security.openshift.io
   resources:

--- a/webhooks-extension/config/triggers_prototype/README.md
+++ b/webhooks-extension/config/triggers_prototype/README.md
@@ -17,6 +17,19 @@ You can create or delete an Ingress using the provided Task, TaskRun, and certif
 4. Apply the TaskRun definition:
 `kubectl create -f config/triggers_prototype/test/ingress-run.yaml`
 
+## Routes
+
+You can create or delete a Route on OpenShift using the provided Task and TaskRun.
+
+1. Apply the Task definition:
+`kubectl apply -f config/triggers_prototype/route.yaml`
+2. Modify the example TaskRun definition, replacing the parameters accordingly:
+
+  - To create a Route, set `Mode` to `create`. To delete a Route, set this to `delete`
+
+3. Apply the TaskRun definition:
+`kubectl create -f config/triggers_prototype/test/route-run.yaml`
+
 ## Using Docker Desktop
 
 In order for the EventListener service to be reachable over Ingress, you should install your own LoadBalancer - for example with:

--- a/webhooks-extension/config/triggers_prototype/route.yaml
+++ b/webhooks-extension/config/triggers_prototype/route.yaml
@@ -1,0 +1,54 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: route-task
+  namespace: tekton-pipelines
+spec:
+  inputs:
+    params:
+    - name: Mode
+      description: Whether to create or delete a Route
+      default: "create"
+      type: string
+    - name: ExternalUrl 
+      description: The external access URL
+      default: "listener.replaceme.nip.io"
+      type: string
+    - name: EventListenerName 
+      description: The EventListener name
+      default: "listener"
+      type: string
+    - name: EventListenerPort
+      description: The EventListener port
+      default: "8082"
+      type: string
+  steps:
+  - name: create-or-delete-route
+    image: lachlanevenson/k8s-kubectl:latest
+    command:
+    - sh
+    args:
+    - -ce
+    - |
+      set -e
+      if [ $(inputs.params.Mode) = "create" ] ; then
+        echo "Creating the Route"
+        cat <<EOF | kubectl apply -f --validate=false -
+        apiVersion: route.openshift.io/v1
+        kind: Route
+        metadata:
+          name: $(inputs.params.EventListenerName)
+        spec:
+          to:
+            kind: Service
+            name: $(inputs.params.EventListenerName)
+          tls:
+            termination: Reencrypt
+            insecureEdgeTerminationPolicy: Redirect
+      EOF
+      fi
+                
+      if [ $(inputs.params.Mode) = "delete" ] ; then
+        echo "Deleting Route"
+        kubectl delete route $(inputs.params.EventListenerName)
+      fi

--- a/webhooks-extension/config/triggers_prototype/test/route-run.yaml
+++ b/webhooks-extension/config/triggers_prototype/test/route-run.yaml
@@ -1,0 +1,20 @@
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  generateName: route-run-
+  namespace: tekton-pipelines
+spec:
+  taskRef:
+    name: route-task
+  inputs:
+    params:
+    - name: Mode
+      value: "create"
+    - name: ExternalUrl
+      value: listener.replaceme.nip.io
+    - name: EventListenerName
+      value: "listener"
+    - name: EventListenerPort
+      value: "8082"
+  timeout: 60s
+  serviceAccount: tekton-webhooks-extension


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

For https://github.com/tektoncd/experimental/issues/278

Example:

```
[root@requite1 triggers_prototype]# k logs route-run-r7mrh-pod-45cbdd 
Creating the Route
route.route.openshift.io/listener created

[root@requite1 triggers_prototype]# k get route
NAME               HOST/PORT                                                 PATH      SERVICES           PORT      TERMINATION          WILDCARD
listener           listener-tekton-pipelines.thehostname                     listener           <all>     reencrypt/Redirect   None
tekton-dashboard   tekton-dashboard-tekton-pipelines.thehostname             tekton-dashboard   <all>     reencrypt/Redirect   None
```

RBAC augmented too

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
