### PR TITLE
Handle missing PipelineRuns for monitor task

### DIFF
--- a/webhooks-extension/base/400-monitor-task.yaml
+++ b/webhooks-extension/base/400-monitor-task.yaml
@@ -140,10 +140,8 @@ spec:
                  "Status | Pipeline | PipelineRun | Namespace\n"
                  ":----- | :------- | :--------------- | :--------\n"
                  ) + "\n".join(results)
-      if not os.path.exists("/workspace/output/pull-request/comments"):
-        os.makedirs("/workspace/output/pull-request/comments")
-        if os.path.exists("/workspace/pull-request/comments/.MANIFEST"):
-          shutil.copyfile("/workspace/pull-request/comments/.MANIFEST","/workspace/output/pull-request/comments/.MANIFEST")
+      # Preserve existing comments
+      shutil.copytree("/workspace/pull-request/comments","/workspace/output/pull-request/comments")
       handle = open("/workspace/output/pull-request/comments/newcomment.json", 'w')
       handle.write(comment)
       handle.close()

--- a/webhooks-extension/base/400-monitor-task.yaml
+++ b/webhooks-extension/base/400-monitor-task.yaml
@@ -11,16 +11,20 @@ spec:
         type: pullRequest
     params:
       - name: commentsuccess
-        description: The text of the success comment
+        description: The text to use in the situation where a PipelineRun has succeeded.
         default: "Success"
         type: string
       - name: commentfailure
-        description: The text of the failure comment
+        description: The text to use in the situation where a PipelineRun has a failed.
         default: "Failed"
         type: string
       - name: commenttimeout
-        description: The text of the timeout comment
+        description: The text to use in the situation where a PipelineRun has timed out.
         default: "Unknown"
+        type: string
+      - name: commentmissing
+        description: The text to use in the situation where a PipelineRun cannot be found.
+        default: "Missing"
         type: string
       - name: dashboard-url
         description: The URL to the pipelineruns page of the dashboard
@@ -51,6 +55,8 @@ spec:
         value: $(inputs.params.commentfailure)
       - name: COMMENT_TIMEOUT
         value: $(inputs.params.commenttimeout)
+      - name: COMMENT_MISSING
+        value: $(inputs.params.commentmissing)
       - name: URL
         value: $(inputs.params.dashboard-url)
       # This can be deleted after any fix to the above mentioned pending status change
@@ -68,6 +74,11 @@ spec:
       cat <<EOF | python
       import time, os, json, requests, pprint, shutil
       from kubernetes import client, config
+      
+      def diff(li1, li2): 
+        li_dif = [i for i in li1 + li2 if i not in li1 or i not in li2] 
+        return li_dif
+
       config.load_incluster_config()
       api_instance = client.CustomObjectsApi(client.ApiClient(client.Configuration()))
       gitPRcontext = "Tekton"
@@ -91,25 +102,51 @@ spec:
         pipelineRunURLPrefix = "http://" + "$URL"
       else:
         pipelineRunURLPrefix = "$URL"
-      labelToCheck = "tekton.dev/triggers-eventid=$EVENTID"
+      labelToCheck = "tekton.dev/triggers-eventid=$EVENTID" 
       runsPassed = []
       runsFailed = []
       runsIncomplete = []
+      runsMissing = []
       failed = 0
       i = range(180)
+      initial_runs = api_instance.list_cluster_custom_object("tekton.dev", "v1alpha1", "pipelineruns", label_selector=labelToCheck)["items"]
+
       for x in i:
           time.sleep( 10 )
           runsPassed = []
           runsFailed = []
           runsIncomplete = []
+          # To test this we need a webhook that will kick off two Pipelines
+          # We will then delete one PipelineRun and observe it is correctly picked up as missing
+          # This is easiest done by reopening an existing PullRequest
+          # It's important to delete the PipelineRun only after the monitor task is already running because 
+          # the first thing it's going to do is figure out the PipelineRuns to watch over
+
           failed = 0
