### PR TITLE
copy original .manifest files to output directory for pipeline 0.8

### DIFF
--- a/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
@@ -335,8 +335,7 @@ spec:
       if not os.path.exists("/workspace/output/pull-request/"):
         os.makedirs("/workspace/output/pull-request/")
       if not os.path.exists("/workspace/output/pull-request/labels"):
-        os.makedirs("/workspace/output/pull-request/labels")
-        shutil.copyfile("/workspace/pull-request/labels/.MANIFEST","/workspace/output/pull-request/labels/.MANIFEST")
+        shutil.copytree("/workspace/pull-request/labels","/workspace/output/pull-request/labels")
       shutil.copyfile("/workspace/pull-request/base.json","/workspace/output/pull-request/base.json") 
       shutil.copyfile("/workspace/pull-request/head.json","/workspace/output/pull-request/head.json") 
       EOF

--- a/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
@@ -317,6 +317,7 @@ spec:
                  ) + "\n".join(results)
       if not os.path.exists("/workspace/output/pull-request/comments"):
         os.makedirs("/workspace/output/pull-request/comments")
+        shutil.copyfile("/workspace/pull-request/comments/.MANIFEST","/workspace/output/pull-request/comments/.MANIFEST")
       handle = open("/workspace/output/pull-request/comments/newcomment.json", 'w')
       handle.write(comment)
       handle.close()
@@ -331,10 +332,11 @@ spec:
       handle = open("/workspace/output/pull-request/status/Tekton.json", 'w')
       handle.write(status)
       handle.close()
-      if not os.path.exists("/workspace/output/pull-request/labels"):
-        os.makedirs("/workspace/output/pull-request/labels")
       if not os.path.exists("/workspace/output/pull-request/"):
         os.makedirs("/workspace/output/pull-request/")
+      if not os.path.exists("/workspace/output/pull-request/labels"):
+        os.makedirs("/workspace/output/pull-request/labels")
+        shutil.copyfile("/workspace/pull-request/labels/.MANIFEST","/workspace/output/pull-request/labels/.MANIFEST")
       shutil.copyfile("/workspace/pull-request/base.json","/workspace/output/pull-request/base.json") 
       shutil.copyfile("/workspace/pull-request/head.json","/workspace/output/pull-request/head.json") 
       EOF

--- a/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
@@ -427,6 +427,7 @@ spec:
                  ) + "\n".join(results)
       if not os.path.exists("/workspace/output/pull-request/comments"):
         os.makedirs("/workspace/output/pull-request/comments")
+        shutil.copyfile("/workspace/pull-request/comments/.MANIFEST","/workspace/output/pull-request/comments/.MANIFEST")
       handle = open("/workspace/output/pull-request/comments/newcomment.json", 'w')
       handle.write(comment)
       handle.close()
@@ -441,10 +442,11 @@ spec:
       handle = open("/workspace/output/pull-request/status/Tekton.json", 'w')
       handle.write(status)
       handle.close()
-      if not os.path.exists("/workspace/output/pull-request/labels"):
-        os.makedirs("/workspace/output/pull-request/labels")
       if not os.path.exists("/workspace/output/pull-request/"):
         os.makedirs("/workspace/output/pull-request/")
+      if not os.path.exists("/workspace/output/pull-request/labels"):
+        os.makedirs("/workspace/output/pull-request/labels")
+        shutil.copyfile("/workspace/pull-request/labels/.MANIFEST","/workspace/output/pull-request/labels/.MANIFEST")
       shutil.copyfile("/workspace/pull-request/base.json","/workspace/output/pull-request/base.json") 
       shutil.copyfile("/workspace/pull-request/head.json","/workspace/output/pull-request/head.json") 
       EOF

--- a/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
@@ -445,8 +445,7 @@ spec:
       if not os.path.exists("/workspace/output/pull-request/"):
         os.makedirs("/workspace/output/pull-request/")
       if not os.path.exists("/workspace/output/pull-request/labels"):
