### PR TITLE
Updates webhooks extension eventlistener to be compatible with triggers 0.2.1

### DIFF
--- a/webhooks-extension/Gopkg.lock
+++ b/webhooks-extension/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:9f3b30d9f8e0d7040f729b82dcbc8f0dead820a133b3147ce355fc451f32d761"
+  name = "github.com/BurntSushi/toml"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
+  version = "v0.3.1"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -10,23 +18,23 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:9b307ab2abef34f4c0d611a34bbc4d322fb05fdb6728045b89cde8b1b8a04ed0"
+  digest = "1:e228f9aa7d73dc1d1119461183bd9798464a04080f5c963123c7fd8d2ce5d9a2"
   name = "github.com/emicklei/go-restful"
   packages = [
     ".",
     "log",
   ]
   pruneopts = "UT"
-  revision = "f48aa74d360eda838561e6db9d36c6538398343f"
-  version = "v2.10.0"
+  revision = "a2fa14558f9a828f859fcad1d5c824437d7d4388"
+  version = "v2.11.2"
 
 [[projects]]
-  digest = "1:ac425d784b13d49b37a5bbed3ce022677f8f3073b216f05d6adcb9303e27fa0f"
+  digest = "1:2b5f431fa18891a2ac0e02353c83fb3bf458fced6ccecd664b429054e0c4ce3b"
   name = "github.com/evanphx/json-patch"
   packages = ["."]
   pruneopts = "UT"
-  revision = "026c730a0dcc5d11f93f1cf1cc65b01247ea7b6f"
-  version = "v4.5.0"
+  revision = "bf22ed9311622d93e213ba31e4ae7a5771e5d379"
+  version = "v4.6.0"
 
 [[projects]]
   digest = "1:2cd7915ab26ede7d95b8749e6b1f933f1c6d5398030684e6505940a10f31cfda"
@@ -37,26 +45,18 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:8a85f428bc6ebfa87f53216b6e43b52b30eccbcffcbd6b057a69ee16718a2248"
+  digest = "1:582e25eccee928dc12416ea4c23b6dae8f3b5687730632aa1473ebebe80a2359"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
     "sortkeys",
   ]
   pruneopts = "UT"
-  revision = "0ca988a254f991240804bf9821f3450d87ccbb1b"
-  version = "v1.3.0"
+  revision = "5628607bb4c51c3157aacc3a50f0ab707582b805"
+  version = "v1.3.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
-  name = "github.com/golang/glog"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
-
-[[projects]]
-  digest = "1:f5ce1529abc1204444ec73779f44f94e2fa8fcdb7aca3c355b0c95947e4005c6"
+  digest = "1:0314772c6631bb25d46f0b6a46bed7145e359cbb7411db99682a3b0d1d0cd00f"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -66,8 +66,8 @@
     "ptypes/timestamp",
   ]
   pruneopts = "UT"
-  revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
-  version = "v1.3.2"
+  revision = "d23c5127dc24889085f8ccea5c9d560a57a879d8"
+  version = "v1.3.3"
 
 [[projects]]
   digest = "1:0bfbe13936953a98ae3cfe8ed6670d396ad81edf069a806d2f6515d7bb6950df"
@@ -91,12 +91,12 @@
   revision = "6f77996f0c42f7b84e5a2b252227263f93432e9b"
 
 [[projects]]
-  digest = "1:91099c6f78b1e7bdf9ed06eb4cb7f017174293a3689d76b995a06f4c8d64a7f0"
+  digest = "1:92a2e4ce17e6b468e1a7c7cd2d6c1570a0503276a9fb07e31f9bf27c5979196c"
   name = "github.com/google/go-github"
   packages = ["github"]
   pruneopts = "UT"
-  revision = "9686ff0746200cf521ce225525b421e13b4eac1a"
-  version = "v28.1.1"
+  revision = "ab35a4779b48b6089e8d3a80cc99c544695853eb"
+  version = "v29.0.2"
 
 [[projects]]
   digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
@@ -107,15 +107,15 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:a6181aca1fd5e27103f9a920876f29ac72854df7345a39f3b01e61c8c94cc8af"
+  digest = "1:a840b166971a2e76fcc4fbafaa181ea109b92d461e7f9b608a49b70be2765bac"
   name = "github.com/google/gofuzz"
   packages = ["."]
   pruneopts = "UT"
-  revision = "f140a6486e521aad38f5917de355cbf147cc0496"
-  version = "v1.0.0"
+  revision = "db92cf7ae75e4a7a28abc005addab2b394362888"
+  version = "v1.1.0"
 
 [[projects]]
-  digest = "1:ca4524b4855ded427c7003ec903a5c854f37e7b1e8e2a93277243462c5b753a8"
+  digest = "1:e35285db21b7d730a52b891a959783e567ca516ea64f2748070f1f917fbccd82"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
@@ -123,8 +123,8 @@
     "extensions",
   ]
   pruneopts = "UT"
-  revision = "ab0dd09aa10e2952b28e12ecd35681b20463ebab"
-  version = "v0.3.1"
+  revision = "99384834bf8c58ce7ab88db353283bedcb53e1ca"
+  version = "v0.4.0"
 
 [[projects]]
   branch = "master"
@@ -138,23 +138,23 @@
   revision = "901d90724c7919163f472a9812253fb26761123d"
 
 [[projects]]
-  digest = "1:c77361e611524ec8f2ad37c408c3c916111a70b6acf806a1200855696bf8fa4d"
+  digest = "1:e631368e174090a276fc00b48283f92ac4ccfbbb1945bcfcee083f5f9210dc00"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
     "simplelru",
   ]
   pruneopts = "UT"
-  revision = "7f827b33c0f158ec5dfbba01bb0b14a4541fd81d"
-  version = "v0.5.3"
+  revision = "14eae340515388ca95aa8e7b86f0de668e981f54"
+  version = "v0.5.4"
 
 [[projects]]
-  digest = "1:709cd2a2c29cc9b89732f6c24846bbb9d6270f28ef5ef2128cc73bd0d6d7bff9"
+  digest = "1:7cd2924a44ecf80a319cfa2378529fabd348d011b739fb4eccc565f65e3296c4"
   name = "github.com/json-iterator/go"
   packages = ["."]
   pruneopts = "UT"
-  revision = "27518f6661eba504be5a7a9a9f6d9460d892ade3"
-  version = "v1.1.7"
+  revision = "acfec88f7a0d5140ace3dcdbee10184e3684a9e1"
+  version = "v1.1.9"
 
 [[projects]]
   branch = "master"
@@ -189,15 +189,16 @@
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:e6deb5269daaf7ab91e3a04a1570d690a60a982d595d090882cee3ded817bb04"
+  branch = "release-4.2"
+  digest = "1:bba83d2f22a43c462ea40d2c78c49e69cb11401ade408b10ee263f19842ae914"
   name = "github.com/openshift/api"
   packages = ["route/v1"]
   pruneopts = "UT"
-  revision = "0d921e363e951d89f583292c60d013c318df64dc"
-  version = "v3.9.0"
+  revision = "d4a64ec2cbd86f11ea74dfdcf6520d5833d0c6cd"
 
 [[projects]]
-  digest = "1:cb6e92c0c79615d275e1ebabd1177f0e73a2271841bd703a195568c01f33249f"
+  branch = "release-4.2"
+  digest = "1:360c87a2e3f586c383bf463cc301824cc2178dc68dbc9c74f69cc45553ce83af"
   name = "github.com/openshift/client-go"
   packages = [
     "route/clientset/versioned",
@@ -207,8 +208,7 @@
     "route/clientset/versioned/typed/route/v1/fake",
   ]
   pruneopts = "UT"
-  revision = "1fa528d3be060e4c7178eb69e76d37cf7e699e3c"
-  version = "v3.9.0"
+  revision = "5a5508328169b8a6992ea4ef711add89ddce3c6d"
 
 [[projects]]
   branch = "master"
@@ -227,43 +227,51 @@
   version = "v3.0.0"
 
 [[projects]]
-  digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
+  digest = "1:9e1d37b58d17113ec3cb5608ac0382313c5b59470b94ed97d0976e69c7022314"
   name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
-  version = "v0.8.1"
+  revision = "614d223910a179a466c1767a985424175c39b465"
+  version = "v0.9.1"
 
 [[projects]]
   digest = "1:4214ab2523b5dc2d4d36b152982b1d65c6b3e6e00d2c0fa8336e6204a793065d"
   name = "github.com/tektoncd/dashboard"
   packages = ["pkg/logging"]
   pruneopts = "UT"
-  revision = "46ba3f8e2774bc13d757e11727ee3e47d145ec96"
-  version = "v0.2.0"
+  revision = "422a0282c2460ae66a9f3e9ca4f95e5ae48b30b4"
+  version = "v0.5.0"
 
 [[projects]]
