### PR TITLE
Fix task monitor by adding copy step

### DIFF
--- a/webhooks-extension/config/task-monitor-result.yaml
+++ b/webhooks-extension/config/task-monitor-result.yaml
@@ -150,3 +150,10 @@ spec:
       handle.write(status)
       handle.close()
       EOF
+  - name: copy
+    image: busybox
+    command: ["cp"]
+    args:
+    - -r
+    - /workspace/pull-request
+    - /workspace/output

--- a/webhooks-extension/pkg/endpoints/sink.go
+++ b/webhooks-extension/pkg/endpoints/sink.go
@@ -31,13 +31,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const gitServerLabel = "gitServer"
-const gitOrgLabel = "gitOrg"
-const gitRepoLabel = "gitRepo"
-const gitBranchLabel = "gitBranch"
-const githubEventParameter = "Ce-Github-Event"
+const (
+	gitServerLabel       = "gitServer"
+	gitOrgLabel          = "gitOrg"
+	gitRepoLabel         = "gitRepo"
+	gitBranchLabel       = "gitBranch"
+	githubEventParameter = "Ce-Github-Event"
+)
 
-// BuildInformation - information required to build a particular commit from a Git repository.
+// BuildInformation is information required to build a particular commit from a git repository.
 type BuildInformation struct {
 	BRANCH         string
 	REPOURL        string

--- a/webhooks-extension/pkg/endpoints/types.go
+++ b/webhooks-extension/pkg/endpoints/types.go
@@ -14,12 +14,13 @@ limitations under the License.
 package endpoints
 
 import (
+	"os"
+
 	eventsrcclientset "github.com/knative/eventing-sources/pkg/client/clientset/versioned"
 	logging "github.com/tektoncd/experimental/webhooks-extension/pkg/logging"
 	tektoncdclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	k8sclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"os"
 )
 
 // Resource stores all types here that are reused throughout files
@@ -94,7 +95,6 @@ type webhook struct {
 // ConfigMapName ... the name of the ConfigMap to create
 const ConfigMapName = "githubwebhook"
 
-//
 type EnvDefaults struct {
 	Namespace      string `json:"namespace"`
 	DockerRegistry string `json:"dockerregistry"`


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
`PipelineResources` were internally modified, which broke the task monitor on Tekton 0.7 (as well as 0.8). This adds a copy step so that the pull-request resource properly uploads when used within the task monitor
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