-          api_response = api_instance.list_cluster_custom_object("tekton.dev", "v1alpha1", "pipelineruns", label_selector=labelToCheck)
-          if len(api_response["items"]) > 0:
-            for entry in api_response["items"]:
+          found_runs = api_instance.list_cluster_custom_object("tekton.dev", "v1alpha1", "pipelineruns", label_selector=labelToCheck)["items"]
+          
+          missingRuns = diff(initial_runs, found_runs)
+          if len(missingRuns) > 0:
+            for missingRun in missingRuns:
+              pr = missingRun["metadata"]["name"]
+              namespace = missingRun["metadata"]["namespace"]
+              pipeline = missingRun["spec"]["pipelineRef"]["name"]
+              link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelineruns/"
+              data = "[**$COMMENT_MISSING**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace
+              if data not in runsMissing:
+                # Don't add duplicates. Fear not, once this run is found it'll be removed
+                runsMissing.append(data)
+
+          if len(found_runs) > 0:
+            for entry in found_runs:
               pr = entry["metadata"]["name"]
               namespace = entry["metadata"]["namespace"]
               pipeline = entry["spec"]["pipelineRef"]["name"]
               link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelineruns/" + pr
+              missingLink = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelineruns/"
+              missingDataEntry = "[**$COMMENT_MISSING**](" + missingLink + ") | " + pipeline + " | " + pr + " | " + namespace
+              if missingDataEntry in runsMissing:
+                runsMissing.remove(data)
               print("Checking pipelinerun " + pr + " in namespace " + namespace)
               if entry["status"]["conditions"][0]["status"] == u'True' and entry["status"]["conditions"][0]["type"] == u'Succeeded':
                 print("Success - pipelinerun " + pr + " in namespace " + namespace)
@@ -131,11 +168,14 @@ spec:
       if failed > 0:
         gitPRdescription = str(failed) + " pipeline(s) failed!"
         gitPRcode = "failure"
+      if len(runsMissing) > 0:
+        gitPRdescription = "Pipeline(s) missing!"
+        gitPRcode = "failure"
       if len(runsIncomplete) > 0:
-        print("Some pipelineruns had not completed when the monitor reached its timeout")
+        print("Some PipelineRuns had not completed when the monitor reached its timeout")
         gitPRdescription = "timed out monitoring pipeline runs"
         gitPRcode = "error"
-      results = runsPassed + runsFailed + runsIncomplete
+      results = runsPassed + runsFailed + runsIncomplete + runsMissing
       comment = ("## Tekton Status Report \n\n"
                  "Status | Pipeline | PipelineRun | Namespace\n"
                  ":----- | :------- | :--------------- | :--------\n"

--- a/webhooks-extension/base/400-monitor-triggertemplate.yaml
+++ b/webhooks-extension/base/400-monitor-triggertemplate.yaml
@@ -28,6 +28,10 @@ spec:
     description: The text of the timeout comment
     default: "Unknown"
     type: string
+  - name: commentmissing
+    description: The text of the missing comment
+    default: "Missing"
+    type: string
   - name: dashboardurl
     description: The URL to the pipelineruns page of the dashboard
     default: "http://localhost:9097/"

--- a/webhooks-extension/docs/CustomizingTheMonitor.md
+++ b/webhooks-extension/docs/CustomizingTheMonitor.md
@@ -22,9 +22,9 @@ If you have not installed into the tekton-pipelines namespace, you would need to
 
 ## Overriding The Status Message
 
-To change the "Success", "Failed" and "Unknown" status messages shown in the 'Tekton Status' comment added to the pull request, you can use the REST endpoint for creating your webhooks, rather than the UI.  Note however that the REST endpoints are only advised to be used in development, see [here](../DevelopmentAPIs.md).
+To change the "Success", "Failed", "Unknown" and "Missing" status messages shown in the 'Tekton Status' comment added to the pull request, you can use the REST endpoint for creating your webhooks, rather than the UI.  Note however that the REST endpoints are only advised to be used in development, see [here](../DevelopmentAPIs.md).
 
-The body you POST to the REST endpoint has three properties, `onsuccesscomment`, `onfailurecomment` and `ontimeoutcomment` that define the value used in the Status column.  For example, creating the webhook using the JSON body:
+The body you POST to the REST endpoint has four properties, `onsuccesscomment`, `onfailurecomment`, `ontimeoutcomment`, `onmissingcomment` that define the value used in the Status column.  For example, creating the webhook using the JSON body:
 
 ```
 {
@@ -36,7 +36,8 @@ The body you POST to the REST endpoint has three properties, `onsuccesscomment`,
   "dockerregistry": "FOO",
   "onsuccesscomment": "Erfolg",  <--------------------------------------------
   "onfailurecomment": "Fehler",  <--------------------------------------------
-  "ontimeoutcomment": "Frozen"   <--------------------------------------------
+  "ontimeoutcomment": "Frozen",  <--------------------------------------------
+  "onmissingcomment": "Fehlt"    <--------------------------------------------
 }
 ```
 
@@ -60,6 +61,7 @@ Using the REST endpoint directly, it is also possible to override the Task that 
   "onsuccesscomment": "Erfolg",
   "onfailurecomment": "Fehler",
   "ontimeoutcomment": "Frozen",
+  "onmissingcomment": "Fehlt",
   "pulltask": "my-custom-task"   <--------------------------------------------
 }
 ```
@@ -75,6 +77,8 @@ In this situation, after the webhook is triggered and the PipelineRun created, a
       value: Fehler
     - name: commenttimeout
       value: Frozen
+    - name: commentmissing
+      value: Fehlt
     - name: secret
       value: GITHUBSECRET
 ```

