### PR TITLE
Border Correction for Firefox

### DIFF
--- a/webhooks-extension/src/components/WebhookDisplayTable/WebhookDisplayTable.scss
+++ b/webhooks-extension/src/components/WebhookDisplayTable/WebhookDisplayTable.scss
@@ -11,7 +11,11 @@
   font-size: 1.25rem;
 }
 .table-container {
-  
+
+  table, .bx--data-table {
+    border-collapse: unset;
+  }
+
   .header {
     display: flex;
     align-items: center;


### PR DESCRIPTION
issue: #130 

# Changes
Apparently the bug was fixed when the `border-collapse` property was removed. 
*This change doesn't affect the page when viewed in Safari or Chrome*

# Before 
![Screen Shot 2019-10-31 at 4 59 44 PM](https://user-images.githubusercontent.com/49996607/67985748-e93f9000-fbff-11e9-90d2-75893e8687ac.png)

# After
![Screen Shot 2019-10-31 at 4 59 33 PM](https://user-images.githubusercontent.com/49996607/67985762-f0ff3480-fbff-11e9-947f-a8fa257da6ba.png)


