### PR TITLE
TLS certificate is added to the ingress for the eventlistener

### DIFF
--- a/webhooks-extension/Gopkg.lock
+++ b/webhooks-extension/Gopkg.lock
@@ -165,14 +165,6 @@
   revision = "81af80346b1a01caae0cbc27fd3c1ba5b11e189f"
 
 [[projects]]
-  digest = "1:53bc4cd4914cd7cd52139990d5170d6dc99067ae31c56530621b18b35fc30318"
-  name = "github.com/mitchellh/mapstructure"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
-  version = "v1.1.2"
-
-[[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
@@ -239,8 +231,8 @@
   name = "github.com/tektoncd/dashboard"
   packages = ["pkg/logging"]
   pruneopts = "UT"
-  revision = "422a0282c2460ae66a9f3e9ca4f95e5ae48b30b4"
-  version = "v0.5.0"
+  revision = "31643951bc8207be7ab0901c2e56ccd8b63fed4d"
+  version = "v0.5.1"
 
 [[projects]]
   digest = "1:a9cf10d8d7b29c2ec35f745361a7679ab14c4efcae2a595af0baa948b088a1c4"
@@ -614,7 +606,7 @@
   version = "kubernetes-1.13.4"
 
 [[projects]]
-  digest = "1:bed5739a1e0698e3b456a40737195c0357f52ba0cc4d84c64fe9031b3ef292bc"
+  digest = "1:48d6d79415e27c7e0ed9863806a10ff5630c8fe151ae114b178a9a3cb3eb30b7"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -774,9 +766,11 @@
     "tools/metrics",
     "tools/pager",
     "tools/reference",
+    "tools/watch",
     "transport",
     "util/buffer",
     "util/cert",
+    "util/certificate/csr",
     "util/connrotation",
     "util/flowcontrol",
     "util/integer",
@@ -835,7 +829,6 @@
     "github.com/emicklei/go-restful",
     "github.com/google/go-cmp/cmp",
     "github.com/google/go-github/github",
-    "github.com/mitchellh/mapstructure",
     "github.com/openshift/api/route/v1",
     "github.com/openshift/client-go/route/clientset/versioned",
     "github.com/openshift/client-go/route/clientset/versioned/fake",
@@ -849,17 +842,17 @@
     "github.com/xanzy/go-gitlab",
     "go.uber.org/zap",
     "golang.org/x/oauth2",
+    "k8s.io/api/certificates/v1beta1",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
-    "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/rest",
-    "k8s.io/client-go/testing",
-    "knative.dev/pkg/apis",
+    "k8s.io/client-go/util/cert",
+    "k8s.io/client-go/util/certificate/csr",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/webhooks-extension/docs/InstallNightlyBuild.md
+++ b/webhooks-extension/docs/InstallNightlyBuild.md
@@ -34,8 +34,9 @@ Note: If you want to install into an alternative namespace you would need to mod
 
       - Open overlays/plainkube-all/deployment-patch.yaml.
       - Find WEBHOOK_CALLBACK_URL.
-      - Edit the value - this could simply be a case of replacing IPADDRESS with your actual value.  If the call back URL is not determined yet in Amazon EKS environment, replace IPADDRESS with a dummy address.  It will be replaced in the step in the [Getting Started](https://github.com/tektoncd/experimental/blob/master/webhooks-extension/docs/GettingStarted.md) guide.
-  3. Apply the yaml
+      - Edit the value - this could simply be a case of replacing IPADDRESS with your actual value.  If WEBHOOK_CALLBACK_URL protocol is https, ssl verification will be enabled on the github webhook and the TLS certificate secret set in WEBHOOK_TLS_CERTIFICATE is used in the ingress. If WEBHOOK_TLS_CERTIFICATE is not defined or the secret doesn't exit, the certificate signed by the platform certificate is created and used in the ingress.  If the platform certificate is not issued by the certificate authority, the SSL verification option in the github webhook must be disabled manually.  If the call back URL is not determined yet in Amazon EKS environment, replace IPADDRESS with a dummy address.  It will be replaced in the step in the [Getting Started](https://github.com/tektoncd/experimental/blob/master/webhooks-extension/docs/GettingStarted.md) guide.
+
+  4. Apply the yaml
 
       _On Red Hat OpenShift:_
 

--- a/webhooks-extension/docs/InstallReleaseBuild.md
+++ b/webhooks-extension/docs/InstallReleaseBuild.md
@@ -30,8 +30,7 @@ If the Tekton Dashboard has been installed into a namespace other than "tekton-p
     _On other Kubernetes environments:_
 
     Use the following command, replacing `YOUR_IP_ADDRESS` with your docker-desktop system's IP address.  Note that in
-    production you should clone the repository and update the WEBHOOK_CALLBACK_URL setting to avoid using nip.io for host resolution.
-    If the call back URL is not determined yet in Amazon EKS environment, replace YOUR_IP_ADDRESS with a dummy address.  It will be replaced in the step in the [Getting Started](https://github.com/tektoncd/experimental/blob/master/webhooks-extension/docs/GettingStarted.md) guide.
+    production you should clone the repository and update the WEBHOOK_CALLBACK_URL setting to avoid using nip.io for host resolution.  If WEBHOOK_CALLBACK_URL protocol is https, ssl verification will be enabled on the github webhook and the TLS certificate secret set in WEBHOOK_TLS_CERTIFICATE is used in the ingress. If WEBHOOK_TLS_CERTIFICATE is not defined or the secret doesn't exit, the certificate signed by the platform certificate is created and used in the ingress.  If the platform certificate is not issued by the certificate authority, the SSL verification option in the github webhook must be disabled manually.  If the call back URL is not determined yet in Amazon EKS environment, replace YOUR_IP_ADDRESS with a dummy address.  It will be replaced in the step in the [Getting Started](https://github.com/tektoncd/experimental/blob/master/webhooks-extension/docs/GettingStarted.md) guide.
 
     ```bash
     curl -L https://github.com/tektoncd/dashboard/releases/latest/download/webhooks-extension_release.yaml \


### PR DESCRIPTION
This PR for https://github.com/tektoncd/experimental/issues/279

when the callback URL has "https" protocol.
The name of the TLS certificate secret can be specified in WEBHOOK_TLS_CERTIFICATE
environment variable.  The default is "cert-" + eventlistener name.
When the secret doesn't exit with the name, the new certificate secret
is created and the certificate is signed by the framework.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
