### PR TITLE
Use ALL_NAMESPACES for webhooks-extension state

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.a1be58d0.js"
+    tekton-dashboard-bundle-location: "web/extension.305e4e36.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
@@ -100,7 +100,7 @@ spec:
             value: /var/run/ko
           # Set this at install time after creating a certificate, e.g. with openssl and the provided convenience script.
           # A secret will be created and this name should be provided here.
-          # This secret name will then be picked up by the Go code that is responsible for 
+          # This secret name will then be picked up by the Go code that is responsible for
           # creating the EventListener, Ingress and webhooks.
           # The Ingress will be created with the tls secret name value set to this variable's value.
           - name: TRIGGERS_PROTOTYPE_INGRESS_CERTIFICATE_SECRET_NAME
@@ -119,7 +119,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.a1be58d0.js"
+    tekton-dashboard-bundle-location: "web/extension.305e4e36.js"
 spec:
   type: NodePort
   ports:
@@ -187,7 +187,7 @@ spec:
         type: string
       # This can be deleted after pending status change issue is resolved, that being that AFAIK the pull request resource only modifies
       # status once everything is complete, so we can only modify status via the pull request resource once.  To get around this we hit
-      # the github status URL to set the status into pending and use this secret to during that request.  
+      # the github status URL to set the status into pending and use this secret to during that request.
       - name: secret
         description: The secret containing the access token to access github
         type: string

--- a/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
@@ -12,9 +12,9 @@ metadata:
   name: tekton-webhooks-extension-minimal
   namespace: tekton-pipelines
 rules:
-- apiGroups: 
+- apiGroups:
   - route.openshift.io
-  resources: 
+  resources:
   - routes
   verbs:
   - get
@@ -187,7 +187,7 @@ spec:
           value: web
         # Set this at install time after creating a certificate, e.g. with openssl and the provided convenience script.
         # A secret will be created and this name should be provided here.
-        # This secret name will then be picked up by the Go code that is responsible for 
+        # This secret name will then be picked up by the Go code that is responsible for
         # creating the EventListener, Ingress and webhooks.
         # The Ingress will be created with the tls secret name value set to this variable's value.
         - name: TRIGGERS_PROTOTYPE_INGRESS_CERTIFICATE_SECRET_NAME
@@ -212,7 +212,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    tekton-dashboard-bundle-location: web/extension.a1be58d0.js
+    tekton-dashboard-bundle-location: web/extension.305e4e36.js
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: webhooks.web
   labels:
@@ -290,7 +290,7 @@ spec:
         type: string
       # This can be deleted after pending status change issue is resolved, that being that AFAIK the pull request resource only modifies
       # status once everything is complete, so we can only modify status via the pull request resource once.  To get around this we hit
-      # the github status URL to set the status into pending and use this secret to during that request.  
+      # the github status URL to set the status into pending and use this secret to during that request.
       - name: secret
         description: The secret containing the access token to access github
         type: string

--- a/webhooks-extension/src/WebhookApp.js
+++ b/webhooks-extension/src/WebhookApp.js
@@ -5,6 +5,8 @@ import { connect } from 'react-redux';
 import { WebhookCreate } from './components/WebhookCreate';
 import { WebhookDisplayTable } from './components/WebhookDisplayTable';
 
+const ALL_NAMESPACES = '*';
+
 class WebhooksApp extends Component {
 
   constructor(props) {
@@ -91,13 +93,13 @@ function mapStateToProps(state, props) {
   return {
     namespace: props.selectors.getSelectedNamespace(state),
     namespaces: props.selectors.getNamespaces(state),
-    pipelines: props.selectors.getPipelines(state),
+    pipelines: props.selectors.getPipelines(state, { namespace: ALL_NAMESPACES }),
     isFetchingNamespaces: props.selectors.isFetchingNamespaces(state),
     isFetchingPipelines: props.selectors.isFetchingPipelines(state),
     pipelinesErrorMessage: props.selectors.getPipelinesErrorMessage(state),
     serviceAccountsErrorMessage: props.selectors.getServiceAccountsErrorMessage(state),
     isFetchingServiceAccounts: props.selectors.isFetchingServiceAccounts(state),
-    serviceAccounts: props.selectors.getServiceAccounts(state)
+    serviceAccounts: props.selectors.getServiceAccounts(state, { namespace: ALL_NAMESPACES })
   };
 }
 

--- a/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
+++ b/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
@@ -318,7 +318,7 @@ class WebhookCreatePage extends Component {
       <Dropdown
         data-testid="pipelinesDropdown"
         id="pipeline"
-        label="select pipeline"
+        label={pipelineItems.length === 0 ? "no pipelines found" : "select pipeline"}
         items={pipelineItems}
         disabled={this.isDisabled()}
         onChange={this.handleChangePipeline}
@@ -352,7 +352,7 @@ class WebhookCreatePage extends Component {
     return <Dropdown
       id="serviceAccounts"
       data-testid="serviceAccounts"
-      label="select service account"
+      label={saItems.length === 0 ? "no service accounts found" : "select service account"}
       items={saItems}
       disabled={this.isDisabled()}
       onChange={this.handleChangeServiceAcct}
@@ -678,14 +678,14 @@ class WebhookCreatePage extends Component {
             <Modal open={this.state.showDeleteDialog}
               id="delete-modal"
               modalLabel=""
-              modalHeading="Please confirm you want to delete the following secret:" 
+              modalHeading="Please confirm you want to delete the following secret:"
               primaryButtonText="Confirm"
               secondaryButtonText="Cancel"
               danger={false}
               onSecondarySubmit={() => this.toggleDeleteDialog()}
               onRequestSubmit={() => this.deleteAccessTokenSecret()}
               onRequestClose={() => this.toggleDeleteDialog()}>
-              
+
               <div className="secret-to-delete">{this.state.gitsecret}</div>
             </Modal>
           </div>
@@ -694,7 +694,7 @@ class WebhookCreatePage extends Component {
             <Modal open={this.state.showCreateDialog}
               id="create-modal"
               modalLabel=""
-              modalHeading="" 
+              modalHeading=""
               primaryButtonText="Create"
               primaryButtonDisabled={this.state.createSecretDisabled}
               secondaryButtonText="Cancel"


### PR DESCRIPTION
# Changes

Fixes #266
The `WebhookApp` was taking its state directly from the Redux store using
the Dashboard's selected namespace (`getSelectedNamespace()`). Instead, we
want to use `ALL_NAMESPACES` so that the `WebhookApp`'s state does not
change when the Dashboard's selected namespace changes.

Also, this PR adds an empty state to the Pipeline and ServiceAccount dropdowns.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
