### PR TITLE
Add a suggested image tag to the webhook event payload

### DIFF
--- a/webhooks-extension/cmd/interceptor/interceptor_test.go
+++ b/webhooks-extension/cmd/interceptor/interceptor_test.go
@@ -19,18 +19,22 @@ import (
 	"testing"
 )
 
-func TestAddBranchToPushPayload(t *testing.T) {
+func TestAddExtrasToPushPayload(t *testing.T) {
 
 	ref := "refs/head/master"
+	commit := "12dee2323r2ef232ef2redw2"
 	pushPayloadStruct := github.PushEvent{
 		Ref: &ref,
+		HeadCommit: &github.PushEventCommit{
+			ID: &commit,
+		},
 	}
 	payload, err := json.Marshal(pushPayloadStruct)
 	if err != nil {
 		t.Errorf("Error in json.Marshal(pushPayloadStruct) %s", err)
 	}
 
-	bytes, err := addBranchToPayload("push", payload)
+	bytes, err := addExtrasToPayload("push", payload)
 	if err != nil {
 		t.Errorf("Error in addBranchToPayload %s", err)
 	}
@@ -44,16 +48,55 @@ func TestAddBranchToPushPayload(t *testing.T) {
 	if "master" != p.WebhookBranch {
 		t.Errorf("Branch name not added as expected, branch was returned as %s", p.WebhookBranch)
 	}
-
+	if "12dee23" != p.WebhookSuggestedImageTag {
+		t.Errorf("Suggested image tag not added as expected, tag was returned as %s", p.WebhookSuggestedImageTag)
+	}
 }
 
-func TestAddBranchToPullRequestPayload(t *testing.T) {
+func TestAddExtrasToPushPayloadForTag(t *testing.T) {
 
-	ref := "refs/head/master"
+	ref := "refs/tags/v1.0.1"
+	commit := "12dee2323r2ef232ef2redw2"
+	pushPayloadStruct := github.PushEvent{
+		Ref: &ref,
+		HeadCommit: &github.PushEventCommit{
+			ID: &commit,
+		},
+	}
+	payload, err := json.Marshal(pushPayloadStruct)
+	if err != nil {
+		t.Errorf("Error in json.Marshal(pushPayloadStruct) %s", err)
+	}
+
+	bytes, err := addExtrasToPayload("push", payload)
+	if err != nil {
+		t.Errorf("Error in addBranchToPayload %s", err)
+	}
+
+	var p PushPayload
+	err = json.Unmarshal(bytes, &p)
+	if err != nil {
+		t.Errorf("Error in json.Unmarshal %s", err)
+	}
+
+	// this is technically wrong as it isnt a branch - issue #378 to address this
+	if "v1.0.1" != p.WebhookBranch {
+		t.Errorf("Branch name not added as expected, branch was returned as %s", p.WebhookBranch)
+	}
+	if "v1.0.1" != p.WebhookSuggestedImageTag {
+		t.Errorf("Suggested image tag not added as expected, tag was returned as %s", p.WebhookSuggestedImageTag)
+	}
+}
+
+func TestAddExtrasToPullRequestPayload(t *testing.T) {
+
+	ref := "refs/heads/master"
+	commit := "9h3f39fu3hf39uh33"
 	pullrequestPayloadStruct := github.PullRequestEvent{
 		PullRequest: &github.PullRequest{
 			Head: &github.PullRequestBranch{
 				Ref: &ref,
+				SHA: &commit,
 			},
 		},
 	}
@@ -63,7 +106,7 @@ func TestAddBranchToPullRequestPayload(t *testing.T) {
 		t.Errorf("Error in json.Marshal(pullrequestPayloadStruct) %s", err)
 	}
 
-	bytes, err := addBranchToPayload("pull_request", payload)
+	bytes, err := addExtrasToPayload("pull_request", payload)
 	if err != nil {
 		t.Errorf("Error in addBranchToPayload %s", err)
 	}
@@ -77,10 +120,12 @@ func TestAddBranchToPullRequestPayload(t *testing.T) {
 	if "master" != p.WebhookBranch {
 		t.Errorf("Branch name not added as expected, branch was returned as %s", p.WebhookBranch)
 	}
-
+	if "9h3f39f" != p.WebhookSuggestedImageTag {
+		t.Errorf("Suggested image tag not added as expected, tag was returned as %s", p.WebhookSuggestedImageTag)
+	}
 }
 
-func TestAddBranchToOtherEventPayload(t *testing.T) {
+func TestAddExtrasToOtherEventPayload(t *testing.T) {
 
 	eventPayloadStruct := github.PingEvent{}
 
@@ -89,7 +134,7 @@ func TestAddBranchToOtherEventPayload(t *testing.T) {
 		t.Errorf("Error in json.Marshal(eventPayloadStruct) %s", err)
 	}
 
-	bytes, err := addBranchToPayload("ping", payload)
+	bytes, err := addExtrasToPayload("ping", payload)
 	if err != nil {
 		t.Errorf("Error in addBranchToPayload %s", err)
 	}

--- a/webhooks-extension/docs/Parameters.md
+++ b/webhooks-extension/docs/Parameters.md
@@ -1,6 +1,40 @@
+# Trigger Parameters
+
+The webhook extension makes a number of parameters automatically available for use in the triggertemplate file and the triggerbinding file(s).  
+
+# TriggerBinding Parameters
+
+These parameters are added to the webhook payload body by the webhooks extension interceptor code.  You can reference these parameters as you would any other parameter from the webhook payload in the trigger binding file(s), by prefixing the parameter name with `body.`.
+
+`webhooks-tekton-git-branch` : this parameter is set to the final path segment of the ref tag in the the webhook payload  
+
+`webhooks-tekton-image-tag` : this parameter is set to the shortened 7 character commit id, or, in the case of a git tag, to the tag name  
+
+Example:
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: simple-pipeline-push-binding
+spec:
+  params:
+  - name: gitrevision
+    value: $(body.head_commit.id)
+  - name: gitrepositoryurl
+    value: $(body.repository.clone_url)
+  - name: docker-tag
+    value: $(body.repository.name):$(body.webhooks-tekton-image-tag)
+  - name: event-type
+    value: $(header.X-Github-Event)
+  - name: webhooks-tekton-git-branch
+    value: $(body.webhooks-tekton-git-branch)
+```
+
+
 # TriggerTemplate Parameters
 
-The webhook extension makes a number of parameters automatically available for use in the triggertemplate file.  These parameters are, for the most part, settings that were configured when creating the webhook through the GUI.
+These parameters are, for the most part, settings that were configured when creating the webhook through the GUI.
 
 Parameters Available:
 


### PR DESCRIPTION
# Changes

Issue 377: This change adds a new property into the webhook body
payload by the interceptor.  The new property is
"webhooks-tekton-image-tag" and can be used in the trigger
bindings file(s).

If the push of a git tag causes the webhook to trigger, this property
will be set to the value/label of the tag.  In other cases, the
property is set to the short commit id.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
