### PR TITLE
Update uninstall docs to include created route/ingress

### DIFF
--- a/webhooks-extension/docs/Uninstall.md
+++ b/webhooks-extension/docs/Uninstall.md
@@ -8,6 +8,7 @@ To uninstall the webhooks extension:
 
     ```bash
     git clone https://github.com/tektoncd/experimental.git
+    cd webhooks-extension
     ```
 
 2. Use the `kubectl delete` command to delete the webhooks extension
@@ -28,16 +29,31 @@ To uninstall the webhooks extension:
 Uninstall any of the prereqs added during installation:
 
 1. [Uninstall Tekton Dashboard](https://github.com/tektoncd/dashboard)  
-2. Uninstall Tekton Triggers
+2. Uninstall Tekton Triggers - this will delete any created EventListener including the `tekton-webhooks-eventlistener` we use:
 
     ```bash
     kubectl delete --filename https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml
     ```
 
-3. Uninstall Tekton Pipelines
+3. Uninstall Tekton Pipelines:
 
     ```bash
     kubectl delete -f https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
     ```
 
 Note: You may need to use the URL of the file you installed rather than the latest release in the above commands.
+
+4. Uninstall additionally created resources added after webhook creation:
+
+   For OpenShift:
+
+   ```bash
+   kubectl delete route el-tekton-webhooks-eventlistener -n <your installation namespace>`
+   ```
+
+   For other environments using Ingress:
+
+   ```bash
+   kubectl delete ingress el-tekton-webhooks-eventlistener -n <your installation namespace>`
+   ```
+


### PR DESCRIPTION
For https://github.com/tektoncd/experimental/issues/441

Verified deleting a CRD (e.g. when you delete Triggers) it does delete any created reosurces too, e.g

```
(base) adams-mbp:dashboard aroberts$ k get el
NAME                            AGE
tekton-webhooks-eventlistener   6d22h

(base) adams-mbp:dashboard aroberts$ k get crd | grep eventlistener
eventlisteners.tekton.dev                                   2020-01-21T13:36:51Z

(base) adams-mbp:dashboard aroberts$ k delete crd eventlisteners.tekton.dev
customresourcedefinition.apiextensions.k8s.io "eventlisteners.tekton.dev" deleted

(base) adams-mbp:dashboard aroberts$ k get el
Error from server (NotFound): Unable to list "tekton.dev/v1alpha1, Resource=eventlisteners": the server could not find the requested resource (get eventlisteners.tekton.dev)
```