### PR TITLE
Embed PipelineResources in PipelineRun and TaskRun

### DIFF
--- a/webhooks-extension/Gopkg.lock
+++ b/webhooks-extension/Gopkg.lock
@@ -157,14 +157,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b8dc716812a3652b5f80648fe3830d10179ef127bae152704cfd5ef43c828738"
+  digest = "1:e1521973f4c4e40b9963f601a7e9de8f1eb8023ea8aa73e209c0bce2f2ef5ffd"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
     "apis/duck",
     "apis/duck/v1alpha1",
-    "apis/duck/v1beta1",
-    "configmap",
     "kmp",
   ]
   pruneopts = "UT"
@@ -227,7 +225,7 @@
   revision = "dbdb5c2805ee17751e30b4888fbd6791770a4b7f"
 
 [[projects]]
-  digest = "1:c1d4d03290ca71b76462cd02b6e1293cd857dc2ba9182ef56d2178c650041021"
+  digest = "1:cc5ac2ab9805196a1adccf86b8cc13cc93366941c5419971454b3e748e6d12e8"
   name = "github.com/tektoncd/pipeline"
   packages = [
     "pkg/apis/config",
@@ -239,13 +237,10 @@
     "pkg/client/clientset/versioned/typed/pipeline/v1alpha1",
     "pkg/client/clientset/versioned/typed/pipeline/v1alpha1/fake",
     "pkg/list",
-    "pkg/merge",
     "pkg/names",
-    "pkg/templating",
   ]
   pruneopts = "UT"
-  revision = "ef4611b7cf0c0b0f0b1876a1652f283fc63f181b"
-  version = "v0.5.2"
+  revision = "8871979dfc08fb65ae544c6ad2de83f8bab617b0"
 
 [[projects]]
   digest = "1:a5158647b553c61877aa9ae74f4015000294e47981e6b8b07525edcbb0747c81"
@@ -680,6 +675,22 @@
   revision = "6b3d3b2d5666c5912bab8b7bf26bf50f75a8f887"
 
 [[projects]]
+  branch = "master"
+  digest = "1:83353bfb5fafed2c02c9b38b1ac27e822f299040a567b96223ce2e49cd1f3fb3"
+  name = "knative.dev/pkg"
+  packages = [
+    "apis",
+    "apis/duck",
+    "apis/duck/v1",
+    "apis/duck/v1beta1",
+    "apis/v1alpha1",
+    "configmap",
+    "kmp",
+  ]
+  pruneopts = "UT"
+  revision = "b5a8deb92e5c8aa8ff8fb231b75ce5b6795f82ab"
+
+[[projects]]
   digest = "1:84a8609383bec11b71d52dd813f33f1d16614b91966940bdc2aa79bea864fa25"
   name = "sigs.k8s.io/controller-runtime"
   packages = ["pkg/runtime/scheme"]
@@ -692,6 +703,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/emicklei/go-restful",
+    "github.com/google/go-cmp/cmp",
     "github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1",
     "github.com/knative/eventing-sources/pkg/client/clientset/versioned",
     "github.com/knative/eventing-sources/pkg/client/clientset/versioned/fake",

--- a/webhooks-extension/Gopkg.toml
+++ b/webhooks-extension/Gopkg.toml
@@ -1,28 +1,10 @@
-# Gopkg.toml example
-#
 # Refer to https://golang.github.io/dep/docs/Gopkg.toml.html
 # for detailed Gopkg.toml documentation.
-#
-# required = ["github.com/user/thing/cmd/thing"]
-# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-#
-# [[constraint]]
-#   name = "github.com/user/project"
-#   version = "1.0.0"
-#
-# [[constraint]]
-#   name = "github.com/user/project2"
-#   branch = "dev"
-#   source = "github.com/myfork/project2"
-#
-# [[override]]
-#   name = "github.com/x/y"
-#   version = "2.4.0"
-#
-# [prune]
-#   non-go = false
-#   go-tests = true
-#   unused-packages = true
+
+[[constraint]]
+  name = "github.com/tektoncd/pipeline"
+  # HEAD as of 2019-10-16
+  revision = "8871979dfc08fb65ae544c6ad2de83f8bab617b0"
 
 [[override]]
   name = "k8s.io/api"

--- a/webhooks-extension/package-lock.json
+++ b/webhooks-extension/package-lock.json
@@ -8682,9 +8682,9 @@
       }
     },
     "react": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
-      "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.10.2.tgz",
+      "integrity": "sha512-MFVIq0DpIhrHFyqLU0S3+4dIcBhhOvBE8bJ/5kHPVOVaGdo0KuiQzpcjCPsf585WvhypqtrMILyoE2th6dT+Lw==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",

--- a/webhooks-extension/package.json
+++ b/webhooks-extension/package.json
@@ -51,7 +51,7 @@
     "node-sass": "^4.12.0",
     "npm-run-all": "^4.1.5",
     "prop-types": "^15.7.2",
-    "react": "^16.9.0",
+    "react": "^16.10.2",
     "react-app-polyfill": "^1.0.0",
     "react-dom": "^16.8.6",
     "react-redux": "^7.0.1",

--- a/webhooks-extension/pkg/endpoints/sink_test.go
+++ b/webhooks-extension/pkg/endpoints/sink_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoints
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+)
+
+func TestStringParam(t *testing.T) {
+	want := v1alpha1.Param{
+		Name: "foo",
+		Value: v1alpha1.ArrayOrString{
+			Type:      v1alpha1.ParamTypeString,
+			StringVal: "bar",
+		},
+	}
+	got := stringParam("foo", "bar")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("stringParam(): -want +got: %s", diff)
+	}
+}


### PR DESCRIPTION
# Changes

Fixes #240

This PR updates our PipelineRuns and TaskRuns to use an embedded PipelineResourceSpec. So, we will no longer encounter race conditions between the PipelineResources and PipelineRun/TaskRun.

I updated the Gopkg.toml file to use revision `8871979dfc08fb65ae544c6ad2de83f8bab617b0` of tektoncd/pipeline, so we can ensure https://github.com/tektoncd/pipeline/pull/1324 will be available.

Some additional changes had to be made to update to this newer version of Tekton Pipelines. The most notable change is with parameters, where we now must account for the `ArrayOrString` struct.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
