### PR TITLE
Set SSL_VERIFICATION_ENABLED=true by default

### DIFF
--- a/webhooks-extension/base/300-extension-deployment.yaml
+++ b/webhooks-extension/base/300-extension-deployment.yaml
@@ -44,8 +44,10 @@ spec:
           - name: WEBHOOK_CALLBACK_URL
             value: "http://listener.IPADDRESS.nip.io"
           # If the WEBHOOK_CALLBACK_URL's protocol is https, should ssl verification be enabled/disabled
+          # Set this to false if your Git server comes with a self-signed https certificate. Be aware that 
+          # this leaves you potentially vulnerable to systems impersonating your Git server :O
           - name: SSL_VERIFICATION_ENABLED
-            value: "false"
+            value: true
           - name: SERVICE_ACCOUNT
             valueFrom:
               fieldRef:

--- a/webhooks-extension/overlays/openshift-all/deployment-patch.yaml
+++ b/webhooks-extension/overlays/openshift-all/deployment-patch.yaml
@@ -11,11 +11,13 @@ spec:
       containers:
         - name: webhooks-extension
           env:
-          # If this endpoint's protocol is https, tls will be enabled on the github webhook
           # openshift_master_default_subdomain usually of the format 'apps.host.company.com'
           - name: WEBHOOK_CALLBACK_URL
             value: https://el-tekton-webhooks-eventlistener-tekton-pipelines.{openshift_master_default_subdomain}
-          # If the WEBHOOK_CALLBACK_URL's protocol is https, should tls verification be enabled/disabled?
-          # See https://github.com/tektoncd/experimental/issues/399
+          # If the WEBHOOK_CALLBACK_URL's protocol is https, should ssl verification be enabled/disabled
+          # Set this to false if your Git server comes with a self-signed https certificate. Be aware that 
+          # this leaves you potentially vulnerable to systems impersonating your Git server :O
+          - name: SSL_VERIFICATION_ENABLED
+            value: true
           - name: PLATFORM
             value: openshift

--- a/webhooks-extension/overlays/plainkube-all/deployment-patch.yaml
+++ b/webhooks-extension/overlays/plainkube-all/deployment-patch.yaml
@@ -13,3 +13,8 @@ spec:
           env:
           - name: WEBHOOK_CALLBACK_URL
             value: http://listener.IPADDRESS.nip.io
+          # If the WEBHOOK_CALLBACK_URL's protocol is https, should ssl verification be enabled/disabled
+          # Set this to false if your Git server comes with a self-signed https certificate. Be aware that 
+          # this leaves you potentially vulnerable to systems impersonating your Git server :O
+          - name: SSL_VERIFICATION_ENABLED
+            value: true


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Set SSL_VERIFICATION_ENABLED=true by default. Extend overlays so that if you're tweaking WEBHOOK_CALLBACK_URL, you also have a handy setting for SSL_VERIFICATION_ENABLED. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
