### PR TITLE
Reduce ClusterRole granted to `tekton-webhooks-extension` service account to a minimum

### DIFF
--- a/webhooks-extension/config/extension-deployment.yaml
+++ b/webhooks-extension/config/extension-deployment.yaml
@@ -7,54 +7,177 @@ metadata:
   name: tekton-webhooks-extension
   namespace: tekton-pipelines
 ---
-# ------------------- Extension Role & Role Binding ------------------- #
-kind: ClusterRole
+# ------------------- ClusterRole/Binding and Role/Binding for webhooks-extension and monitor-task ------------------- #
+# webhooks-extension must be able to list pipelines and service accounts in remote namespaces
+# monitor needs to list pipelineruns
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: tekton-webhooks-extension-minimal
-  namespace: tekton-pipelines
+  name: tekton-webhooks-extension-minimal-cluster-powers
 rules:
-  - apiGroups: [""]
-    resources: ["serviceaccounts"]
-    verbs: ["get", "list", "patch", "update", "watch"]
-  - apiGroups: [""]
-    resources: ["pods", "services"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: [""]
-    resources: ["pods/log", "namespaces", "events"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["secrets", "configmaps"]
-    verbs: ["get", "list", "create", "delete", "update", "watch"]
-  - apiGroups: ["extensions", "apps"]
-    resources: ["deployments"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: ["tekton.dev"]
-    resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns", "pipelineresources", "eventlisteners", "triggerbindings", "triggertemplates", "conditions"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: ["tekton.dev"]
-    resources: ["taskruns/finalizers", "pipelineruns/finalizers"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: ["tekton.dev"]
-    resources: ["tasks/status", "clustertasks/status", "taskruns/status", "pipelines/status", "pipelineruns/status"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: ["sources.eventing.knative.dev"]
-    resources: ["githubsources"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelines
+  - pipelineruns
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: tekton-webhooks-extension-minimal
-subjects:
-  - kind: ServiceAccount
-    name: tekton-webhooks-extension
-    namespace: tekton-pipelines
+  name: tekton-webhooks-extension-minimal-cluster-powers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tekton-webhooks-extension-minimal
+  name: tekton-webhooks-extension-minimal-cluster-powers
+subjects:
+- kind: ServiceAccount
+  name: tekton-webhooks-extension
+  namespace: tekton-pipelines
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tekton-webhooks-extension-minimal
+  namespace: tekton-pipelines
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  - namespaces
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+  - update
+  - watch
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - clustertasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  - eventlisteners
+  - triggerbindings
+  - triggertemplates
+  - conditions
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - taskruns/finalizers
+  - pipelineruns/finalizers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks/status
+  - clustertasks/status
+  - taskruns/status
+  - pipelines/status
+  - pipelineruns/status
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  - ingresses/status
+  verbs:
+  - delete
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: tekton-pipelines
+  name: tekton-webhooks-extension-minimal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tekton-webhooks-extension-minimal
+subjects:
+- kind: ServiceAccount
+  name: tekton-webhooks-extension
+---
+# ------------------- Event Listener ServiceAccount, ClusterRole and Binding ----------------------- #
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -100,6 +223,7 @@ subjects:
   name: tekton-webhooks-extension-eventlistener
   namespace: tekton-pipelines
 ---
+# ------------------- Webhooks Extension Deployment ----------------------- #
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/gcr-tekton-webhooks-extension.yaml
@@ -8,52 +8,175 @@ metadata:
   namespace: tekton-pipelines
 ---
 # ------------------- Extension Role & Role Binding ------------------- #
-kind: ClusterRole
+# ------------------- ClusterRole/Binding and Role/Binding for webhooks-extension and monitor-task ------------------- #
+# webhooks-extension must be able to list pipelines and service accounts in remote namespaces
+# monitor needs to list pipelineruns
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: tekton-webhooks-extension-minimal
-  namespace: tekton-pipelines
+  name: tekton-webhooks-extension-minimal-cluster-powers
 rules:
-  - apiGroups: [""]
-    resources: ["serviceaccounts"]
-    verbs: ["get", "list", "patch", "update", "watch"]
-  - apiGroups: [""]
-    resources: ["pods", "services"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: [""]
-    resources: ["pods/log", "namespaces", "events"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["secrets", "configmaps"]
-    verbs: ["get", "list", "create", "delete", "update", "watch"]
-  - apiGroups: ["extensions", "apps"]
-    resources: ["deployments"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: ["tekton.dev"]
-    resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns", "pipelineresources", "eventlisteners", "triggerbindings", "triggertemplates", "conditions"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: ["tekton.dev"]
-    resources: ["taskruns/finalizers", "pipelineruns/finalizers"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: ["tekton.dev"]
-    resources: ["tasks/status", "clustertasks/status", "taskruns/status", "pipelines/status", "pipelineruns/status"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: ["sources.eventing.knative.dev"]
-    resources: ["githubsources"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelines
+  - pipelineruns
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: tekton-webhooks-extension-minimal
-subjects:
-  - kind: ServiceAccount
-    name: tekton-webhooks-extension
-    namespace: tekton-pipelines
+  name: tekton-webhooks-extension-minimal-cluster-powers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+  name: tekton-webhooks-extension-minimal-cluster-powers
+subjects:
+- kind: ServiceAccount
+  name: tekton-webhooks-extension
+  namespace: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: tekton-webhooks-extension-minimal
+  namespace: tekton-pipelines
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  - namespaces
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+  - update
+  - watch
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - clustertasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  - eventlisteners
+  - triggerbindings
+  - triggertemplates
+  - conditions
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - taskruns/finalizers
+  - pipelineruns/finalizers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks/status
+  - clustertasks/status
+  - taskruns/status
+  - pipelines/status
+  - pipelineruns/status
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  - ingresses/status
+  verbs:
+  - delete
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: tekton-pipelines
+  name: tekton-webhooks-extension-minimal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tekton-webhooks-extension-minimal
+subjects:
+- kind: ServiceAccount
+  name: tekton-webhooks-extension
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
+++ b/webhooks-extension/config/latest/openshift-tekton-webhooks-extension.yaml
@@ -6,11 +6,12 @@ metadata:
   name: tekton-webhooks-extension
   namespace: tekton-pipelines
 ---
+# webhooks-extension must be able to list pipelines and service accounts in remote namespaces
+# monitor needs to list pipelineruns
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: tekton-webhooks-extension-minimal
-  namespace: tekton-pipelines
+  name: tekton-webhooks-extension-minimal-cluster-powers
 rules:
 - apiGroups:
   - security.openshift.io
@@ -25,9 +26,36 @@ rules:
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelines
+  - pipelineruns
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-webhooks-extension-minimal-cluster-powers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-webhooks-extension-minimal-cluster-powers
+subjects:
+- kind: ServiceAccount
+  name: tekton-webhooks-extension
+  namespace: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tekton-webhooks-extension-minimal
+  namespace: tekton-pipelines
+rules:
 - apiGroups:
   - ""
   resources:
@@ -152,18 +180,17 @@ rules:
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
+  namespace: tekton-pipelines
   name: tekton-webhooks-extension-minimal
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: tekton-webhooks-extension-minimal
 subjects:
 - kind: ServiceAccount
   name: tekton-webhooks-extension
-  namespace: tekton-pipelines
----
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/webhooks-extension/config/openshift-development/openshift-tekton-webhooks-extension-development.yaml
+++ b/webhooks-extension/config/openshift-development/openshift-tekton-webhooks-extension-development.yaml
@@ -6,11 +6,12 @@ metadata:
   name: tekton-webhooks-extension
   namespace: tekton-pipelines
 ---
+# webhooks-extension must be able to list pipelines and service accounts in remote namespaces
+# monitor needs to list pipelineruns
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: tekton-webhooks-extension-minimal
-  namespace: tekton-pipelines
+  name: tekton-webhooks-extension-minimal-cluster-powers
 rules:
 - apiGroups:
   - security.openshift.io
@@ -25,9 +26,36 @@ rules:
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelines
+  - pipelineruns
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-webhooks-extension-minimal-cluster-powers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-webhooks-extension-minimal-cluster-powers
+subjects:
+- kind: ServiceAccount
+  name: tekton-webhooks-extension
+  namespace: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tekton-webhooks-extension-minimal
+  namespace: tekton-pipelines
+rules:
 - apiGroups:
   - ""
   resources:
@@ -152,17 +180,18 @@ rules:
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
+  namespace: tekton-pipelines
   name: tekton-webhooks-extension-minimal
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: tekton-webhooks-extension-minimal
 subjects:
 - kind: ServiceAccount
   name: tekton-webhooks-extension
-  namespace: tekton-pipelines
+
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/webhooks-extension/config/openshift/openshift-tekton-webhooks-extension-release.yaml
+++ b/webhooks-extension/config/openshift/openshift-tekton-webhooks-extension-release.yaml
@@ -6,11 +6,12 @@ metadata:
   name: tekton-webhooks-extension
   namespace: tekton-pipelines
 ---
+# webhooks-extension must be able to list pipelines and service accounts in remote namespaces
+# monitor needs to list pipelineruns
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: tekton-webhooks-extension-minimal
-  namespace: tekton-pipelines
+  name: tekton-webhooks-extension-minimal-cluster-powers
 rules:
 - apiGroups:
   - security.openshift.io
@@ -25,9 +26,36 @@ rules:
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelines
+  - pipelineruns
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-webhooks-extension-minimal-cluster-powers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-webhooks-extension-minimal-cluster-powers
+subjects:
+- kind: ServiceAccount
+  name: tekton-webhooks-extension
+  namespace: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tekton-webhooks-extension-minimal
+  namespace: tekton-pipelines
+rules:
 - apiGroups:
   - ""
   resources:
@@ -152,18 +180,17 @@ rules:
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
+  namespace: tekton-pipelines
   name: tekton-webhooks-extension-minimal
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: tekton-webhooks-extension-minimal
 subjects:
 - kind: ServiceAccount
   name: tekton-webhooks-extension
-  namespace: tekton-pipelines
----
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

For https://github.com/tektoncd/experimental/issues/331 - turn the `tekton-webhooks-extension-minimal` ClusterRole into a Role and create a minimal new ClusterRole for just those powers required to operate across namespaces. `tekton-webhooks-extension-minimal` is still too broad but I'd like to get https://github.com/tektoncd/experimental/issues/394 fixed first so that we can edit one, and not five, copies of the same yaml. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