-        os.makedirs("/workspace/output/pull-request/labels")
-        shutil.copyfile("/workspace/pull-request/labels/.MANIFEST","/workspace/output/pull-request/labels/.MANIFEST")
+        shutil.copytree("/workspace/pull-request/labels","/workspace/output/pull-request/labels")
       shutil.copyfile("/workspace/pull-request/base.json","/workspace/output/pull-request/base.json") 
       shutil.copyfile("/workspace/pull-request/head.json","/workspace/output/pull-request/head.json") 
       EOF

--- a/webhooks-extension/config/monitor.yaml
+++ b/webhooks-extension/config/monitor.yaml
@@ -160,8 +160,7 @@ spec:
       if not os.path.exists("/workspace/output/pull-request/"):
         os.makedirs("/workspace/output/pull-request/")
       if not os.path.exists("/workspace/output/pull-request/labels"):
-        os.makedirs("/workspace/output/pull-request/labels")
-        shutil.copyfile("/workspace/pull-request/labels/.MANIFEST","/workspace/output/pull-request/labels/.MANIFEST")
+        shutil.copytree("/workspace/pull-request/labels","/workspace/output/pull-request/labels")
       shutil.copyfile("/workspace/pull-request/base.json","/workspace/output/pull-request/base.json") 
       shutil.copyfile("/workspace/pull-request/head.json","/workspace/output/pull-request/head.json") 
       EOF

--- a/webhooks-extension/config/monitor.yaml
+++ b/webhooks-extension/config/monitor.yaml
@@ -142,6 +142,7 @@ spec:
                  ) + "\n".join(results)
       if not os.path.exists("/workspace/output/pull-request/comments"):
         os.makedirs("/workspace/output/pull-request/comments")
+        shutil.copyfile("/workspace/pull-request/comments/.MANIFEST","/workspace/output/pull-request/comments/.MANIFEST")
       handle = open("/workspace/output/pull-request/comments/newcomment.json", 'w')
       handle.write(comment)
       handle.close()
@@ -156,10 +157,11 @@ spec:
       handle = open("/workspace/output/pull-request/status/Tekton.json", 'w')
       handle.write(status)
       handle.close()
-      if not os.path.exists("/workspace/output/pull-request/labels"):
-        os.makedirs("/workspace/output/pull-request/labels")
       if not os.path.exists("/workspace/output/pull-request/"):
         os.makedirs("/workspace/output/pull-request/")
+      if not os.path.exists("/workspace/output/pull-request/labels"):
+        os.makedirs("/workspace/output/pull-request/labels")
+        shutil.copyfile("/workspace/pull-request/labels/.MANIFEST","/workspace/output/pull-request/labels/.MANIFEST")
       shutil.copyfile("/workspace/pull-request/base.json","/workspace/output/pull-request/base.json") 
       shutil.copyfile("/workspace/pull-request/head.json","/workspace/output/pull-request/head.json") 
       EOF

--- a/webhooks-extension/config/openshift-development/openshift-tekton-webhooks-extension-development.yaml
+++ b/webhooks-extension/config/openshift-development/openshift-tekton-webhooks-extension-development.yaml
@@ -447,8 +447,7 @@ spec:
       if not os.path.exists("/workspace/output/pull-request/"):
         os.makedirs("/workspace/output/pull-request/")
       if not os.path.exists("/workspace/output/pull-request/labels"):
-        os.makedirs("/workspace/output/pull-request/labels")
-        shutil.copyfile("/workspace/pull-request/labels/.MANIFEST","/workspace/output/pull-request/labels/.MANIFEST")
+        shutil.copytree("/workspace/pull-request/labels","/workspace/output/pull-request/labels")
       shutil.copyfile("/workspace/pull-request/base.json","/workspace/output/pull-request/base.json") 
       shutil.copyfile("/workspace/pull-request/head.json","/workspace/output/pull-request/head.json") 
       EOF

--- a/webhooks-extension/config/openshift-development/openshift-tekton-webhooks-extension-development.yaml
+++ b/webhooks-extension/config/openshift-development/openshift-tekton-webhooks-extension-development.yaml
@@ -429,6 +429,7 @@ spec:
                  ) + "\n".join(results)
       if not os.path.exists("/workspace/output/pull-request/comments"):
         os.makedirs("/workspace/output/pull-request/comments")
