### PR TITLE
Update Docs for Istio Version 1.1.16

### DIFF
--- a/webhooks-extension/docs/InstallPrereqs.md
+++ b/webhooks-extension/docs/InstallPrereqs.md
@@ -26,13 +26,13 @@
    - **For a quickstart Istio install:**
  
        - Clone this repository: `git clone https://github.com/tektoncd/experimental.git`
-       - Run the Istio installation script: `./scripts/install_istio.sh <version>` 
-         
-         **Note:** requires [Helm](https://helm.sh/docs/using_helm/#installing-helm) 2.x to be installed and Istio 1.1.7 as `<version>` is a known working configuration
-   
+       - Run the Istio installation script: `./scripts/install_istio.sh <version>`
+
+         **Note:** requires [Helm](https://helm.sh/docs/using_helm/#installing-helm) 2.x to be installed and Istio `<version>` from 1.1.7 to 1.1.16 are known working configurations.
+
    - **For a custom quickstart install:**
- 
-       - Install as per instructions in the knative docs [https://knative.dev/docs/install/installing-istio/](https://knative.dev/docs/install/installing-istio/) _(Istio version 1.1.7 is recommended)_
+
+       - Install as per instructions in the knative docs [https://knative.dev/docs/install/installing-istio/](https://knative.dev/docs/install/installing-istio/) _(Istio version 1.1.16 is recommended)_
 
    - **For official Istio install steps:**
 

--- a/webhooks-extension/test/config.sh
+++ b/webhooks-extension/test/config.sh
@@ -5,7 +5,7 @@
 export KNATIVE_VERSION="v0.6.0"
 export TEKTON_VERSION="0.7.0"
 # Use "latest" or specify exact version/release: https://github.com/istio/istio/releases
-export ISTIO_VERSION="1.1.7"
+export ISTIO_VERSION="1.1.16"
 # Side car injection gets stuck in "Container Creating" state when disabled
 export ISTIO_SIDECAR_INJECTION="true"
 # To prevent Git Hub rate limiting when pulling latest Istio


### PR DESCRIPTION
Due to conclusions in issue: #238, docs and scripts have been updated to use Istio 1.1.16.