### PR TITLE
Consistent Modal Buttons

### DIFF
--- a/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
+++ b/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
@@ -679,9 +679,9 @@ class WebhookCreatePage extends Component {
               id="delete-modal"
               modalLabel=""
               modalHeading="Please confirm you want to delete the following secret:"
-              primaryButtonText="Confirm"
+              primaryButtonText="Delete"
               secondaryButtonText="Cancel"
-              danger={false}
+              danger={true}
               onSecondarySubmit={() => this.toggleDeleteDialog()}
               onRequestSubmit={() => this.deleteAccessTokenSecret()}
               onRequestClose={() => this.toggleDeleteDialog()}>

--- a/webhooks-extension/src/components/WebhookCreate/WebhookCreate.scss
+++ b/webhooks-extension/src/components/WebhookCreate/WebhookCreate.scss
@@ -147,61 +147,51 @@
   .bx--modal-content > * {
     font-size: 1.1rem;
   }
-  
+
   .bx--modal.is-visible {
     background-color: rgba(255,255,255,0.82);
   }
-  
+
   .bx--modal-container {
     border: 1px solid black;
     background-color: white;
   }
-  
-  %primary-secondary-shared {
-    display: inline;
-    text-align: center;
-    padding: 0px;
-    font-weight: bold;
-  }
 
   .bx--btn.bx--btn--primary {
-    @extend %primary-secondary-shared;
     background-color: green;
-  }
-  
-  .bx--btn.bx--btn--secondary {
-    @extend %primary-secondary-shared;
-    background-color: red;
+    padding-left: 10;
+    font-weight: bold;
   }
 
   .bx--btn.bx--btn--primary.bx--btn--disabled {
     background-color: lightgrey;
-    font-weight: bold;
-    float: right;
     color: white;
   }
 
-  .modal-btn {
-    padding-left: 15% !important;
-    padding-right: 15% !important;
-  }
-  
   .modal-row {
     display: flex;
     align-items: center;
     padding: 1%;
   }
-  
+
   .modal-row-help-icon {
     width: 8%;
   }
-  
+
   .modal-row-item-label {
     width: 30%;
   }
-  
+
   .modal-row-entry-field {
     width: 60%;
+  }
+
+  .secret-to-delete{
+    
+    font-weight: bold;
+    display: list-item;
+    list-style-type: disc;
+    list-style-position: inside;
   }
 
 }

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirm.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirm.test.js
@@ -112,7 +112,7 @@ describe('confirm deletion success', () => {
     expect(document.getElementById('delete-modal').getAttribute('class')).toContain('is-visible');
 
     jest.spyOn(API, 'getSecrets').mockImplementation(() => Promise.resolve(secretsDeletedMock));
-    fireEvent.click(document.getElementById('delete-modal').getElementsByClassName('bx--btn--primary').item(0));
+    fireEvent.click(document.getElementById('delete-modal').getElementsByClassName('bx--btn--danger').item(0));
 
     await waitForElement(() => getByText(/Secret deleted./));
     expect(document.getElementById('delete-modal').getAttribute('class')).not.toContain('is-visible');

--- a/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirmError.test.js
+++ b/webhooks-extension/src/components/WebhookCreate/tests/DeleteModalConfirmError.test.js
@@ -113,7 +113,7 @@ describe('confirm deletion errors', () => {
     expect(document.getElementById('delete-modal').getAttribute('class')).toContain('is-visible');
 
     jest.spyOn(API, 'deleteSecret').mockImplementation(() => Promise.reject(deleteSecretFailMock));
-    fireEvent.click(document.getElementById('delete-modal').getElementsByClassName('bx--btn--primary').item(0));
+    fireEvent.click(document.getElementById('delete-modal').getElementsByClassName('bx--btn--danger').item(0));
     await waitForElement(() => getByText(/Mock Error Deleting Secret/i));
   });
 


### PR DESCRIPTION
issue: #211 

# Changes

- Other delete modals: 
_Webhooks_
![image](https://user-images.githubusercontent.com/49996607/67233866-07440e00-f412-11e9-8bb2-11252b82cb93.png)
_Secrets_
![image](https://user-images.githubusercontent.com/49996607/67233963-2fcc0800-f412-11e9-9e2a-fa77fee997a2.png)

- Access Token Modals:
_Before_
<img width="782" alt="Screen Shot 2019-10-21 at 2 51 47 PM" src="https://user-images.githubusercontent.com/49996607/67234040-60ac3d00-f412-11e9-947b-b455b50a1107.png">
<img width="779" alt="Screen Shot 2019-10-21 at 2 52 03 PM" src="https://user-images.githubusercontent.com/49996607/67234041-6144d380-f412-11e9-82aa-a8cce9e7628e.png">
_After_
<img width="780" alt="Screen Shot 2019-10-21 at 2 37 10 PM" src="https://user-images.githubusercontent.com/49996607/67234074-6c97ff00-f412-11e9-99a5-ec81c5a1c0af.png">
<img width="780" alt="Screen Shot 2019-10-21 at 2 36 55 PM" src="https://user-images.githubusercontent.com/49996607/67234073-6c97ff00-f412-11e9-8a1d-06d9510fc24a.png">