-  digest = "1:3023718e79c04239565bdf2bc45bbc28b6b9616893f1f32eedd45f2c2d1cd0a0"
+  digest = "1:a9cf10d8d7b29c2ec35f745361a7679ab14c4efcae2a595af0baa948b088a1c4"
   name = "github.com/tektoncd/pipeline"
   packages = [
     "pkg/apis/config",
     "pkg/apis/pipeline",
+    "pkg/apis/pipeline/pod",
     "pkg/apis/pipeline/v1alpha1",
+    "pkg/apis/pipeline/v1alpha2",
+    "pkg/apis/resource/v1alpha1",
+    "pkg/apis/validate",
     "pkg/client/clientset/versioned",
     "pkg/client/clientset/versioned/fake",
     "pkg/client/clientset/versioned/scheme",
     "pkg/client/clientset/versioned/typed/pipeline/v1alpha1",
     "pkg/client/clientset/versioned/typed/pipeline/v1alpha1/fake",
+    "pkg/client/clientset/versioned/typed/pipeline/v1alpha2",
+    "pkg/client/clientset/versioned/typed/pipeline/v1alpha2/fake",
+    "pkg/contexts",
     "pkg/list",
     "pkg/names",
+    "pkg/reconciler/pipeline/dag",
+    "pkg/substitution",
   ]
   pruneopts = "UT"
-  revision = "c105b6835a899ad1cccadc3556c8a260e812d2cf"
-  version = "v0.6.0"
+  revision = "9d40d325b27a98ec496e9d0bc4d6f28ed078d0fc"
+  version = "v0.10.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:4c7d797d1c0d52cf69ac57ac1b3a2ab265cc4504a5c872d2b45ebdf631e48db8"
+  digest = "1:8018dd77e5588011502c81df00eaa63e0642cd7621e0bc081a6c19ef5bb8f7d1"
   name = "github.com/tektoncd/triggers"
   packages = [
     "pkg/apis/triggers/v1alpha1",
@@ -274,58 +282,43 @@
     "pkg/client/clientset/versioned/typed/triggers/v1alpha1/fake",
   ]
   pruneopts = "UT"
-  revision = "6d48de8ce56462930f9dcab00029d86a9fa59b3f"
+  revision = "6fd954437e30a23124d869e0fc24673aad042af7"
+  version = "v0.2.1"
 
 [[projects]]
-  digest = "1:5a68167017eaa32aa408397806b9d69815244238ed774439a8863ef4bc329eeb"
-  name = "github.com/tidwall/gjson"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "c34bf81952c067718854115564f8e55978be5e1d"
-  version = "v1.3.4"
-
-[[projects]]
-  digest = "1:8453ddbed197809ee8ca28b06bd04e127bec9912deb4ba451fea7a1eca578328"
-  name = "github.com/tidwall/match"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "33827db735fff6510490d69a8622612558a557ed"
-  version = "v1.0.1"
-
-[[projects]]
-  digest = "1:ddfe0a54e5f9b29536a6d7b2defa376f2cb2b6e4234d676d7ff214d5b097cb50"
-  name = "github.com/tidwall/pretty"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "1166b9ac2b65e46a43d8618d30d1554f4652d49b"
-  version = "v1.0.0"
-
-[[projects]]
-  digest = "1:b5712d3cd9ebee0caff53dc3c14aedad7fdced06387b4d8e4076e7220cd4f1e7"
+  digest = "1:5ce9ee060fd2631f7b8429031d76b52de72a302992ca983f4128a6f0770d5836"
   name = "github.com/xanzy/go-gitlab"
   packages = ["."]
   pruneopts = "UT"
-  revision = "f74501cbc643b2731fcdfb29ca53230bbb2b935a"
-  version = "v0.22.2"
+  revision = "7bb993b2bff45de7c174839992d5e7e1344901da"
+  version = "v0.24.0"
 
 [[projects]]
-  digest = "1:a5158647b553c61877aa9ae74f4015000294e47981e6b8b07525edcbb0747c81"
+  digest = "1:c708d00d1097e62bf4f3a72f239efa7dafc257581421b0b7d3789e1ff5299f30"
   name = "go.uber.org/atomic"
   packages = ["."]
   pruneopts = "UT"
-  revision = "df976f2515e274675050de7b3f42545de80594fd"
-  version = "v1.4.0"
+  revision = "40ae6a40a970ef4cdbffa7b24b280e316db8accc"
+  version = "v1.5.1"
 
 [[projects]]
-  digest = "1:ed14edb4b5ec8eff801b1e8217ffaf021729c5a1dee9d940af5bb3302ab7297d"
+  digest = "1:e6d88834deb4e35eb998c74f4d042db6ccecaaf62c0f6d57905852800994af00"
   name = "go.uber.org/multierr"
   packages = ["."]
   pruneopts = "UT"
-  revision = "71e610a0e48dbda460d9c18adca8b5f2de04a7c1"
-  version = "v1.2.0"
+  revision = "824d08f79702fe5f54aca8400aa0d754318786e7"
+  version = "v1.4.0"
 
 [[projects]]
-  digest = "1:676160e6a4722b08e0e26b11521d575c2cb2b6f0c679e1ee6178c5d8dee51e5e"
+  branch = "master"
+  digest = "1:3032e90a153750ea149f68bf081f97ca738f041fba45c41c80737f572ffdf2f4"
+  name = "go.uber.org/tools"
+  packages = ["update-license"]
+  pruneopts = "UT"
+  revision = "2cfd321de3ee5d5f8a5fda2521d1703478334d98"
+
+[[projects]]
+  digest = "1:260048b6193e304ee294452a9e3410c474e3ce187248c7e2e4a2631207386f74"
   name = "go.uber.org/zap"
   packages = [
     ".",
@@ -336,12 +329,12 @@
     "zapcore",
   ]
   pruneopts = "UT"
-  revision = "27376062155ad36be76b0f12cf1572a221d3a48c"
-  version = "v1.10.0"
+  revision = "33e58d4d0120aa28d4df84cd244838c490846c9d"
+  version = "v1.13.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:23dfdf4b01b979f6600b5796ad10cdd4f38a0685492d1e3d74230a0e8020372d"
+  digest = "1:ef0c8131c4b5fccf1c6b62323bf741ea283fd49f6ad6e3d30d5f55b0d48920e8"
   name = "golang.org/x/crypto"
   packages = [
     "cast5",
@@ -354,11 +347,22 @@
     "ssh/terminal",
   ]
   pruneopts = "UT"
-  revision = "af544f31c8ac5794d2134b792e9eb714d9d8f9ce"
+  revision = "ecb85df213405b7d32e4d73cb5bbaace2ec88881"
 
 [[projects]]
   branch = "master"
-  digest = "1:100c00fede54e19af923c9e4599da4694449c95b37518b815805151a5f76af7f"
+  digest = "1:802fc3c45ff4507b6e4a5c0c5ea55836242aeac3b8eddfe31d5d80a3cac50731"
+  name = "golang.org/x/lint"
+  packages = [
+    ".",
+    "golint",
+  ]
+  pruneopts = "UT"
+  revision = "910be7a94367618fd0fd25eaabbee4fdc0ac7092"
+
+[[projects]]
+  branch = "master"
+  digest = "1:96c0696233ec0e7c9f472c53c8fa3d2c50f476341d24f101236367d80ef0ca19"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -369,29 +373,29 @@
     "idna",
   ]
   pruneopts = "UT"
-  revision = "d66e71096ffb9f08f36d9aefcae80ce319de6d68"
+  revision = "16171245cfb220d5317888b716d69c1fb4e7992b"
 
 [[projects]]
   branch = "master"
-  digest = "1:8d1c112fb1679fa097e9a9255a786ee47383fa2549a3da71bcb1334a693ebcfe"
+  digest = "1:911b45b658f5fab1a26259e2fd1085ab296f9d3e46117311d25f8dae51efe720"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "internal",
   ]
   pruneopts = "UT"
-  revision = "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33"
+  revision = "bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"
 
 [[projects]]
   branch = "master"
-  digest = "1:9f5be1dbb5091bb62d83fbb6db8e794adb8f0e05424679d6f15a17b670e38b4c"
+  digest = "1:b40521580b68b3cd78f87d1820116ba94090f426b7da3c4e3124e874e1f431dd"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "b09406accb4736d857a32bf9444cd7edae2ffa79"
+  revision = "d101bd2416d505c0448a6ce8a282482678040a89"
 
 [[projects]]
   digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
@@ -420,22 +424,32 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:cdd088b35bbf78713a6861a44a1bbe97e581861b6b8835c7f2211bbeca3671f6"
+  digest = "1:a2f668c709f9078828e99cb1768cb02e876cb81030545046a32b54b2ac2a9ea8"
   name = "golang.org/x/time"
   packages = ["rate"]
   pruneopts = "UT"
-  revision = "c4c64cad1fd0a1a8dab2523e04e61d35308e131e"
+  revision = "555d28b269f0569763d25dbe1a237ae74c6bcc82"
 
 [[projects]]
   branch = "master"
-  digest = "1:a0e46a43516d3f5ff0ba3636488b8a8df632b2986da49823cd8340c070c1a125"
-  name = "golang.org/x/xerrors"
+  digest = "1:048c2d9968a02665e815995397497caf0427a29789473b30cd21e209d5652328"
+  name = "golang.org/x/tools"
   packages = [
-    ".",
-    "internal",
+    "go/analysis",
+    "go/analysis/passes/inspect",
+    "go/ast/astutil",
+    "go/ast/inspector",
+    "go/buildutil",
+    "go/gcexportdata",
+    "go/internal/gcimporter",
+    "go/internal/packagesdriver",
+    "go/packages",
+    "go/types/objectpath",
+    "go/types/typeutil",
+    "internal/packagesinternal",
   ]
   pruneopts = "UT"
