### PR TITLE
Issue #363: Fix "No such file or directory" error for the .MANIFEST file during monitor

### DIFF
--- a/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
@@ -317,7 +317,8 @@ spec:
                  ) + "\n".join(results)
       if not os.path.exists("/workspace/output/pull-request/comments"):
         os.makedirs("/workspace/output/pull-request/comments")
-        shutil.copyfile("/workspace/pull-request/comments/.MANIFEST","/workspace/output/pull-request/comments/.MANIFEST")
+        if os.path.exists("/workspace/pull-request/comments/.MANIFEST"):
+         shutil.copyfile("/workspace/pull-request/comments/.MANIFEST","/workspace/output/pull-request/comments/.MANIFEST")
       handle = open("/workspace/output/pull-request/comments/newcomment.json", 'w')
       handle.write(comment)
       handle.close()

--- a/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
@@ -427,7 +427,8 @@ spec:
                  ) + "\n".join(results)
       if not os.path.exists("/workspace/output/pull-request/comments"):
         os.makedirs("/workspace/output/pull-request/comments")
-        shutil.copyfile("/workspace/pull-request/comments/.MANIFEST","/workspace/output/pull-request/comments/.MANIFEST")
+        if os.path.exists("/workspace/pull-request/comments/.MANIFEST"):
+          shutil.copyfile("/workspace/pull-request/comments/.MANIFEST","/workspace/output/pull-request/comments/.MANIFEST")
       handle = open("/workspace/output/pull-request/comments/newcomment.json", 'w')
       handle.write(comment)
       handle.close()

--- a/webhooks-extension/config/monitor.yaml
+++ b/webhooks-extension/config/monitor.yaml
@@ -142,7 +142,8 @@ spec:
                  ) + "\n".join(results)
       if not os.path.exists("/workspace/output/pull-request/comments"):
         os.makedirs("/workspace/output/pull-request/comments")
-        shutil.copyfile("/workspace/pull-request/comments/.MANIFEST","/workspace/output/pull-request/comments/.MANIFEST")
+        if os.path.exists("/workspace/pull-request/comments/.MANIFEST"):
+          shutil.copyfile("/workspace/pull-request/comments/.MANIFEST","/workspace/output/pull-request/comments/.MANIFEST")
       handle = open("/workspace/output/pull-request/comments/newcomment.json", 'w')
       handle.write(comment)
       handle.close()

--- a/webhooks-extension/config/openshift-development/openshift-tekton-webhooks-extension-development.yaml
+++ b/webhooks-extension/config/openshift-development/openshift-tekton-webhooks-extension-development.yaml
@@ -429,7 +429,8 @@ spec:
                  ) + "\n".join(results)
       if not os.path.exists("/workspace/output/pull-request/comments"):
         os.makedirs("/workspace/output/pull-request/comments")
-        shutil.copyfile("/workspace/pull-request/comments/.MANIFEST","/workspace/output/pull-request/comments/.MANIFEST")
+        if os.path.exists("/workspace/pull-request/comments/.MANIFEST"):
+          shutil.copyfile("/workspace/pull-request/comments/.MANIFEST","/workspace/output/pull-request/comments/.MANIFEST")
       handle = open("/workspace/output/pull-request/comments/newcomment.json", 'w')
       handle.write(comment)
       handle.close()

--- a/webhooks-extension/config/openshift/openshift-tekton-webhooks-extension-release.yaml
+++ b/webhooks-extension/config/openshift/openshift-tekton-webhooks-extension-release.yaml
@@ -427,7 +427,8 @@ spec:
                  ) + "\n".join(results)
       if not os.path.exists("/workspace/output/pull-request/comments"):
         os.makedirs("/workspace/output/pull-request/comments")
-        shutil.copyfile("/workspace/pull-request/comments/.MANIFEST","/workspace/output/pull-request/comments/.MANIFEST")
+        if os.path.exists("/workspace/pull-request/comments/.MANIFEST"):
+          shutil.copyfile("/workspace/pull-request/comments/.MANIFEST","/workspace/output/pull-request/comments/.MANIFEST")
       handle = open("/workspace/output/pull-request/comments/newcomment.json", 'w')
       handle.write(comment)
       handle.close()


### PR DESCRIPTION
# Changes

To work with both v0.7 and v0.8 of pipelines, an additional if statement has been added to only copy the /workspace/pull-request/comments/.MANIFEST file if it exists. (Fixes Issue #363)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
