### PR TITLE
make monitor task timeout message configureable

### DIFF
--- a/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
@@ -193,6 +193,10 @@ spec:
         description: The text of the failure comment
         default: "Failed"
         type: string
+      - name: commenttimeout
+        description: The text of the timeout comment
+        default: "Unknown"
+        type: string
       - name: dashboard-url
         description: The URL to the pipelineruns page of the dashboard
         default: "http://localhost:9097/"
@@ -220,6 +224,8 @@ spec:
         value: $(inputs.params.commentsuccess)
       - name: COMMENT_FAILURE
         value: $(inputs.params.commentfailure)
+      - name: COMMENT_TIMEOUT
+        value: $(inputs.params.commenttimeout)
       - name: URL
         value: $(inputs.params.dashboard-url)
       # This can be deleted after any fix to the above mentioned pending status change
@@ -290,7 +296,7 @@ spec:
                 runsFailed.append("[**$COMMENT_FAILURE**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
                 continue
               link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
-              runsIncomplete.append("[**??????**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
+              runsIncomplete.append("[**$COMMENT_TIMEOUT**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
             if len(runsIncomplete) == 0:
               break
           else:
@@ -371,6 +377,10 @@ spec:
     description: The text of the failure comment
     default: "Failed"
     type: string
+  - name: commenttimeout
+    description: The text of the timeout comment
+    default: "Unknown"
+    type: string
   - name: dashboardurl
     description: The URL to the pipelineruns page of the dashboard
     default: "http://localhost:9097/"
@@ -404,6 +414,8 @@ spec:
           value: $(params.commentsuccess)
         - name: commentfailure
           value: $(params.commentfailure)
+        - name: commenttimeout
+          value: $(params.commenttimeout)
         - name: dashboard-url
           value: $(params.dashboardurl)
         - name: secret

--- a/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
@@ -303,6 +303,10 @@ spec:
         description: The text of the failure comment
         default: "Failed"
         type: string
+      - name: commenttimeout
+        description: The text of the timeout comment
+        default: "Unknown"
+        type: string
       - name: dashboard-url
         description: The URL to the pipelineruns page of the dashboard
         default: "http://localhost:9097/"
@@ -330,6 +334,8 @@ spec:
         value: $(inputs.params.commentsuccess)
       - name: COMMENT_FAILURE
         value: $(inputs.params.commentfailure)
+      - name: COMMENT_TIMEOUT
+        value: $(inputs.params.commenttimeout)
       - name: URL
         value: $(inputs.params.dashboard-url)
       # This can be deleted after any fix to the above mentioned pending status change
@@ -400,7 +406,7 @@ spec:
                 runsFailed.append("[**$COMMENT_FAILURE**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
                 continue
               link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
-              runsIncomplete.append("[**??????**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
+              runsIncomplete.append("[**$COMMENT_TIMEOUT**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
             if len(runsIncomplete) == 0:
               break
           else:
@@ -481,6 +487,10 @@ spec:
     description: The text of the failure comment
     default: "Failed"
     type: string
+  - name: commenttimeout
+    description: The text of the timeout comment
+    default: "Unknown"
+    type: string
   - name: dashboardurl
     description: The URL to the pipelineruns page of the dashboard
     default: "http://localhost:9097/"
@@ -515,6 +525,8 @@ spec:
           value: $(params.commentsuccess)
         - name: commentfailure
           value: $(params.commentfailure)
+        - name: commenttimeout
+          value: $(params.commenttimeout)
         - name: dashboard-url
           value: $(params.dashboardurl)
         - name: secret

--- a/webhooks-extension/config/monitor.yaml
+++ b/webhooks-extension/config/monitor.yaml
@@ -18,6 +18,10 @@ spec:
         description: The text of the failure comment
         default: "Failed"
         type: string
+      - name: commenttimeout
+        description: The text of the timeout comment
+        default: "Unknown"
+        type: string
       - name: dashboard-url
         description: The URL to the pipelineruns page of the dashboard
         default: "http://localhost:9097/"
@@ -45,6 +49,8 @@ spec:
         value: $(inputs.params.commentsuccess)
       - name: COMMENT_FAILURE
         value: $(inputs.params.commentfailure)
+      - name: COMMENT_TIMEOUT
+        value: $(inputs.params.commenttimeout)
       - name: URL
         value: $(inputs.params.dashboard-url)
       # This can be deleted after any fix to the above mentioned pending status change
@@ -115,7 +121,7 @@ spec:
                 runsFailed.append("[**$COMMENT_FAILURE**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
                 continue
               link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
-              runsIncomplete.append("[**??????**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
+              runsIncomplete.append("[**$COMMENT_TIMEOUT**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
             if len(runsIncomplete) == 0:
               break
           else:
@@ -196,6 +202,10 @@ spec:
     description: The text of the failure comment
     default: "Failed"
     type: string
+  - name: commenttimeout
+    description: The text of the timeout comment
+    default: "Unknown"
+    type: string
   - name: dashboardurl
     description: The URL to the pipelineruns page of the dashboard
     default: "http://localhost:9097/"
@@ -230,6 +240,8 @@ spec:
           value: $(params.commentsuccess)
         - name: commentfailure
           value: $(params.commentfailure)
+        - name: commenttimeout
+          value: $(params.commenttimeout)
         - name: dashboard-url
           value: $(params.dashboardurl)
         - name: secret

--- a/webhooks-extension/config/openshift-development/openshift-tekton-webhooks-extension-development.yaml
+++ b/webhooks-extension/config/openshift-development/openshift-tekton-webhooks-extension-development.yaml
@@ -305,6 +305,10 @@ spec:
         description: The text of the failure comment
         default: "Failed"
         type: string
+      - name: commenttimeout
+        description: The text of the timeout comment
+        default: "Unknown"
+        type: string
       - name: dashboard-url
         description: The URL to the pipelineruns page of the dashboard
         default: "http://localhost:9097/"
@@ -332,6 +336,8 @@ spec:
         value: $(inputs.params.commentsuccess)
       - name: COMMENT_FAILURE
         value: $(inputs.params.commentfailure)
+      - name: COMMENT_TIMEOUT
+        value: $(inputs.params.commenttimeout)
       - name: URL
         value: $(inputs.params.dashboard-url)
       # This can be deleted after any fix to the above mentioned pending status change
@@ -402,7 +408,7 @@ spec:
                 runsFailed.append("[**$COMMENT_FAILURE**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
                 continue
               link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
-              runsIncomplete.append("[**??????**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
+              runsIncomplete.append("[**$COMMENT_TIMEOUT**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
             if len(runsIncomplete) == 0:
               break
           else:
@@ -483,6 +489,10 @@ spec:
     description: The text of the failure comment
     default: "Failed"
     type: string
+  - name: commenttimeout
+    description: The text of the timeout comment
+    default: "Unknown"
+    type: string
   - name: dashboardurl
     description: The URL to the pipelineruns page of the dashboard
     default: "http://localhost:9097/"
@@ -517,6 +527,8 @@ spec:
           value: $(params.commentsuccess)
         - name: commentfailure
           value: $(params.commentfailure)
+        - name: commenttimeout
+          value: $(params.commenttimeout)
         - name: dashboard-url
           value: $(params.dashboardurl)
         - name: secret

--- a/webhooks-extension/config/openshift/openshift-tekton-webhooks-extension-release.yaml
+++ b/webhooks-extension/config/openshift/openshift-tekton-webhooks-extension-release.yaml
@@ -303,6 +303,10 @@ spec:
         description: The text of the failure comment
         default: "Failed"
         type: string
+      - name: commenttimeout
+        description: The text of the timeout comment
+        default: "Unknown"
+        type: string
       - name: dashboard-url
         description: The URL to the pipelineruns page of the dashboard
         default: "http://localhost:9097/"
@@ -330,6 +334,8 @@ spec:
         value: $(inputs.params.commentsuccess)
       - name: COMMENT_FAILURE
         value: $(inputs.params.commentfailure)
+      - name: COMMENT_TIMEOUT
+        value: $(inputs.params.commenttimeout)
       - name: URL
         value: $(inputs.params.dashboard-url)
       # This can be deleted after any fix to the above mentioned pending status change
@@ -400,7 +406,7 @@ spec:
                 runsFailed.append("[**$COMMENT_FAILURE**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
                 continue
               link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
-              runsIncomplete.append("[**??????**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
+              runsIncomplete.append("[**$COMMENT_TIMEOUT**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
             if len(runsIncomplete) == 0:
               break
           else:
@@ -481,6 +487,10 @@ spec:
     description: The text of the failure comment
     default: "Failed"
     type: string
+  - name: commenttimeout
+    description: The text of the timeout comment
+    default: "Unknown"
+    type: string
   - name: dashboardurl
     description: The URL to the pipelineruns page of the dashboard
     default: "http://localhost:9097/"
@@ -515,6 +525,8 @@ spec:
           value: $(params.commentsuccess)
         - name: commentfailure
           value: $(params.commentfailure)
+        - name: commenttimeout
+          value: $(params.commenttimeout)
         - name: dashboard-url
           value: $(params.dashboardurl)
         - name: secret

--- a/webhooks-extension/docs/CustomizingTheMonitor.md
+++ b/webhooks-extension/docs/CustomizingTheMonitor.md
@@ -22,9 +22,9 @@ If you have not installed into the tekton-pipelines namespace, you would need to
 
 ## Overriding The Status Message
 
-To change the "Success" and "Failed" status messages shown in the 'Tekton Status' comment added to the pull request, you can use the REST endpoint for creating your webhooks, rather than the UI.  Note however that the REST endpoints are only advised to be used in development, see [here](./DevelopmentAPIs.md).
+To change the "Success", "Failed" and "Unknown" status messages shown in the 'Tekton Status' comment added to the pull request, you can use the REST endpoint for creating your webhooks, rather than the UI.  Note however that the REST endpoints are only advised to be used in development, see [here](../DevelopmentAPIs.md).
 
-The body you POST to the REST endpoint has two properties, `onsuccesscomment` and `onfailurecomment` that define the value used in the Status column.  For example, creating the webhook using the JSON body:
+The body you POST to the REST endpoint has three properties, `onsuccesscomment`, `onfailurecomment` and `ontimeoutcomment` that define the value used in the Status column.  For example, creating the webhook using the JSON body:
 
 ```
 {
@@ -35,7 +35,8 @@ The body you POST to the REST endpoint has two properties, `onsuccesscomment` an
   "pipeline": "simple-pipeline",
   "dockerregistry": "FOO",
   "onsuccesscomment": "Erfolg",  <--------------------------------------------
-  "onfailurecomment": "Fehler"   <--------------------------------------------
+  "onfailurecomment": "Fehler",  <--------------------------------------------
+  "ontimeoutcomment": "Frozen"   <--------------------------------------------
 }
 ```
 
@@ -58,6 +59,7 @@ Using the REST endpoint directly, it is also possible to override the Task that 
   "dockerregistry": "FOO",
   "onsuccesscomment": "Erfolg",
   "onfailurecomment": "Fehler",
+  "ontimeoutcomment": "Frozen",
   "pulltask": "my-custom-task"   <--------------------------------------------
 }
 ```
@@ -71,6 +73,8 @@ In this situation, after the webhook is triggered and the PipelineRun created, a
       value: Erfolg
     - name: commentfailure
       value: Fehler
+    - name: commenttimeout
+      value: Frozen
     - name: secret
       value: GITHUBSECRET
 ```

--- a/webhooks-extension/docs/Monitoring.md
+++ b/webhooks-extension/docs/Monitoring.md
@@ -18,7 +18,7 @@ If the webhook is triggered due to a pull request being created (or updated with
 
 ![Error status on pull request](./images/errorStatus.png?raw=true "Error status shown on a GitHub pull request")
 
-5.  A comment is added to the pull request showing the result of the PipelineRun. The reported status operates as a hyperlink to the specific PipelineRun in the Tekton Dashboard, allowing you to quickly navigate to any relevant log files.  Note that `??????` as a status denotes that the PipelineRun had not completed before the monitor Task reached its maximum polling duration (30 mins).  
+5.  A comment is added to the pull request showing the result of the PipelineRun. The reported status operates as a hyperlink to the specific PipelineRun in the Tekton Dashboard, allowing you to quickly navigate to any relevant log files.  Note that `Unknown` as a status denotes that the PipelineRun had not completed before the monitor Task reached its maximum polling duration (30 mins).  
 
 ![PipelineRun status reporting](./images/comment.png?raw=true "PipelineRun status report as comment on GitHub pull request")
 

--- a/webhooks-extension/pkg/endpoints/types.go
+++ b/webhooks-extension/pkg/endpoints/types.go
@@ -88,6 +88,7 @@ type webhook struct {
 	PullTask         string `json:"pulltask,omitempty"`
 	OnSuccessComment string `json:"onsuccesscomment,omitempty"`
 	OnFailureComment string `json:"onfailurecomment,omitempty"`
+	OnTimeoutComment string `json:"ontimeoutcomment,omitempty"`
 }
 
 // ConfigMapName ... the name of the ConfigMap to create

--- a/webhooks-extension/pkg/endpoints/webhook.go
+++ b/webhooks-extension/pkg/endpoints/webhook.go
@@ -201,10 +201,15 @@ func (r Resource) getParams(webhook webhook) (webhookParams, monitorParams []pip
 	if onFailureComment == "" {
 		onFailureComment = "Failed"
 	}
+	onTimeoutComment := webhook.OnTimeoutComment
+	if onTimeoutComment == "" {
+		onTimeoutComment = "Unknown"
+	}
 
 	prMonitorParams := []pipelinesv1alpha1.Param{
 		{Name: "commentsuccess", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: onSuccessComment}},
 		{Name: "commentfailure", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: onFailureComment}},
+		{Name: "commenttimeout", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: onTimeoutComment}},
 		{Name: "gitsecretname", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: webhook.AccessTokenRef}},
 		{Name: "gitsecretkeyname", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "accessToken"}},
 		{Name: "dashboardurl", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: r.getDashboardURL(r.Defaults.Namespace)}},

--- a/webhooks-extension/pkg/endpoints/webhook_test.go
+++ b/webhooks-extension/pkg/endpoints/webhook_test.go
@@ -116,6 +116,7 @@ func TestGetParams(t *testing.T) {
 			PullTask:         "pulltask1",
 			OnSuccessComment: "onsuccesscomment1",
 			OnFailureComment: "onfailurecomment1",
+			OnTimeoutComment: "ontimeoutcomment1",
 		},
 		{
 			Name:             "name2",
@@ -126,6 +127,7 @@ func TestGetParams(t *testing.T) {
 			DockerRegistry:   "registry2",
 			OnSuccessComment: "onsuccesscomment2",
 			OnFailureComment: "onfailurecomment2",
+			OnTimeoutComment: "ontimeoutcomment2",
 		},
 		{
 			Name:             "name3",
@@ -168,6 +170,7 @@ func TestCreateEventListener(t *testing.T) {
 			PullTask:         "pulltask1",
 			OnSuccessComment: "onsuccesscomment1",
 			OnFailureComment: "onfailurecomment1",
+			OnTimeoutComment: "ontimeoutcomment1",
 		},
 		{
 			Name:             "name2",
@@ -178,6 +181,7 @@ func TestCreateEventListener(t *testing.T) {
 			DockerRegistry:   "registry2",
 			OnSuccessComment: "onsuccesscomment2",
 			OnFailureComment: "onfailurecomment2",
+			OnTimeoutComment: "ontimeoutcomment2",
 		},
 		{
 			Name:             "name3",
@@ -238,6 +242,7 @@ func TestUpdateEventListenerTriggerListing(t *testing.T) {
 			PullTask:         "pulltask1",
 			OnSuccessComment: "onsuccesscomment1",
 			OnFailureComment: "onfailurecomment1",
+			OnTimeoutComment: "ontimeoutcomment1",
 		},
 		{
 			Name:             "name2",
@@ -248,6 +253,7 @@ func TestUpdateEventListenerTriggerListing(t *testing.T) {
 			DockerRegistry:   "registry2",
 			OnSuccessComment: "onsuccesscomment2",
 			OnFailureComment: "onfailurecomment2",
+			OnTimeoutComment: "ontimeoutcomment2",
 		},
 		{
 			Name:             "name3",
@@ -323,6 +329,7 @@ func TestDeleteFromEventListener(t *testing.T) {
 			PullTask:         "pulltask1",
 			OnSuccessComment: "onsuccesscomment1",
 			OnFailureComment: "onfailurecomment1",
+			OnTimeoutComment: "ontimeoutcomment1",
 		},
 		{
 			Name:             "name2",
@@ -333,6 +340,7 @@ func TestDeleteFromEventListener(t *testing.T) {
 			DockerRegistry:   "registry2",
 			OnSuccessComment: "onsuccesscomment2",
 			OnFailureComment: "onfailurecomment2",
+			OnTimeoutComment: "ontimeoutcomment2",
 		},
 	}
 
@@ -412,6 +420,7 @@ func TestCreateAndDeleteWebhook(t *testing.T) {
 			ReleaseName:      "releasename1",
 			OnSuccessComment: "onsuccesscomment1",
 			OnFailureComment: "onfailurecomment1",
+			OnTimeoutComment: "ontimeoutcomment1",
 		},
 		{
 			Name:             "name2",
@@ -422,6 +431,7 @@ func TestCreateAndDeleteWebhook(t *testing.T) {
 			DockerRegistry:   "registry2",
 			OnSuccessComment: "onsuccesscomment2",
 			OnFailureComment: "onfailurecomment2",
+			OnTimeoutComment: "ontimeoutcomment2",
 		},
 		{
 			Name:             "name3",
@@ -575,6 +585,11 @@ func getExpectedParams(hook webhook, r *Resource) (expectedHookParams, expectedM
 		expectedMonitorParams = append(expectedMonitorParams, pipelinesv1alpha1.Param{Name: "commentfailure", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: hook.OnFailureComment}})
 	} else {
 		expectedMonitorParams = append(expectedMonitorParams, pipelinesv1alpha1.Param{Name: "commentfailure", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "Failed"}})
+	}
+	if hook.OnTimeoutComment != "" {
+		expectedMonitorParams = append(expectedMonitorParams, pipelinesv1alpha1.Param{Name: "commenttimeout", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: hook.OnTimeoutComment}})
+	} else {
+		expectedMonitorParams = append(expectedMonitorParams, pipelinesv1alpha1.Param{Name: "commenttimeout", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "Unknown"}})
 	}
 	expectedMonitorParams = append(expectedMonitorParams, pipelinesv1alpha1.Param{Name: "gitsecretname", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: hook.AccessTokenRef}})
 	expectedMonitorParams = append(expectedMonitorParams, pipelinesv1alpha1.Param{Name: "gitsecretkeyname", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "accessToken"}})


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This PR is for https://github.com/tektoncd/experimental/issues/220

make monitor task timeout message configureable

```
      - name: commenttimeout
        description: The text of the timeout comment
        default: "Unknown"
```
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