-  revision = "1b5146add8981d58be77b16229c0ff0f8bebd8c1"
+  revision = "61798d64f0258df3b7b6e3667997eaebec9c0d99"
 
 [[projects]]
   digest = "1:e0a1881f9e0564bebdeac98c75e59f07acdde6ed3a5396e0e613eaad31194866"
@@ -462,15 +476,49 @@
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:59f10c1537d2199d9115d946927fe31165959a95190849c82ff11e05803528b0"
+  digest = "1:55b110c99c5fdc4f14930747326acce56b52cfce60b24b1c03ef686ac0e46bb1"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "UT"
-  revision = "f221b8435cfb71e54062f6c6e99e9ade30b124d5"
-  version = "v2.2.4"
+  revision = "53403b58ad1b561927d19068c655246f2db79d48"
+  version = "v2.2.8"
 
 [[projects]]
-  digest = "1:faf52d216e0d651ee48a5ee8fb43f818a6c36bf4246282a5e30b8985da5581ff"
+  digest = "1:131158a88aad1f94854d0aa21a64af2802d0a470fb0f01cb33c04fafd2047111"
+  name = "honnef.co/go/tools"
+  packages = [
+    "arg",
+    "cmd/staticcheck",
+    "config",
+    "deprecated",
+    "facts",
+    "functions",
+    "go/types/typeutil",
+    "internal/cache",
+    "internal/passes/buildssa",
+    "internal/renameio",
+    "internal/sharedcheck",
+    "lint",
+    "lint/lintdsl",
+    "lint/lintutil",
+    "lint/lintutil/format",
+    "loader",
+    "printf",
+    "simple",
+    "ssa",
+    "ssautil",
+    "staticcheck",
+    "staticcheck/vrp",
+    "stylecheck",
+    "unused",
+    "version",
+  ]
+  pruneopts = "UT"
+  revision = "afd67930eec2a9ed3e9b19f684d17a062285f16a"
+  version = "2019.2.3"
+
+[[projects]]
+  digest = "1:6cec2c64c7569cd43b9fa5f8973f3a82919ebed36296d19312de057e59651b05"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -478,6 +526,7 @@
     "apps/v1",
     "apps/v1beta1",
     "apps/v1beta2",
+    "auditregistration/v1alpha1",
     "authentication/v1",
     "authentication/v1beta1",
     "authorization/v1",
@@ -506,11 +555,11 @@
     "storage/v1beta1",
   ]
   pruneopts = "UT"
-  revision = "9ad12a4af32677db3ae70bef3371bf9b618eb3a0"
-  version = "kubernetes-1.12.9"
+  revision = "5cb15d34447165a97c76ed5a60e4e99c8a01ecfe"
+  version = "kubernetes-1.13.4"
 
 [[projects]]
-  digest = "1:94babe94a374f3367bc9606841879a72591bef89a7370751b0cc3957f0d8c804"
+  digest = "1:0afffece6bd75faf0a0eae11afae4868416b140076c2df75894be751bdeab6e8"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -561,11 +610,11 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "UT"
-  revision = "01f179d85dbce0f2e0e4351a92394b38694b7cae"
-  version = "kubernetes-1.12.9"
+  revision = "86fb29eff6288413d76bd8506874fddd9fccdff0"
+  version = "kubernetes-1.13.4"
 
 [[projects]]
-  digest = "1:b6ba3dc64add5ba37fdfe21157d24794a87d40acc3e24cda8b380558a216ae7a"
+  digest = "1:bed5739a1e0698e3b456a40737195c0357f52ba0cc4d84c64fe9031b3ef292bc"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -579,6 +628,8 @@
     "informers/apps/v1",
     "informers/apps/v1beta1",
     "informers/apps/v1beta2",
+    "informers/auditregistration",
+    "informers/auditregistration/v1alpha1",
     "informers/autoscaling",
     "informers/autoscaling/v1",
     "informers/autoscaling/v2beta1",
@@ -628,6 +679,8 @@
     "kubernetes/typed/apps/v1beta1/fake",
     "kubernetes/typed/apps/v1beta2",
     "kubernetes/typed/apps/v1beta2/fake",
+    "kubernetes/typed/auditregistration/v1alpha1",
+    "kubernetes/typed/auditregistration/v1alpha1/fake",
     "kubernetes/typed/authentication/v1",
     "kubernetes/typed/authentication/v1/fake",
     "kubernetes/typed/authentication/v1beta1",
@@ -685,6 +738,7 @@
     "listers/apps/v1",
     "listers/apps/v1beta1",
     "listers/apps/v1beta2",
+    "listers/auditregistration/v1alpha1",
     "listers/autoscaling/v1",
     "listers/autoscaling/v2beta1",
     "listers/autoscaling/v2beta2",
@@ -729,8 +783,16 @@
     "util/retry",
   ]
   pruneopts = "UT"
-  revision = "4f3abb12cae2d6817e1b6d72d9cbc3d3a6ddf965"
-  version = "kubernetes-1.12.9"
+  revision = "b40b2a5939e43f7ffe0028ad67586b7ce50bb675"
+  version = "kubernetes-1.13.4"
+
+[[projects]]
+  digest = "1:93e82f25d75aba18436ad1ac042cb49493f096011f2541075721ed6f9e05c044"
+  name = "k8s.io/klog"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2ca9ad30301bf30a8a6e0fa2110db6b8df699a91"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -738,11 +800,11 @@
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
   pruneopts = "UT"
-  revision = "30be4d16710ac61bce31eb28a01054596fe6a9f1"
+  revision = "addea2498afe5a6d58f8bdcd9ae51363d12f12ef"
 
 [[projects]]
   branch = "master"
-  digest = "1:156f51e433a73aa3b879bfdb54add97e544278b854a51095d280cddf06aa6d0a"
+  digest = "1:306b7ce0dc1fa5396fb379493bd4b0a318d5932289a5e8260484e43c65384707"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -751,10 +813,20 @@
     "apis/duck/v1alpha1",
     "apis/duck/v1beta1",
     "configmap",
+    "kmeta",
     "kmp",
+    "tracker",
   ]
   pruneopts = "UT"
-  revision = "6335100d292c9ff09161c5c11714ffb8cc4c730a"
+  revision = "32ea8458157368451b8e0383aafdacdf5ec061c8"
+
+[[projects]]
+  digest = "1:36d2b2cb1fa6e4a731e38c3582c203213cdbc52c5f202af07db6dc6eeaec88dc"
+  name = "sigs.k8s.io/yaml"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9fc95527decd95bb9d28cc2eab08179b2d0f6971"
+  version = "v1.2.0"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/webhooks-extension/Gopkg.toml
+++ b/webhooks-extension/Gopkg.toml
@@ -25,20 +25,32 @@
 #   unused-packages = true
 
 [[override]]
+  name = "github.com/tektoncd/triggers"
+  version = "v0.2.1"
+
+[[override]]
   name = "k8s.io/api"
-  version = "kubernetes-1.12.9"
+  version = "kubernetes-1.13.4"
 
 [[override]]
   name = "k8s.io/apimachinery"
-  version = "kubernetes-1.12.9"
+  version = "kubernetes-1.13.4"
 
 [[override]]
   name = "k8s.io/client-go"
-  version = "kubernetes-1.12.9"
+  version = "kubernetes-1.13.4"
 
 [[override]]
-  name = "github.com/tektoncd/triggers"
-  branch = "master"
+  name = "github.com/openshift/client-go"
+  branch = "release-4.2"
+
+[[override]]
+  name = "github.com/openshift/api"
+  branch = "release-4.2"
+
+[[override]]
+  name = "github.com/tektoncd/pipeline"
+  version = "v0.10.1"
 
 [prune]
   go-tests = true

--- a/webhooks-extension/base/200-clusterrole-eventListener.yaml
+++ b/webhooks-extension/base/200-clusterrole-eventListener.yaml
@@ -21,3 +21,11 @@ rules:
   - taskruns
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - get
+  - watch

