### PR TITLE
Adds correct validation for webhook name length

### DIFF
--- a/webhooks-extension/config/extension-service.yaml
+++ b/webhooks-extension/config/extension-service.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.ce910735.js"
+    tekton-dashboard-bundle-location: "web/extension.1045ddf4.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
@@ -164,7 +164,7 @@ metadata:
   annotations:
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.ce910735.js"
+    tekton-dashboard-bundle-location: "web/extension.1045ddf4.js"
 spec:
   type: NodePort
   ports:

--- a/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
@@ -266,7 +266,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    tekton-dashboard-bundle-location: web/extension.ce910735.js
+    tekton-dashboard-bundle-location: web/extension.1045ddf4.js
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: webhooks.web
   labels:

--- a/webhooks-extension/config/openshift-development/openshift-tekton-webhooks-extension-development.yaml
+++ b/webhooks-extension/config/openshift-development/openshift-tekton-webhooks-extension-development.yaml
@@ -268,7 +268,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    tekton-dashboard-bundle-location: web/extension.ce910735.js
+    tekton-dashboard-bundle-location: web/extension.1045ddf4.js
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: webhooks.web
   labels:

--- a/webhooks-extension/config/openshift/openshift-tekton-webhooks-extension-release.yaml
+++ b/webhooks-extension/config/openshift/openshift-tekton-webhooks-extension-release.yaml
@@ -266,7 +266,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    tekton-dashboard-bundle-location: web/extension.ce910735.js
+    tekton-dashboard-bundle-location: web/extension.1045ddf4.js
     tekton-dashboard-display-name: Webhooks
     tekton-dashboard-endpoints: webhooks.web
   labels:

--- a/webhooks-extension/pkg/endpoints/webhook.go
+++ b/webhooks-extension/pkg/endpoints/webhook.go
@@ -42,6 +42,7 @@ var (
 	modifyingConfigMapLock sync.Mutex
 	actions = pipelinesv1alpha1.Param{Name: "Wext-Incoming-Actions", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "opened,reopened,synchronize"}}
 )
+
 const eventListenerName = "tekton-webhooks-eventlistener"
 
 /*
@@ -336,9 +337,9 @@ func (r Resource) createWebhook(request *restful.Request, response *restful.Resp
 		webhook.PullTask = "monitor-task"
 	}
 
-	if webhook.ReleaseName != "" {
-		if len(webhook.ReleaseName) > 63 {
-			tooLongMessage := fmt.Sprintf("requested release name (%s) must be less than 64 characters", webhook.ReleaseName)
+	if webhook.Name != "" {
+		if len(webhook.Name) > 57 {
+			tooLongMessage := fmt.Sprintf("requested release name (%s) must be less than 58 characters", webhook.Name)
 			err := errors.New(tooLongMessage)
 			logging.Log.Errorf("error: %s", err.Error())
 			RespondError(response, err, http.StatusBadRequest)

--- a/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
+++ b/webhooks-extension/src/components/WebhookCreate/WebhookCreate.js
@@ -20,7 +20,7 @@ function validateInputs(value, id) {
   }
 
   if (id === "name" || id === "newSecretName") {
-    if (trimmed.length > 253) {
+    if (trimmed.length > 57) {
       return false;
     }
 
@@ -550,7 +550,7 @@ class WebhookCreatePage extends Component {
                     labelText="Display Name"
                     data-testid="display-name-entry"
                     invalid={invalidFields.indexOf('name') > -1}
-                    invalidText="Must be less than 563 characters, contain only lowercase alphanumeric character, . or - ."
+                    invalidText="Must be fewer than 58 characters, contain only lowercase alphanumeric characters, . or - ."
                   />
                 </div>
               </div>


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
For Kabanero Issue: https://github.com/kabanero-io/kabanero-foundation/issues/135

Restricts webhook names to be no more than 57 characters (or 63 including the name extension).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