+        shutil.copyfile("/workspace/pull-request/comments/.MANIFEST","/workspace/output/pull-request/comments/.MANIFEST")
       handle = open("/workspace/output/pull-request/comments/newcomment.json", 'w')
       handle.write(comment)
       handle.close()
@@ -443,10 +444,11 @@ spec:
       handle = open("/workspace/output/pull-request/status/Tekton.json", 'w')
       handle.write(status)
       handle.close()
-      if not os.path.exists("/workspace/output/pull-request/labels"):
-        os.makedirs("/workspace/output/pull-request/labels")
       if not os.path.exists("/workspace/output/pull-request/"):
         os.makedirs("/workspace/output/pull-request/")
+      if not os.path.exists("/workspace/output/pull-request/labels"):
+        os.makedirs("/workspace/output/pull-request/labels")
+        shutil.copyfile("/workspace/pull-request/labels/.MANIFEST","/workspace/output/pull-request/labels/.MANIFEST")
       shutil.copyfile("/workspace/pull-request/base.json","/workspace/output/pull-request/base.json") 
       shutil.copyfile("/workspace/pull-request/head.json","/workspace/output/pull-request/head.json") 
       EOF

--- a/webhooks-extension/config/openshift/openshift-tekton-webhooks-extension-release.yaml
+++ b/webhooks-extension/config/openshift/openshift-tekton-webhooks-extension-release.yaml
@@ -427,6 +427,7 @@ spec:
                  ) + "\n".join(results)
       if not os.path.exists("/workspace/output/pull-request/comments"):
         os.makedirs("/workspace/output/pull-request/comments")
+        shutil.copyfile("/workspace/pull-request/comments/.MANIFEST","/workspace/output/pull-request/comments/.MANIFEST")
       handle = open("/workspace/output/pull-request/comments/newcomment.json", 'w')
       handle.write(comment)
       handle.close()
@@ -441,10 +442,11 @@ spec:
       handle = open("/workspace/output/pull-request/status/Tekton.json", 'w')
       handle.write(status)
       handle.close()
-      if not os.path.exists("/workspace/output/pull-request/labels"):
-        os.makedirs("/workspace/output/pull-request/labels")
       if not os.path.exists("/workspace/output/pull-request/"):
         os.makedirs("/workspace/output/pull-request/")
+      if not os.path.exists("/workspace/output/pull-request/labels"):
+        os.makedirs("/workspace/output/pull-request/labels")
+        shutil.copyfile("/workspace/pull-request/labels/.MANIFEST","/workspace/output/pull-request/labels/.MANIFEST")
       shutil.copyfile("/workspace/pull-request/base.json","/workspace/output/pull-request/base.json") 
       shutil.copyfile("/workspace/pull-request/head.json","/workspace/output/pull-request/head.json") 
       EOF

--- a/webhooks-extension/config/openshift/openshift-tekton-webhooks-extension-release.yaml
+++ b/webhooks-extension/config/openshift/openshift-tekton-webhooks-extension-release.yaml
@@ -445,8 +445,7 @@ spec:
       if not os.path.exists("/workspace/output/pull-request/"):
         os.makedirs("/workspace/output/pull-request/")
       if not os.path.exists("/workspace/output/pull-request/labels"):
-        os.makedirs("/workspace/output/pull-request/labels")
-        shutil.copyfile("/workspace/pull-request/labels/.MANIFEST","/workspace/output/pull-request/labels/.MANIFEST")
+        shutil.copytree("/workspace/pull-request/labels","/workspace/output/pull-request/labels")
       shutil.copyfile("/workspace/pull-request/base.json","/workspace/output/pull-request/base.json") 
       shutil.copyfile("/workspace/pull-request/head.json","/workspace/output/pull-request/head.json") 
       EOF


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This PR is for https://github.com/tektoncd/experimental/issues/334

The `.MANIFEST` files in the `labels` and `comments` directories are copied into the directories under `output` directory for the pullrequest pipeline resource.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
