### PR TITLE
Issue 375: Fix for org repositories not triggering pipelineruns

### DIFF
--- a/webhooks-extension/cmd/interceptor/interceptor.go
+++ b/webhooks-extension/cmd/interceptor/interceptor.go
@@ -39,7 +39,7 @@ type Result struct {
 }
 
 type PushPayload struct {
-	github.WebHookPayload
+	github.PushEvent
 	WebhookBranch string `json:"webhooks-tekton-git-branch"`
 }
 
@@ -173,14 +173,14 @@ func main() {
 func addBranchToPayload(event string, payload []byte) ([]byte, error) {
 	if "push" == event {
 		var toReturn PushPayload
-		var p github.WebHookPayload
+		var p github.PushEvent
 		err := json.Unmarshal(payload, &p)
 		if err != nil {
 			return nil, err
 		}
 		toReturn = PushPayload{
-			WebHookPayload: p,
-			WebhookBranch:  p.GetRef()[strings.LastIndex(p.GetRef(), "/")+1:],
+			PushEvent:     p,
+			WebhookBranch: p.GetRef()[strings.LastIndex(p.GetRef(), "/")+1:],
 		}
 		return json.Marshal(toReturn)
 	} else if "pull_request" == event {

--- a/webhooks-extension/cmd/interceptor/interceptor_test.go
+++ b/webhooks-extension/cmd/interceptor/interceptor_test.go
@@ -22,7 +22,7 @@ import (
 func TestAddBranchToPushPayload(t *testing.T) {
 
 	ref := "refs/head/master"
-	pushPayloadStruct := github.WebHookPayload{
+	pushPayloadStruct := github.PushEvent{
 		Ref: &ref,
 	}
 	payload, err := json.Marshal(pushPayloadStruct)


### PR DESCRIPTION
For #375
# Changes

Changed the interceptor to unmarshal the push event webhook payload into a go-github PushEvent rather than the incorrect WebhookPayload.

This now avoids the error: cannot unmarshal string into Go struct field Repository.organization of type github.Organization

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