--- a/webhooks-extension/pkg/endpoints/types.go
+++ b/webhooks-extension/pkg/endpoints/types.go
@@ -105,6 +105,7 @@ type webhook struct {
 	OnSuccessComment string `json:"onsuccesscomment,omitempty"`
 	OnFailureComment string `json:"onfailurecomment,omitempty"`
 	OnTimeoutComment string `json:"ontimeoutcomment,omitempty"`
+	OnMissingComment string `json:"onmissingcomment,omitempty"`
 }
 
 // ConfigMapName ... the name of the ConfigMap to create

--- a/webhooks-extension/pkg/endpoints/webhook.go
+++ b/webhooks-extension/pkg/endpoints/webhook.go
@@ -224,11 +224,16 @@ func (r Resource) getParams(webhook webhook) (webhookParams, monitorParams []pip
 	if onTimeoutComment == "" {
 		onTimeoutComment = "Unknown"
 	}
+	onMissingComment := webhook.OnMissingComment
+	if onMissingComment == "" {
+		onMissingComment = "Missing"
+	}
 
 	prMonitorParams := []pipelinesv1alpha1.Param{
 		{Name: "commentsuccess", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: onSuccessComment}},
 		{Name: "commentfailure", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: onFailureComment}},
 		{Name: "commenttimeout", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: onTimeoutComment}},
+		{Name: "commentmissing", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: onMissingComment}},
 		{Name: "gitsecretname", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: webhook.AccessTokenRef}},
 		{Name: "gitsecretkeyname", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "accessToken"}},
 		{Name: "dashboardurl", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: r.getDashboardURL(r.Defaults.Namespace)}},

