### PR TITLE
Make timeout message configurable 

### DIFF
--- a/webhooks-extension/config/task-monitor-result.yaml
+++ b/webhooks-extension/config/task-monitor-result.yaml
@@ -22,6 +22,10 @@ spec:
         description: The text of the failure comment
         default: "Failed"
         type: string
+      - name: commenttimeout
+        description: The text of the timeout comment
+        default: "Unknown"
+        type: string
       - name: dashboard-url
         description: The URL to the pipelineruns page of the dashboard
         default: "http://localhost:9097/"
@@ -47,6 +51,8 @@ spec:
         value: $(inputs.params.commentsuccess)
       - name: COMMENT_FAILURE
         value: $(inputs.params.commentfailure)
+      - name: COMMENT_TIMEOUT
+        value: $(inputs.params.commenttimeout)
       - name: URL
         value: $(inputs.params.dashboard-url)
       # This can be deleted after any fix to the above mentioned pending status change
@@ -131,7 +137,7 @@ spec:
           pipeline = pipeline.strip()
           print("Still Running - pipelinerun " + pr + " in namespace " + namespace)
           link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
-          runsIncomplete.append("[**??????**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
+          runsIncomplete.append("[**$COMMENT_TIMEOUT**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
       results = runsPassed + runsFailed + runsIncomplete
       comment = ("## Tekton Status Report \n\n"
                  "Status | Pipeline | PipelineRun | Namespace\n"

--- a/webhooks-extension/config/triggers_prototype/task-monitor-result.yaml
+++ b/webhooks-extension/config/triggers_prototype/task-monitor-result.yaml
@@ -22,6 +22,10 @@ spec:
         description: The URL to the pipelineruns page of the dashboard
         default: "http://localhost:9097/"
         type: string
+      - name: commenttimeout
+        description: The text of the timeout comment
+        default: "Unknown"
+        type: string
       # This can be deleted after pending status change issue is resolved, that being that AFAIK the pull request resource only modifies
       # status once everything is complete, so we can only modify status via the pull request resource once.  To get around this we hit
       # the github status URL to set the status into pending and use this secret to during that request.  
@@ -45,6 +49,8 @@ spec:
         value: $(inputs.params.commentsuccess)
       - name: COMMENT_FAILURE
         value: $(inputs.params.commentfailure)
+      - name: COMMENT_TIMEOUT
+        value: $(inputs.params.commenttimeout)
       - name: URL
         value: $(inputs.params.dashboard-url)
       # This can be deleted after any fix to the above mentioned pending status change
@@ -116,7 +122,7 @@ spec:
                 runsFailed.append("[**$COMMENT_FAILURE**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
                 continue
               link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
-              runsIncomplete.append("[**??????**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
+              runsIncomplete.append("[**$COMMENT_TIMEOUT**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
             if len(runsIncomplete) == 0:
               break
           else:

--- a/webhooks-extension/docs/CustomizingTheMonitor.md
+++ b/webhooks-extension/docs/CustomizingTheMonitor.md
@@ -22,9 +22,9 @@ If you have not installed into the tekton-pipelines namespace, you would need to
 
 ## Overriding The Status Message
 
-To change the "Success" and "Failed" status messages shown in the 'Tekton Status' comment added to the pull request, you can use the REST endpoint for creating your webhooks, rather than the UI.  Note however that the REST endpoints are only advised to be used in development, see [here](../DEVELOPMENT.md).
+To change the "Success", "Failed" and "Unknown" status messages shown in the 'Tekton Status' comment added to the pull request, you can use the REST endpoint for creating your webhooks, rather than the UI.  Note however that the REST endpoints are only advised to be used in development, see [here](../DEVELOPMENT.md).
 
-The body you POST to the REST endpoint has two properties, `onsuccesscomment` and `onfailurecomment` that define the value used in the Status column.  For example, creating the webhook using the JSON body:
+The body you POST to the REST endpoint has three properties, `onsuccesscomment`, `onfailurecomment` and `ontimeoutcomment` that define the value used in the Status column.  For example, creating the webhook using the JSON body:
 
 ```
 {
@@ -35,7 +35,8 @@ The body you POST to the REST endpoint has two properties, `onsuccesscomment` an
   "pipeline": "simple-pipeline",
   "dockerregistry": "FOO",
   "onsuccesscomment": "Erfolg",  <--------------------------------------------
-  "onfailurecomment": "Fehler"   <--------------------------------------------
+  "onfailurecomment": "Fehler",  <--------------------------------------------
+  "ontimeoutcomment": "Frozen"   <--------------------------------------------
 }
 ```
 
@@ -58,6 +59,7 @@ Using the REST endpoint directly, it is also possible to override the Task that 
   "dockerregistry": "FOO",
   "onsuccesscomment": "Erfolg",
   "onfailurecomment": "Fehler",
+  "ontimeoutcomment": "Frozen",
   "pulltask": "my-custom-task"   <--------------------------------------------
 }
 ```
@@ -71,6 +73,8 @@ In this situation, after the webhook is triggered and the PipelineRun created, a
       value: Erfolg
     - name: commentfailure
       value: Fehler
+    - name: commenttimeout
+      value: Frozen
     - name: secret
       value: GITHUBSECRET
 ```

--- a/webhooks-extension/docs/Monitoring.md
+++ b/webhooks-extension/docs/Monitoring.md
@@ -18,7 +18,7 @@ If the webhook is triggered due to a pull request being created (or updated with
 
 ![Error status on pull request](./images/errorStatus.png?raw=true "Error status shown on a GitHub pull request")
 
-5.  A comment is added to the pull request showing the result of the PipelineRun. The reported status operates as a hyperlink to the specific PipelineRun in the Tekton Dashboard, allowing you to quickly navigate to any relevant log files.  Note that `??????` as a status denotes that the PipelineRun had not completed before the monitor Task reached its maximum polling duration (30 mins).  
+5.  A comment is added to the pull request showing the result of the PipelineRun. The reported status operates as a hyperlink to the specific PipelineRun in the Tekton Dashboard, allowing you to quickly navigate to any relevant log files.  Note that `Unknown` as a status denotes that the PipelineRun had not completed before the monitor Task reached its maximum polling duration (30 mins).  
 
 ![PipelineRun status reporting](./images/comment.png?raw=true "PipelineRun status report as comment on GitHub pull request")
 

--- a/webhooks-extension/pkg/endpoints/sink.go
+++ b/webhooks-extension/pkg/endpoints/sink.go
@@ -333,6 +333,7 @@ func createTaskRunFromWebhookData(buildInformation BuildInformation, r Resource,
 	taskTemplateName := webhooksForRepo[0].PullTask
 	onSuccessComment := webhooksForRepo[0].OnSuccessComment
 	onFailureComment := webhooksForRepo[0].OnFailureComment
+	onTimeoutComment := webhooksForRepo[0].OnTimeoutComment
 	accessTokenRef := webhooksForRepo[0].AccessTokenRef
 
 	// Assumes you've already applied the yml: so the task definition must exist upfront.
@@ -360,6 +361,10 @@ func createTaskRunFromWebhookData(buildInformation BuildInformation, r Resource,
 
 	if onFailureComment == "" {
 		onFailureComment = "Failed"
+	}
+
+	if onTimeoutComment == "" {
+		onTimeoutComment = "Unknown"
 	}
 
 	logging.Log.Debugf("Build information: %+v.", buildInformation)
@@ -392,6 +397,7 @@ func createTaskRunFromWebhookData(buildInformation BuildInformation, r Resource,
 
 	params := []v1alpha1.Param{{Name: "commentsuccess", Value: onSuccessComment},
 		{Name: "commentfailure", Value: onFailureComment},
+		{Name: "commenttimeout", Value: onTimeoutComment},
 		{Name: "pipelineruns", Value: taskPipelineRunsParam},
 		{Name: "dashboard-url", Value: getDashboardURL(r, installNs)},
 		{Name: "secret", Value: accessTokenRef}}

--- a/webhooks-extension/pkg/endpoints/types.go
+++ b/webhooks-extension/pkg/endpoints/types.go
@@ -88,6 +88,7 @@ type webhook struct {
 	PullTask         string `json:"pulltask,omitempty"`
 	OnSuccessComment string `json:"onsuccesscomment,omitempty"`
 	OnFailureComment string `json:"onfailurecomment,omitempty"`
+	OnTimeoutComment string `json:"ontimeoutcomment,omitempty"`
 	GithubSource     string `json:"githubsource,omitempty"`
 }
 

--- a/webhooks-extension/pkg/endpoints/webhook_test.go
+++ b/webhooks-extension/pkg/endpoints/webhook_test.go
@@ -67,6 +67,7 @@ func TestGitHubSource(t *testing.T) {
 			PullTask:         "pulltask1",
 			OnSuccessComment: "onsuccesscomment1",
 			OnFailureComment: "onfailurecomment1",
+			OnTimeoutComment: "ontimeoutcomment1",
 			// The GithubSource name here is important as it needs to match the name that is generated.
 			// The integer needs to match the order in which it was created (or more correctly where it is
 			// in the map created in shared-test-funcs.go)
@@ -98,6 +99,7 @@ func TestGitHubSource(t *testing.T) {
 			PullTask:         "pulltask3",
 			OnSuccessComment: "onsuccesscomment3",
 			OnFailureComment: "onfailurecomment3",
+			OnTimeoutComment: "ontimeoutcomment3",
 			// The GithubSource name here is important as it needs to match the name that is generated.
 			// The integer needs to match the order in which it was created (or more correctly where it is
 			// in the map created in shared-test-funcs.go)
@@ -366,6 +368,7 @@ func TestDeleteByNameKeepRuns(t *testing.T) {
 		PullTask:         "pulltask1",
 		OnSuccessComment: "onsuccesscomment1",
 		OnFailureComment: "onfailurecomment1",
+		OnTimeoutComment: "ontimeoutcomment1",
 		// The GithubSource name here is important as it needs to match the name that is generated.
 		// The integer needs to match the order in which it was created (or more correctly where it is
 		// in the map created in shared-test-funcs.go)
@@ -503,6 +506,7 @@ func TestDeleteByNameDeleteRuns(t *testing.T) {
 		PullTask:         "pulltask1",
 		OnSuccessComment: "onsuccesscomment1",
 		OnFailureComment: "onfailurecomment1",
+		OnTimeoutComment: "ontimeoutcomment1",
 	}
 
 	resp := createWebhook(theWebhook, r)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This PR is for issue https://github.com/tektoncd/experimental/issues/220.

Add a parameter for the timeout message in the monitor task.

The changes are in both webhooks-extension/config/task-monitor-result.yaml and webhooks-extension/config/triggers_prototype/task-monitor-result.yaml

The webhook-extension/pkg/endpoints/sink.go, webhook-extension/pkg/endpoints/types.go and related unit tests are updated, too. 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