--- a/webhooks-extension/cmd/interceptor/interceptor.go
+++ b/webhooks-extension/cmd/interceptor/interceptor.go
@@ -15,14 +15,15 @@ package main
 
 import (
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"log"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 const (
@@ -32,6 +33,14 @@ const (
 func main() {
 	log.Print("Interceptor started")
 	http.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
+
+		// Copy Headers from the request onto the response
+		for k, valueArray := range request.Header {
+			for _, v := range valueArray {
+				writer.Header().Add(k, v)
+			}
+		}
+
 		foundTriggerName := request.Header.Get("Wext-Trigger-Name")
 		config, err := rest.InClusterConfig()
 		if err != nil {

--- a/webhooks-extension/docs/InstallPrereqs.md
+++ b/webhooks-extension/docs/InstallPrereqs.md
@@ -7,16 +7,15 @@
 
 **All Kubernetes Clusters:**
 
-- Knative requires a Kubernetes cluster running version v.1.11 or greater.
-- Cluster must also be supplied with sufficient resources, for a single node cluster _(6 CPUs, 10GiB Memory & 2.5GiB swap)_.
+- Cluster must be supplied with sufficient resources, for a single node cluster _(6 CPUs, 10GiB Memory & 2.5GiB swap)_.
 
 **Docker Desktop Only:**
 
-- Known to work with Kubernetes v1.11 and Kubernetes v1.14 (intermediate versions should work too, we just haven't tested it)
+- Known to work with Kubernetes v1.12 and Kubernetes v1.14 (intermediate versions should work too, we just haven't tested it)
 
 ## Install prereqs
 
-1. Install [Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) version 0.8
+1. Install [Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) version 0.10.1
 
 2. Install [Tekton Dashboard](https://github.com/tektoncd/dashboard)
 
@@ -30,7 +29,7 @@
         oc annotate route tekton-dashboard --overwrite haproxy.router.openshift.io/timeout=2m
         ```
 
-3. Install [Tekton Triggers](https://github.com/tektoncd/triggers/blob/master/docs/install.md#installing-tekton-triggers-1) version 0.1  
+3. Install [Tekton Triggers](https://github.com/tektoncd/triggers/blob/master/docs/install.md#installing-tekton-triggers-1) version 0.2.1  
 
 4. Install a LoadBalancer if one is not present on your cluster.  For Docker Desktop you could consider using nginx as per the following instructions:
 

--- a/webhooks-extension/pkg/endpoints/credentials.go
+++ b/webhooks-extension/pkg/endpoints/credentials.go
@@ -126,8 +126,8 @@ func (r Resource) credentialToSecret(cred credential, response *restful.Response
 	// Create new secret struct
 	secret := corev1.Secret{}
 	secret.Type = corev1.SecretTypeOpaque
-	secret.SetNamespace(r.Defaults.Namespace)
-	secret.SetName(cred.Name)
+	secret.ObjectMeta.Namespace = r.Defaults.Namespace
+	secret.ObjectMeta.Name = cred.Name
 	secret.Data = make(map[string][]byte)
 	secret.Data["accessToken"] = []byte(cred.AccessToken)
 	if cred.SecretToken != "" {
@@ -167,7 +167,7 @@ func secretToCredential(secret *corev1.Secret, mask bool) credential {
 	var cred credential
 	if secret.Data["accessToken"] != nil {
 		cred = credential{
-			Name:        secret.GetName(),
+			Name:        secret.ObjectMeta.Name,
 			AccessToken: string(secret.Data["accessToken"]),
 			SecretToken: string(secret.Data["secretToken"]),
 		}

--- a/webhooks-extension/pkg/endpoints/webhook_test.go
+++ b/webhooks-extension/pkg/endpoints/webhook_test.go
@@ -1,15 +1,15 @@
-/*
-Copyright 2019 The Tekton Authors
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-		http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// /*
+// Copyright 2019 The Tekton Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 		http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
 
 package endpoints
 
@@ -24,27 +24,28 @@ import (
 	"os"
 	"reflect"
 	"strconv"
-	"strings"
 	"testing"
+
+	"strings"
 
 	restful "github.com/emicklei/go-restful"
 	"github.com/google/go-cmp/cmp"
 	routesv1 "github.com/openshift/api/route/v1"
+	"github.com/tektoncd/experimental/webhooks-extension/pkg/utils"
 	pipelinesv1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	v1alpha1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-
-	utils "github.com/tektoncd/experimental/webhooks-extension/pkg/utils"
 )
 
 var server *httptest.Server
 
 type testcase struct {
-	Webhook          webhook
-	expectedProvider string
-	expectedAPIURL   string
+	Webhook            webhook
+	MonitorTriggerName string
+	expectedProvider   string
+	expectedAPIURL     string
 }
 
 // All event sources will be created in the "default" namespace because the INSTALLED_NAMESPACE env variable is not set
@@ -100,14 +101,41 @@ func TestGetOpenshiftServiceDashboardURL(t *testing.T) {
 
 func TestNewTrigger(t *testing.T) {
 	r := dummyResource()
-
-	params := []pipelinesv1alpha1.Param{
-		{Name: "My-Param1", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "myParam1Value"}},
-		{Name: "My-Param2", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "myParam2Value"}},
+	trigger := r.newTrigger("myName", "myBindingName", "myTemplateName", "myRepoURL", "myEvent", "mySecretName", "foo1234")
+	expectedTrigger := v1alpha1.EventListenerTrigger{
+		Name: "myName",
+		Bindings: []*v1alpha1.EventListenerBinding{
+			{
+				Name:       "myBindingName",
+				APIVersion: "v1alpha1",
+			},
+			{
+				Name:       "foo1234",
+				APIVersion: "v1alpha1",
+			},
+		},
+		Template: v1alpha1.EventListenerTemplate{
+			Name:       "myTemplateName",
+			APIVersion: "v1alpha1",
+		},
+		Interceptors: []*v1alpha1.EventInterceptor{
+			{
+				Webhook: &v1alpha1.WebhookInterceptor{
+					Header: []pipelinesv1alpha1.Param{
+						{Name: "Wext-Trigger-Name", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "myName"}},
+						{Name: "Wext-Repository-Url", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "myRepoURL"}},
+						{Name: "Wext-Incoming-Event", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "myEvent"}},
+						{Name: "Wext-Secret-Name", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "mySecretName"}}},
+					ObjectRef: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Service",
+						Name:       "tekton-webhooks-extension-validator",
+						Namespace:  r.Defaults.Namespace,
+					},
+				},
+			},
+		},
 	}
-
-	trigger := r.newTrigger("myName", "myBindingName", "myTemplateName", "myRepoURL", "myEvent", "mySecretName", params)
-	expectedTrigger := createTrigger("myName", "myBindingName", "myTemplateName", "myRepoURL", "myEvent", "mySecretName", params, r)
 
 	if !reflect.DeepEqual(trigger, expectedTrigger) {
 		t.Errorf("Eventlistener trigger did not match expectation")
@@ -117,7 +145,6 @@ func TestNewTrigger(t *testing.T) {
 }
 
 func TestGetParams(t *testing.T) {
-
 	var testcases = []testcase{
 		{
 			Webhook: webhook{
@@ -210,156 +237,351 @@ func TestGetParams(t *testing.T) {
 	}
 }
 
-func TestCreateEventListener(t *testing.T) {
-	var testcases = []testcase{
+func TestCompareRepos(t *testing.T) {
+	type testcase struct {
+		url1          string
+		url2          string
+		expectedMatch bool
+		expectedError string
+	}
+	testcases := []testcase{
+		{
+			url1:          "Http://GitHub.Com/foo/BAR",
+			url2:          "http://github.com/foo/bar",
+			expectedMatch: true,
+		},
+		{
+			url1:          "Http://GitHub.Com/foo/BAR",
+			url2:          "http://github.com/foo/bar.git",
+			expectedMatch: true,
+		},
+		{
+			url1:          "Http://github.com/foo/bar.git",
+			url2:          "http://github.com/foo/bar",
+			expectedMatch: true,
+		},
+		{
+			url1:          "http://gitlab.com/foo/bar",
+			url2:          "http://github.com/foo/bar",
+			expectedMatch: false,
+		},
+		{
+			url1:          "http://github.com/bar/bar",
+			url2:          "http://github.com/foo/bar",
+			expectedMatch: false,
+		},
+		{
+			url1:          "http://gitlab.com/foo/bar",
+			url2:          "http://gitLAB.com/FoO/bar",
+			expectedMatch: true,
+		},
+	}
+	r := dummyResource()
+	for _, tt := range testcases {
+		match, err := r.compareGitRepoNames(tt.url1, tt.url2)
+		if tt.expectedMatch != match {
+			if err != nil {
+				t.Errorf("url mismatch with error %s", err.Error())
+			}
+			t.Errorf("url mismatch unexpected: %s, %s", tt.url1, tt.url2)
+		}
+	}
+}
+
+func TestGenerateMonitorTriggerName(t *testing.T) {
+	r := dummyResource()
+	var triggers []v1alpha1.EventListenerTrigger
+	triggersMap := make(map[string]v1alpha1.EventListenerTrigger)
+	for i := 0; i < 2000; i++ {
+		t := r.newTrigger("foo-"+strconv.Itoa(i), "foo", "foo", "https://foo.com/foo/bar", "foo", "foo", "foo")
+		triggers = append(triggers, t)
+		triggersMap["foo-"+strconv.Itoa(i)] = t
+	}
+
+	for j := 0; j < 5000; j++ {
+		name := r.generateMonitorTriggerName("foo-", triggers)
+		if _, ok := triggersMap[name]; ok {
+			t.Errorf("generateMonitorTriggerName did not provide a unique name")
+		}
+	}
+}
+
+func TestDoesMonitorExist(t *testing.T) {
+	type testcase struct {
+		Webhook           webhook
+		TriggerNamePrefix string
+		Expected          bool
+	}
+	testcases := []testcase{
 		{
 			Webhook: webhook{
 				Name:             "name1",
-				Namespace:        installNs,
-				GitRepositoryURL: "https://github.com/owner/repo",
+				Namespace:        "foo1",
+				GitRepositoryURL: "https://github.com/owner/repo1",
 				AccessTokenRef:   "token1",
 				Pipeline:         "pipeline1",
-				DockerRegistry:   "registry1",
-				HelmSecret:       "helmsecret1",
-				ReleaseName:      "releasename1",
-				PullTask:         "pulltask1",
-				OnSuccessComment: "onsuccesscomment1",
-				OnFailureComment: "onfailurecomment1",
-				OnTimeoutComment: "ontimeoutcomment1",
-				OnMissingComment: "onmissingcomment1",
+				ServiceAccount:   "my-sa",
 			},
-			expectedProvider: "github",
-			expectedAPIURL:   "https://api.github.com/",
+			TriggerNamePrefix: "name1-",
+			Expected:          true,
 		},
 		{
 			Webhook: webhook{
 				Name:             "name2",
-				Namespace:        "foo",
+				Namespace:        "foo2",
 				GitRepositoryURL: "https://github.com/owner/repo2",
 				AccessTokenRef:   "token2",
 				Pipeline:         "pipeline2",
-				DockerRegistry:   "registry2",
-				OnSuccessComment: "onsuccesscomment2",
-				OnFailureComment: "onfailurecomment2",
-				OnTimeoutComment: "ontimeoutcomment2",
-				OnMissingComment: "onmissingcomment2",
-			},
-			expectedProvider: "github",
-			expectedAPIURL:   "https://api.github.com/",
-		},
-		{
-			Webhook: webhook{
-				Name:             "name3",
-				Namespace:        "foo2",
-				GitRepositoryURL: "https://github.com/owner/repo3",
-				AccessTokenRef:   "token3",
-				Pipeline:         "pipeline3",
 				ServiceAccount:   "my-sa",
-				PullTask:         "check-me",
 			},
-			expectedProvider: "github",
-			expectedAPIURL:   "https://api.github.com/",
+			TriggerNamePrefix: "name2-",
+			Expected:          false,
 		},
 	}
 
 	r := dummyResource()
 
-	for _, tt := range testcases {
-		el, err := r.createEventListener(tt.Webhook, "install-namespace", "my/monitor/name")
-		if err != nil {
-			t.Errorf("Error creating eventlistener: %s", err)
+	// Create some pre-existing triggers to pretend to be the monitor
+	// we will cheat and use webhook name as the prefix
+	// for the trigger name
+	var eventListenerTriggers []v1alpha1.EventListenerTrigger
+	for i, tt := range testcases {
+		if tt.Expected {
+			t := r.newTrigger(tt.Webhook.Name+"-"+strconv.Itoa(i), "foo", "foo", tt.Webhook.GitRepositoryURL, "foo", "foo", "foo")
+			eventListenerTriggers = append(eventListenerTriggers, t)
 		}
+	}
 
-		if el.Name != "tekton-webhooks-eventlistener" {
-			t.Errorf("Eventlistener name was: %s, expected: tekton-webhooks-eventlistener", el.Name)
-		}
-		if el.Namespace != "install-namespace" {
-			t.Errorf("Eventlistener namespace was: %s, expected: install-namespace", el.Namespace)
-		}
-		if el.Spec.ServiceAccountName != "tekton-webhooks-extension-eventlistener" {
-			t.Errorf("Eventlistener service account was: %s, expected tekton-webhooks-extension-eventlistener", el.Spec.ServiceAccountName)
-		}
-		if len(el.Spec.Triggers) != 3 {
-			t.Errorf("Eventlistener had %d triggers, but expected 3", len(el.Spec.Triggers))
-		} else {
-			expectedTriggers := getExpectedTriggers(tt.Webhook, "my/monitor/name", r, tt.expectedProvider, tt.expectedAPIURL)
-			if !reflect.DeepEqual(el.Spec.Triggers, expectedTriggers) {
-				t.Errorf("Eventlistener trigger did not match expectation")
-				t.Errorf("got: %+v", el.Spec.Triggers)
-				t.Errorf("expected: %+v", expectedTriggers)
-			}
-		}
-		err = r.TriggersClient.TektonV1alpha1().EventListeners("install-namespace").Delete(el.Name, &metav1.DeleteOptions{})
-		if err != nil {
-			t.Error("Error occurred deleting eventlistener")
+	// Now test
+	for _, tt := range testcases {
+		found, _ := r.doesMonitorExist(tt.TriggerNamePrefix, tt.Webhook, eventListenerTriggers)
+		if tt.Expected != found {
+			t.Errorf("Unexpected result checking existence of trigger with monitorprefix %s", tt.TriggerNamePrefix)
 		}
 	}
 }
 
-func TestUpdateEventListenerTriggerListing(t *testing.T) {
-	var testcases = []testcase{
+func TestGetMonitorBindingName(t *testing.T) {
+	type testcase struct {
+		repoURL             string
+		monitorTask         string
+		expectedBindingName string
+		expectedError       string
+	}
+	testcases := []testcase{
 		{
-			Webhook: webhook{
-				Name:             "name1",
-				Namespace:        installNs,
-				GitRepositoryURL: "https://github.com/owner/repo",
-				AccessTokenRef:   "token1",
-				Pipeline:         "pipeline1",
-				DockerRegistry:   "registry1",
-				HelmSecret:       "helmsecret1",
-				ReleaseName:      "releasename1",
-				PullTask:         "pulltask1",
-				OnSuccessComment: "onsuccesscomment1",
-				OnFailureComment: "onfailurecomment1",
-				OnTimeoutComment: "ontimeoutcomment1",
-				OnMissingComment: "onmissingcomment1",
-			},
-			expectedProvider: "github",
-			expectedAPIURL:   "https://api.github.com/",
+			repoURL:             "http://foo.github.com/wibble/fish",
+			monitorTask:         "monitor-task",
+			expectedBindingName: "monitor-task-github-binding",
 		},
 		{
-			Webhook: webhook{
-				Name:             "name2",
-				Namespace:        "foo",
-				GitRepositoryURL: "https://github.com/owner/repo",
-				AccessTokenRef:   "token2",
-				Pipeline:         "pipeline2",
-				DockerRegistry:   "registry2",
-				OnSuccessComment: "onsuccesscomment2",
-				OnFailureComment: "onfailurecomment2",
-				OnTimeoutComment: "ontimeoutcomment2",
-				OnMissingComment: "onmissingcomment2",
-			},
-			expectedProvider: "github",
-			expectedAPIURL:   "https://api.github.com/",
+			repoURL:             "https://github.bob.com/foo/dog",
+			monitorTask:         "wibble",
+			expectedBindingName: "wibble-binding",
 		},
 		{
-			Webhook: webhook{
-				Name:             "name3",
-				Namespace:        "foo2",
-				GitRepositoryURL: "https://github.com/owner/repo2",
-				AccessTokenRef:   "token3",
-				Pipeline:         "pipeline3",
-				ServiceAccount:   "my-sa",
-				PullTask:         "check-me",
-			},
-			expectedProvider: "github",
-			expectedAPIURL:   "https://api.github.com/",
+			repoURL:             "http://foo.gitlab.com/wibble/fish",
+			monitorTask:         "monitor-task",
+			expectedBindingName: "monitor-task-gitlab-binding",
+		},
+		{
+			repoURL:       "",
+			monitorTask:   "monitor-task",
+			expectedError: "no repository URL provided on call to GetGitProviderAndAPIURL",
+		},
+		{
+			repoURL:             "http://foo.gitlab.com/wibble/fish",
+			monitorTask:         "",
+			expectedBindingName: "",
+			expectedError:       "no monitor task set on call to getMonitorBindingName",
+		},
+		{
+			repoURL:             "https://hungry.dinosaur.com/wibble/fish",
+			monitorTask:         "monitor-task",
+			expectedBindingName: "",
+			expectedError:       "Git Provider for project URL: https://hungry.dinosaur.com/wibble/fish not recognized",
+		},
+	}
+
+	r := dummyResource()
+	for _, tt := range testcases {
+		name, err := r.getMonitorBindingName(tt.repoURL, tt.monitorTask)
+		if err != nil {
+			if tt.expectedError != err.Error() {
+				t.Errorf("unexpected error in TestGetMonitorBindingName: %s", err.Error())
+			}
+		}
+		if name != tt.expectedBindingName {
+			t.Errorf("mismatch in expected binding name, expected %s got %s", tt.expectedBindingName, name)
+		}
+	}
+}
+
+func TestCreateEventListener(t *testing.T) {
+	hook := webhook{
+		Name:             "name1",
+		Namespace:        installNs,
+		GitRepositoryURL: "https://github.com/owner/repo",
+		AccessTokenRef:   "token1",
+		Pipeline:         "pipeline1",
+		DockerRegistry:   "registry1",
+		HelmSecret:       "helmsecret1",
+		ReleaseName:      "releasename1",
+		PullTask:         "pulltask1",
+	}
+
+	r := dummyResource()
+	createTriggerResources(hook, r)
+
+	_, owner, repo, _ := r.getGitValues(hook.GitRepositoryURL)
+	monitorTriggerNamePrefix := owner + "." + repo
+
+	GetTriggerBindingObjectMeta = FakeGetTriggerBindingObjectMeta
+
+	el, err := r.createEventListener(hook, r.Defaults.Namespace, monitorTriggerNamePrefix)
+	if err != nil {
+		t.Errorf("Error creating eventlistener: %s", err)
+	}
+
+	if el.Name != "tekton-webhooks-eventlistener" {
+		t.Errorf("Eventlistener name was: %s, expected: tekton-webhooks-eventlistener", el.Name)
+	}
+	if el.Namespace != r.Defaults.Namespace {
+		t.Errorf("Eventlistener namespace was: %s, expected: %s", el.Namespace, r.Defaults.Namespace)
+	}
+	if el.Spec.ServiceAccountName != "tekton-webhooks-extension-eventlistener" {
+		t.Errorf("Eventlistener service account was: %s, expected tekton-webhooks-extension-eventlistener", el.Spec.ServiceAccountName)
+	}
+	if len(el.Spec.Triggers) != 3 {
+		t.Errorf("Eventlistener had %d triggers, but expected 3", len(el.Spec.Triggers))
+	}
+
+	hooks, err := r.getHooksForRepo(hook.GitRepositoryURL)
+	if err != nil {
+		t.Errorf("Error occurred retrieving hook in getHooksForRepo: %s", err.Error())
+	}
+	if len(hooks) != 1 {
+		t.Errorf("Unexpected number of hooks returned from getHooksForRepo: %+v", hooks)
+	}
+	if !reflect.DeepEqual(hooks[0], hook) {
+		t.Errorf("Hook didn't match: Got %+v, Expected %+v", hooks[0], hook)
+	}
+
+	expectedTriggers := r.getExpectedPushAndPullRequestTriggersForWebhook(hook)
+	for _, trigger := range el.Spec.Triggers {
+		found := false
+		for _, t := range expectedTriggers {
+			if reflect.DeepEqual(t, trigger) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			// Should be the monitor, can't deep equal monitor due to created name
+			if !strings.HasPrefix(trigger.Name, owner+"."+repo) {
+				t.Errorf("trigger %+v unexpected", trigger)
+			}
+			// Check params on monitor
+			os.Setenv("SSL_VERIFICATION_ENABLED", "true")
+			_, expectedMonitorParams := getExpectedParams(hook, r, "github", "https://api.github.com/")
+			wextMonitorBindingFound := false
+			for _, monitorBinding := range trigger.Bindings {
+				if strings.HasPrefix(monitorBinding.Name, "wext-") {
+					wextMonitorBindingFound = true
+					binding, err := r.TriggersClient.TektonV1alpha1().TriggerBindings(r.Defaults.Namespace).Get(monitorBinding.Name, metav1.GetOptions{})
+					if err != nil {
+						t.Errorf("%s", err.Error())
+					}
+					if !reflect.DeepEqual(binding.Spec.Params, expectedMonitorParams) {
+						t.Error("The monitor params returned from r.getParams were not as expected")
+						t.Errorf("monitorParams: %+v", binding.Spec.Params)
+						t.Errorf("expected: %+v", expectedMonitorParams)
+					}
+				}
+			}
+			if !wextMonitorBindingFound {
+				t.Errorf("Did not find monitor bindings")
+			}
+		}
+	}
+
+	err = r.TriggersClient.TektonV1alpha1().EventListeners(r.Defaults.Namespace).Delete(el.Name, &metav1.DeleteOptions{})
+	if err != nil {
+		t.Errorf("Error occurred deleting eventlistener: %s", err.Error())
+	}
+
+	err = r.deleteAllBindings()
+	if err != nil {
+		t.Errorf("Error occurred deleting triggerbindings: %s", err.Error())
+	}
+}
+
+func TestUpdateEventListener(t *testing.T) {
+	var testcases = []webhook{
+		{
+			Name:             "name1",
+			Namespace:        installNs,
+			GitRepositoryURL: "https://github.com/owner/repo",
+			AccessTokenRef:   "token1",
+			Pipeline:         "pipeline1",
+			DockerRegistry:   "registry1",
+			HelmSecret:       "helmsecret1",
+			ReleaseName:      "releasename1",
+			PullTask:         "pulltask1",
+			OnSuccessComment: "onsuccesscomment1",
+			OnFailureComment: "onfailurecomment1",
+			OnTimeoutComment: "ontimeoutcomment1",
+			OnMissingComment: "onmissingcomment1",
+		},
+		{
+			Name:             "name2",
+			Namespace:        "foo",
+			GitRepositoryURL: "https://github.com/owner/repo",
+			AccessTokenRef:   "token2",
+			Pipeline:         "pipeline2",
+			DockerRegistry:   "registry2",
+			PullTask:         "pulltask1",
+			OnSuccessComment: "onsuccesscomment2",
+			OnFailureComment: "onfailurecomment2",
+			OnTimeoutComment: "ontimeoutcomment2",
+			OnMissingComment: "onmissingcomment2",
+		},
+		{
+			Name:             "name3",
+			Namespace:        "foo2",
+			GitRepositoryURL: "https://github.com/owner/repo2",
+			AccessTokenRef:   "token3",
+			Pipeline:         "pipeline3",
+			ServiceAccount:   "my-sa",
+			PullTask:         "check-me",
 		},
 	}
 
 	r := dummyResource()
 	os.Setenv("SERVICE_ACCOUNT", "tekton-test-service-account")
+	GetTriggerBindingObjectMeta = FakeGetTriggerBindingObjectMeta
 
-	el, err := r.createEventListener(testcases[0].Webhook, "install-namespace", testcases[0].Webhook.GitRepositoryURL[strings.LastIndex(testcases[0].Webhook.GitRepositoryURL, ":")+3:])
+	createTriggerResources(testcases[0], r)
+	_, owner, repo, _ := r.getGitValues(testcases[0].GitRepositoryURL)
+	monitorTriggerNamePrefix := owner + "." + repo
+
+	el, err := r.createEventListener(testcases[0], r.Defaults.Namespace, monitorTriggerNamePrefix)
 	if err != nil {
 		t.Errorf("Error creating eventlistener: %s", err)
 	}
-	el, err = r.updateEventListener(el, testcases[1].Webhook, testcases[1].Webhook.GitRepositoryURL[strings.LastIndex(testcases[1].Webhook.GitRepositoryURL, ":")+3:])
+
+	_, owner, repo, _ = r.getGitValues(testcases[1].GitRepositoryURL)
+	monitorTriggerNamePrefix = owner + "." + repo
+
+	el, err = r.updateEventListener(el, testcases[1], monitorTriggerNamePrefix)
 	if err != nil {
 		t.Errorf("Error updating eventlistener - first time: %s", err)
 	}
-	el, err = r.updateEventListener(el, testcases[2].Webhook, testcases[2].Webhook.GitRepositoryURL[strings.LastIndex(testcases[2].Webhook.GitRepositoryURL, ":")+3:])
+
+	_, owner, repo, _ = r.getGitValues(testcases[2].GitRepositoryURL)
+	monitorTriggerNamePrefix = owner + "." + repo
+
+	el, err = r.updateEventListener(el, testcases[2], monitorTriggerNamePrefix)
 	if err != nil {
 		t.Errorf("Error updating eventlistener - second time: %s", err)
 	}
@@ -367,32 +589,16 @@ func TestUpdateEventListenerTriggerListing(t *testing.T) {
 	// Two of the webhooks are on the same repo - therefore only one monitor trigger for these
 	if len(el.Spec.Triggers) != 8 {
 		t.Errorf("Eventlistener had %d triggers, but expected 8", len(el.Spec.Triggers))
-	} else {
-		// getExpectedTriggers returns 3 triggers per hook (push, pullrequest and monitor)
-		// in the event that multiple webhooks have been created for the same repository we
-		// would only expect one occurence of the monitor, so we need to filter the expected
-		// triggers such that the monitor is only expected once.
-		expectedTriggers := []v1alpha1.EventListenerTrigger{}
-		triggerNamesExpected := make(map[string]string)
-		for _, tt := range testcases {
-			for _, t := range getExpectedTriggers(tt.Webhook, tt.Webhook.GitRepositoryURL[strings.LastIndex(tt.Webhook.GitRepositoryURL, ":")+3:], r, tt.expectedProvider, tt.expectedAPIURL) {
-				if triggerNamesExpected[t.Name] == "" {
-					triggerNamesExpected[t.Name] = "added"
-					expectedTriggers = append(expectedTriggers, t)
-				}
-			}
-		}
-
-		if !reflect.DeepEqual(el.Spec.Triggers, expectedTriggers) {
-			t.Errorf("Eventlistener trigger did not match expectation")
-			t.Errorf("got: %+v", el.Spec.Triggers)
-			t.Errorf("expected: %+v", expectedTriggers)
-		}
 	}
 
-	err = r.TriggersClient.TektonV1alpha1().EventListeners("install-namespace").Delete(el.Name, &metav1.DeleteOptions{})
+	err = r.TriggersClient.TektonV1alpha1().EventListeners(r.Defaults.Namespace).Delete(el.Name, &metav1.DeleteOptions{})
 	if err != nil {
-		t.Error("Error occurred deleting eventlistener")
+		t.Errorf("Error occurred deleting eventlistener: %s", err.Error())
+	}
+
+	err = r.deleteAllBindings()
+	if err != nil {
+		t.Errorf("Error occurred deleting triggerbindings: %s", err.Error())
 	}
 
 }
@@ -426,6 +632,7 @@ func TestDeleteFromEventListener(t *testing.T) {
 				AccessTokenRef:   "token2",
 				Pipeline:         "pipeline2",
 				DockerRegistry:   "registry2",
+				PullTask:         "pulltask1",
 				OnSuccessComment: "onsuccesscomment2",
 				OnFailureComment: "onfailurecomment2",
 				OnTimeoutComment: "ontimeoutcomment2",
@@ -437,12 +644,20 @@ func TestDeleteFromEventListener(t *testing.T) {
 	}
 
 	r := dummyResource()
+	GetTriggerBindingObjectMeta = FakeGetTriggerBindingObjectMeta
 	os.Setenv("SERVICE_ACCOUNT", "tekton-test-service-account")
-	el, err := r.createEventListener(testcases[0].Webhook, "install-namespace", testcases[0].Webhook.GitRepositoryURL[strings.LastIndex(testcases[0].Webhook.GitRepositoryURL, ":")+3:])
+
+	_, owner, repo, _ := r.getGitValues(testcases[0].Webhook.GitRepositoryURL)
+	monitorTriggerNamePrefix := owner + "." + repo
+
+	el, err := r.createEventListener(testcases[0].Webhook, r.Defaults.Namespace, monitorTriggerNamePrefix)
 	if err != nil {
 		t.Errorf("Error creating eventlistener: %s", err)
 	}
-	el, err = r.updateEventListener(el, testcases[1].Webhook, testcases[1].Webhook.GitRepositoryURL[strings.LastIndex(testcases[1].Webhook.GitRepositoryURL, ":")+3:])
+	_, owner, repo, _ = r.getGitValues(testcases[1].Webhook.GitRepositoryURL)
+	monitorTriggerNamePrefix = owner + "." + repo
+
+	el, err = r.updateEventListener(el, testcases[1].Webhook, monitorTriggerNamePrefix)
 	if err != nil {
 		t.Errorf("Error updating eventlistener: %s", err)
 	}
@@ -451,46 +666,22 @@ func TestDeleteFromEventListener(t *testing.T) {
 		t.Errorf("Eventlistener had %d triggers, but expected 5", len(el.Spec.Triggers))
 	}
 
-	// getExpectedTriggers returns 3 triggers per hook (push, pullrequest and monitor)
-	// in the event that multiple webhooks have been created for the same repository we
-	// would only expect one occurence of the monitor, so we need to filter the expected
-	// triggers such that the monitor is only expected once.
-	expectedTriggers := []v1alpha1.EventListenerTrigger{}
-	triggerNamesExpected := make(map[string]string)
-	for _, tt := range testcases {
-		for _, t := range getExpectedTriggers(tt.Webhook, tt.Webhook.GitRepositoryURL[strings.LastIndex(tt.Webhook.GitRepositoryURL, ":")+3:], r, tt.expectedProvider, tt.expectedAPIURL) {
-			if triggerNamesExpected[t.Name] == "" {
-				triggerNamesExpected[t.Name] = "added"
-				expectedTriggers = append(expectedTriggers, t)
-			}
-		}
-	}
+	_, gitOwner, gitRepo, _ := r.getGitValues(testcases[1].Webhook.GitRepositoryURL)
+	monitorTriggerNamePrefix = gitOwner + "." + gitRepo
 
-	if !reflect.DeepEqual(el.Spec.Triggers, expectedTriggers) {
-		t.Errorf("Eventlistener trigger did not match expectation")
-		t.Errorf("got: %+v", el.Spec.Triggers)
-		t.Errorf("expected: %+v", expectedTriggers)
-	}
-
-	err = r.deleteFromEventListener(testcases[1].Webhook.Name+"-"+testcases[1].Webhook.Namespace, "install-namespace", testcases[1].Webhook.GitRepositoryURL[strings.LastIndex(testcases[1].Webhook.GitRepositoryURL, ":")+3:], "https://github.com/owner/repo")
+	err = r.deleteFromEventListener(testcases[1].Webhook.Name+"-"+testcases[1].Webhook.Namespace, r.Defaults.Namespace, monitorTriggerNamePrefix, testcases[1].Webhook)
 	if err != nil {
 		t.Errorf("Error deleting entry from eventlistener: %s", err)
 	}
 
-	el, err = r.TriggersClient.TektonV1alpha1().EventListeners("install-namespace").Get("", metav1.GetOptions{})
+	el, err = r.TriggersClient.TektonV1alpha1().EventListeners(r.Defaults.Namespace).Get("", metav1.GetOptions{})
 	if len(el.Spec.Triggers) != 3 {
 		t.Errorf("Eventlistener had %d triggers, but expected 3", len(el.Spec.Triggers))
 	}
 
-	expectedRemainingTrigger := getExpectedTriggers(testcases[0].Webhook, testcases[0].Webhook.GitRepositoryURL[strings.LastIndex(testcases[0].Webhook.GitRepositoryURL, ":")+3:], r, testcases[0].expectedProvider, testcases[0].expectedAPIURL)
-	if !reflect.DeepEqual(el.Spec.Triggers, expectedRemainingTrigger) {
-		t.Errorf("Eventlistener trigger did not match expectation")
-		t.Errorf("got: %+v", el.Spec.Triggers)
-		t.Errorf("expected: %+v", expectedRemainingTrigger)
-	}
 }
 
-func TestCreateAndDeleteWebhook(t *testing.T) {
+func TestFailToCreateWebhookNoTriggerResources(t *testing.T) {
 	r := setUpServer()
 	os.Setenv("SERVICE_ACCOUNT", "tekton-test-service-account")
 
@@ -500,51 +691,26 @@ func TestCreateAndDeleteWebhook(t *testing.T) {
 	}
 	r = updateResourceDefaults(r, newDefaults)
 
-	var hooks = []webhook{
-		{
-			Name:             "name1",
-			Namespace:        installNs,
-			GitRepositoryURL: "https://github.com/owner/repo",
-			AccessTokenRef:   "token1",
-			Pipeline:         "pipeline1",
-			DockerRegistry:   "registry1",
-			HelmSecret:       "helmsecret1",
-			ReleaseName:      "releasename1",
-			OnSuccessComment: "onsuccesscomment1",
-			OnFailureComment: "onfailurecomment1",
-			OnTimeoutComment: "ontimeoutcomment1",
-			OnMissingComment: "onmissingcomment1",
-		},
-		{
-			Name:             "name2",
-			Namespace:        "foo",
-			GitRepositoryURL: "https://github.com/owner/repo",
-			AccessTokenRef:   "token2",
-			Pipeline:         "pipeline2",
-			DockerRegistry:   "registry2",
-			OnSuccessComment: "onsuccesscomment2",
-			OnFailureComment: "onfailurecomment2",
-			OnTimeoutComment: "ontimeoutcomment2",
-			OnMissingComment: "onmissingcomment2",
-		},
-		{
-			Name:             "name3",
-			Namespace:        "foo2",
-			GitRepositoryURL: "https://github.com/owner/repo2",
-			AccessTokenRef:   "token3",
-			Pipeline:         "pipeline3",
-			ServiceAccount:   "my-sa",
-			PullTask:         "check-me",
-		},
+	hook := webhook{
+		Name:             "name1",
+		Namespace:        installNs,
+		GitRepositoryURL: "https://github.com/owner/repo",
+		AccessTokenRef:   "token1",
+		Pipeline:         "pipeline1",
+		DockerRegistry:   "registry1",
+		HelmSecret:       "helmsecret1",
+		ReleaseName:      "releasename1",
+		OnSuccessComment: "onsuccesscomment1",
+		OnFailureComment: "onfailurecomment1",
+		OnTimeoutComment: "ontimeoutcomment1",
+		OnMissingComment: "onmissingcomment1",
 	}
 
-	for _, h := range hooks {
-		resp := createWebhook(h, r)
-		if resp.StatusCode() != 400 {
-			t.Errorf("Webhook creation succeeded for webhook %s but was expected to fail due to lack of triggertemplate and triggerbinding", h.Name)
-		}
+	resp := createWebhook(hook, r)
+	if resp.StatusCode() != 400 {
+		t.Errorf("Webhook creation succeeded for webhook %s but was expected to fail due to lack of triggertemplate and triggerbinding", hook.Name)
 	}
-	testGetAllWebhooks([]webhook{}, r, t)
+
 }
 
 func TestDockerRegUnset(t *testing.T) {
@@ -575,7 +741,7 @@ func TestDockerRegSet(t *testing.T) {
 }
 
 func TestDeleteByNameNoName405(t *testing.T) {
-
+	setUpServer()
 	httpReq, _ := http.NewRequest(http.MethodDelete, server.URL+"/webhooks/?namespace=foo&repository=bar", nil)
 	response, _ := http.DefaultClient.Do(httpReq)
 	if response.StatusCode != 405 {
@@ -610,7 +776,7 @@ func TestDeleteByNameNoRepoBadRequest(t *testing.T) {
 	}
 }
 
-//------------------- UTILS -------------------//
+// //------------------- UTILS -------------------//
 
 func createDashboardService(name, labelValue string) *corev1.Service {
 	labels := make(map[string]string)
@@ -703,68 +869,99 @@ func getExpectedParams(hook webhook, r *Resource, expectedProvider, expectedAPIU
 	return
 }
 
-func getExpectedTriggers(hook webhook, monitorTriggerName string, r *Resource, expectedProvider, expectedAPIURL string) []v1alpha1.EventListenerTrigger {
-	actions = pipelinesv1alpha1.Param{Name: "Wext-Incoming-Actions", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "opened,reopened,synchronize"}}
-	expectedHookParams, expectedMonitorParams := getExpectedParams(hook, r, expectedProvider, expectedAPIURL)
-	push := createTrigger(hook.Name+"-"+hook.Namespace+"-push-event",
-		hook.Pipeline+"-push-binding",
-		hook.Pipeline+"-template",
-		hook.GitRepositoryURL,
-		"push, Push Hook, Tag Push Hook",
-		hook.AccessTokenRef,
-		expectedHookParams,
-		r)
-
-	pullRequest := createTrigger(hook.Name+"-"+hook.Namespace+"-pullrequest-event",
-		hook.Pipeline+"-pullrequest-binding",
-		hook.Pipeline+"-template",
-		hook.GitRepositoryURL,
-		"pull_request, Merge Request Hook",
-		hook.AccessTokenRef,
-		expectedHookParams,
-		r)
-	pullRequest.Interceptor.Header = append(pullRequest.Interceptor.Header, actions)
-
-	monitor := createTrigger(monitorTriggerName,
-		hook.PullTask+"-binding",
-		hook.PullTask+"-template",
-		hook.GitRepositoryURL,
-		"pull_request, Merge Request Hook",
-		hook.AccessTokenRef,
-		expectedMonitorParams,
-		r)
-	monitor.Interceptor.Header = append(monitor.Interceptor.Header, actions)
-
-	triggers := []v1alpha1.EventListenerTrigger{push, pullRequest, monitor}
-	return triggers
+func (r Resource) deleteAllBindings() error {
+	tbs, err := r.TriggersClient.TektonV1alpha1().TriggerBindings(r.Defaults.Namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, tb := range tbs.Items {
+		err = r.TriggersClient.TektonV1alpha1().TriggerBindings(r.Defaults.Namespace).Delete(tb.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-func createTrigger(name, bindingName, templateName, repoURL, event, secretName string, params []pipelinesv1alpha1.Param, r *Resource) v1alpha1.EventListenerTrigger {
-	return v1alpha1.EventListenerTrigger{
-		Name: name,
-		Binding: v1alpha1.EventListenerBinding{
-			Name:       bindingName,
-			APIVersion: "v1alpha1",
+func (r Resource) getExpectedPushAndPullRequestTriggersForWebhook(webhook webhook) []v1alpha1.EventListenerTrigger {
+
+	triggers := []v1alpha1.EventListenerTrigger{
+		{
+			Name: webhook.Name + "-" + webhook.Namespace + "-push-event",
+			Bindings: []*v1alpha1.EventListenerBinding{
+				{
+					Name:       webhook.Pipeline + "-push-binding",
+					APIVersion: "v1alpha1",
+				},
+				{
+					// This name is not as it would be in the product, as
+					// GenerateName is used.
+					Name:       "wext-" + webhook.Name + "-",
+					APIVersion: "v1alpha1",
+				},
+			},
+			Template: v1alpha1.EventListenerTemplate{
+				Name:       webhook.Pipeline + "-template",
+				APIVersion: "v1alpha1",
+			},
+			Interceptors: []*v1alpha1.EventInterceptor{
+				{
+					Webhook: &v1alpha1.WebhookInterceptor{
+						Header: []pipelinesv1alpha1.Param{
+							{Name: "Wext-Trigger-Name", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: webhook.Name + "-" + webhook.Namespace + "-push-event"}},
+							{Name: "Wext-Repository-Url", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: webhook.GitRepositoryURL}},
+							{Name: "Wext-Incoming-Event", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "push, Push Hook, Tag Push Hook"}},
+							{Name: "Wext-Secret-Name", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: webhook.AccessTokenRef}}},
+						ObjectRef: &corev1.ObjectReference{
+							APIVersion: "v1",
+							Kind:       "Service",
+							Name:       "tekton-webhooks-extension-validator",
+							Namespace:  r.Defaults.Namespace,
+						},
+					},
+				},
+			},
 		},
-		Params: params,
-		Template: v1alpha1.EventListenerTemplate{
-			Name:       templateName,
-			APIVersion: "v1alpha1",
-		},
-		Interceptor: &v1alpha1.EventInterceptor{
-			Header: []pipelinesv1alpha1.Param{
-				{Name: "Wext-Trigger-Name", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: name}},
-				{Name: "Wext-Repository-Url", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: repoURL}},
-				{Name: "Wext-Incoming-Event", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: event}},
-				{Name: "Wext-Secret-Name", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: secretName}}},
-			ObjectRef: &corev1.ObjectReference{
-				APIVersion: "v1",
-				Kind:       "Service",
-				Name:       "tekton-webhooks-extension-validator",
-				Namespace:  r.Defaults.Namespace,
+		{
+			Name: webhook.Name + "-" + webhook.Namespace + "-pullrequest-event",
+			Bindings: []*v1alpha1.EventListenerBinding{
+				{
+					Name:       webhook.Pipeline + "-pullrequest-binding",
+					APIVersion: "v1alpha1",
+				},
+				{
+					// This name is not as it would be in the product, as
+					// GenerateName is used.
+					Name:       "wext-" + webhook.Name + "-",
+					APIVersion: "v1alpha1",
+				},
+			},
+			Template: v1alpha1.EventListenerTemplate{
+				Name:       webhook.Pipeline + "-template",
+				APIVersion: "v1alpha1",
+			},
+			Interceptors: []*v1alpha1.EventInterceptor{
+				{
+					Webhook: &v1alpha1.WebhookInterceptor{
+						Header: []pipelinesv1alpha1.Param{
+							{Name: "Wext-Trigger-Name", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: webhook.Name + "-" + webhook.Namespace + "-pullrequest-event"}},
+							{Name: "Wext-Repository-Url", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: webhook.GitRepositoryURL}},
+							{Name: "Wext-Incoming-Event", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "pull_request, Merge Request Hook"}},
+							{Name: "Wext-Secret-Name", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: webhook.AccessTokenRef}},
+							{Name: "Wext-Incoming-Actions", Value: pipelinesv1alpha1.ArrayOrString{Type: pipelinesv1alpha1.ParamTypeString, StringVal: "opened,reopened,synchronize"}}},
+						ObjectRef: &corev1.ObjectReference{
+							APIVersion: "v1",
+							Kind:       "Service",
+							Name:       "tekton-webhooks-extension-validator",
+							Namespace:  r.Defaults.Namespace,
+						},
+					},
+				},
 			},
 		},
 	}
+
+	return triggers
 }
 
 func getEnvDefaults(r *Resource, t *testing.T) EnvDefaults {
@@ -780,6 +977,12 @@ func getEnvDefaults(r *Resource, t *testing.T) EnvDefaults {
 		t.Errorf("Error decoding result into defaults{}: %s", err.Error())
 	}
 	return defaults
+}
+
+func FakeGetTriggerBindingObjectMeta(name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name: "wext-" + name + "-",
+	}
 }
 
 func createWebhook(webhook webhook, r *Resource) (response *restful.Response) {
@@ -1091,5 +1294,30 @@ func Test_deleteOpenshiftRoute(t *testing.T) {
 				t.Errorf("Route not expected")
 			}
 		})
+	}
+}
+
+func TestCreateDeleteIngress(t *testing.T) {
+	r := dummyResource()
+	r.Defaults.CallbackURL = "http://wibble.com"
+	expectedHost := "wibble.com"
+
+	err := r.createDeleteIngress("create", r.Defaults.Namespace)
+	if err != nil {
+		t.Errorf("error creating ingress: %s", err.Error())
+	}
+
+	ingress, err := r.K8sClient.ExtensionsV1beta1().Ingresses(r.Defaults.Namespace).Get("el-tekton-webhooks-eventlistener", metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("error getting ingress: %s", err.Error())
+	}
+
+	if ingress.Spec.Rules[0].Host != expectedHost {
+		t.Error("ingress Host did not match the callback URL")
+	}
+
+	err = r.createDeleteIngress("delete", r.Defaults.Namespace)
+	if err != nil {
+		t.Errorf("error deleting ingress: %s", err.Error())
 	}
 }

--- a/webhooks-extension/pkg/utils/utils.go
+++ b/webhooks-extension/pkg/utils/utils.go
@@ -87,6 +87,10 @@ func GetWebhookSecretTokens(kubeClient k8sclient.Interface, namespace, name stri
 
 // Returns (provider, apiurl, error):
 func GetGitProviderAndAPIURL(inputURL string) (string, string, error) {
+	if inputURL == "" {
+		return "", "", errors.New("no repository URL provided on call to GetGitProviderAndAPIURL")
+	}
+
 	gitURL, err := url.ParseRequestURI(inputURL)
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
# Changes

Modifies eventlistener to triggers 0.2.1 format.  This is possibly a breaking change and I believe users of previous versions will need to remove all existing webhooks before upgrading to triggers 0.2.1 and this PR level of the webhooks extension. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
