### PR TITLE
Webhook names can contain '0'

### DIFF
--- a/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
+++ b/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
@@ -23,7 +23,7 @@ function validateInputs(value, id) {
       return false;
     }
 
-    if (/[^-.a-z1-9]/.test(trimmed)) {
+    if (/[^-.a-z0-9]/.test(trimmed)) {
       return false;
     }
   }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
For: https://github.com/tektoncd/experimental/issues/314
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
One character change so that webhook names can include "0".
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