--- a/webhooks-extension/pkg/endpoints/webhook_test.go
+++ b/webhooks-extension/pkg/endpoints/webhook_test.go
@@ -124,6 +124,7 @@ func TestGetParams(t *testing.T) {
 			OnSuccessComment: "onsuccesscomment1",
 			OnFailureComment: "onfailurecomment1",
 			OnTimeoutComment: "ontimeoutcomment1",
+			OnMissingComment: "onmissingcomment1",
 		},
 		{
 			Name:             "name2",
@@ -135,6 +136,7 @@ func TestGetParams(t *testing.T) {
 			OnSuccessComment: "onsuccesscomment2",
 			OnFailureComment: "onfailurecomment2",
 			OnTimeoutComment: "ontimeoutcomment2",
+			OnMissingComment: "onmissingcomment2",
 		},
 		{
 			Name:             "name3",
@@ -178,6 +180,7 @@ func TestCreateEventListener(t *testing.T) {
 			OnSuccessComment: "onsuccesscomment1",
 			OnFailureComment: "onfailurecomment1",
 			OnTimeoutComment: "ontimeoutcomment1",
+			OnMissingComment: "onmissingcomment1",
 		},
 		{
 			Name:             "name2",
@@ -189,6 +192,7 @@ func TestCreateEventListener(t *testing.T) {
 			OnSuccessComment: "onsuccesscomment2",
 			OnFailureComment: "onfailurecomment2",
 			OnTimeoutComment: "ontimeoutcomment2",
+			OnMissingComment: "onmissingcomment2",
 		},
 		{
 			Name:             "name3",
@@ -250,6 +254,7 @@ func TestUpdateEventListenerTriggerListing(t *testing.T) {
 			OnSuccessComment: "onsuccesscomment1",
 			OnFailureComment: "onfailurecomment1",
 			OnTimeoutComment: "ontimeoutcomment1",
+			OnMissingComment: "onmissingcomment1",
 		},
 		{
 			Name:             "name2",
@@ -261,6 +266,7 @@ func TestUpdateEventListenerTriggerListing(t *testing.T) {
 			OnSuccessComment: "onsuccesscomment2",
 			OnFailureComment: "onfailurecomment2",
 			OnTimeoutComment: "ontimeoutcomment2",
+			OnMissingComment: "onmissingcomment2",
 		},
 		{
 			Name:             "name3",
@@ -337,6 +343,7 @@ func TestDeleteFromEventListener(t *testing.T) {
 			OnSuccessComment: "onsuccesscomment1",
 			OnFailureComment: "onfailurecomment1",
 			OnTimeoutComment: "ontimeoutcomment1",
+			OnMissingComment: "onmissingcomment1",
 		},
 		{
 			Name:             "name2",
@@ -348,6 +355,7 @@ func TestDeleteFromEventListener(t *testing.T) {
 			OnSuccessComment: "onsuccesscomment2",
 			OnFailureComment: "onfailurecomment2",
 			OnTimeoutComment: "ontimeoutcomment2",
+			OnMissingComment: "onmissingcomment2",
 		},
 	}
 
@@ -428,6 +436,7 @@ func TestCreateAndDeleteWebhook(t *testing.T) {
 			OnSuccessComment: "onsuccesscomment1",
 			OnFailureComment: "onfailurecomment1",
 			OnTimeoutComment: "ontimeoutcomment1",
+			OnMissingComment: "onmissingcomment1",
 		},
 		{
 			Name:             "name2",
@@ -439,6 +448,7 @@ func TestCreateAndDeleteWebhook(t *testing.T) {
 			OnSuccessComment: "onsuccesscomment2",
 			OnFailureComment: "onfailurecomment2",
 			OnTimeoutComment: "ontimeoutcomment2",
+			OnMissingComment: "onmissingcomment2",
 		},
 		{
 			Name:             "name3",
@@ -594,6 +604,11 @@ func getExpectedParams(hook webhook, r *Resource) (expectedHookParams, expectedM
 		expectedMonitorParams = append(expectedMonitorParams, pipelinesv1alpha1.Param{Name: "commenttimeout", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: hook.OnTimeoutComment}})
 	} else {
 		expectedMonitorParams = append(expectedMonitorParams, pipelinesv1alpha1.Param{Name: "commenttimeout", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "Unknown"}})
+	}
+	if hook.OnMissingComment != "" {
+		expectedMonitorParams = append(expectedMonitorParams, pipelinesv1alpha1.Param{Name: "commentmissing", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: hook.OnMissingComment}})
+	} else {
+		expectedMonitorParams = append(expectedMonitorParams, pipelinesv1alpha1.Param{Name: "commentmissing", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "Missing"}})
 	}
 	expectedMonitorParams = append(expectedMonitorParams, pipelinesv1alpha1.Param{Name: "gitsecretname", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: hook.AccessTokenRef}})
 	expectedMonitorParams = append(expectedMonitorParams, pipelinesv1alpha1.Param{Name: "gitsecretkeyname", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "accessToken"}})


### PR DESCRIPTION
For https://github.com/tektoncd/experimental/issues/395

Also adds override for the missing comment

Testing is:
- reopen two PullRequests thus triggering two PipelineRuns
- delete one PipelineRun, check table reflects state accordingly

Also:
- reopen two PullRequests thus triggering two PipelineRuns
- delete both PipelineRuns, check table reflects state accordingly