### PR TITLE
Split SSL_VERIFICATION_ENABLED for Git and webhooks

### DIFF
--- a/webhooks-extension/base/300-extension-deployment.yaml
+++ b/webhooks-extension/base/300-extension-deployment.yaml
@@ -41,11 +41,22 @@ spec:
             value: DOCKER_REPO
           - name: WEB_RESOURCES_DIR
             value: web
+
+          # Set GIT_SSL_VERIFICATION_ENABLED to "false" if your Git server has a self-signed HTTPS certificate. 
+          # Caution! Doing this leaves you potentially vulnerable to systems impersonating your Git server 
+          - name: GIT_SSL_VERIFICATION_ENABLED
+            value: "true"
+
+          # WEBHOOK_CALLBACK_URL is the value of the endpoint that Git will deliver webhooks to. 
+          # Exposed via a Route or Ingress; needs to be set at install time. 
           - name: WEBHOOK_CALLBACK_URL
             value: "http://listener.IPADDRESS.nip.io"
-          # If the WEBHOOK_CALLBACK_URL's protocol is https, should ssl verification be enabled/disabled
-          - name: SSL_VERIFICATION_ENABLED
+
+          # Set WEBHOOK_SSL_VERIFICATION_ENABLED to "true" if the Route or Ingress in front of WEBHOOK_CALLBACK_URL is protected
+          # by an HTTPS endpoint signed by a certificate that your Git server accepts. 
+          - name: WEBHOOK_SSL_VERIFICATION_ENABLED
             value: "false"
+
           - name: SERVICE_ACCOUNT
             valueFrom:
               fieldRef:

--- a/webhooks-extension/docs/Security.md
+++ b/webhooks-extension/docs/Security.md
@@ -4,7 +4,7 @@
 
 Webhook SSL verification is enabled by setting the `WEBHOOK_CALLBACK_URL` environment variable to an `https://` endpoint and by setting the `SSL_VERIFICATION_ENABLED` environment variable to `"true"`.  These environment variables are found in the installation yaml file and need setting in advance of install.
 
-The certificate setup is left as an exercise for the reader, but should you wish to have an `https://` connection but with certificate validation disabled, you could set the `WEBHOOK_CALLBACK_URL` environment variable to an `https://` endpoint and set the `SSL_VERIFICATION_ENABLED` environment variable to `"false"`.  Please ensure you understand the security risks of disabling certificate validation.
+The certificate setup is left as an exercise for the reader, but should you wish to have an `https://` connection but with certificate validation disabled, you could set the `WEBHOOK_CALLBACK_URL` environment variable to an `https://` endpoint and set the `WEBHOOK_SSL_VERIFICATION_ENABLED` environment variable to `"false"`.  Please ensure you understand the security risks of disabling certificate validation.
 
 An additional security mechanism which is always enabled, is the validation of the `secret token` associated with the webhook.  This secret token is generated for you when you create the webhook in the UI and automatically checked by an interceptor service running behind the eventlistener.
 
@@ -26,7 +26,7 @@ There are a number of additional places that verify the certificate from the git
 
 ### Disabling Certificate Verification
 
-By setting the environment variable `SSL_VERIFICATION_ENABLED` to `"false"` you will disable certificate validation in the monitor task that udpdates status on your pull requests.  The setting is made available to your trigger templates as the parameters `webhooks-tekton-ssl-verify` and `webhooks-tekton-insecure-skip-tls-verify` which can then be used to set the requisite values on your pipelineresources (or you could hardcode the required values).
+By setting the environment variable `GIT_SSL_VERIFICATION_ENABLED` to `"false"` you will disable certificate validation in the monitor task that udpdates status on your pull requests.  The setting is made available to your trigger templates as the parameters `webhooks-tekton-ssl-verify` and `webhooks-tekton-insecure-skip-tls-verify` which can then be used to set the requisite values on your pipelineresources (or you could hardcode the required values).
 
 - Tekton's Git Pipeline Resource
 

--- a/webhooks-extension/overlays/openshift-all/deployment-patch.yaml
+++ b/webhooks-extension/overlays/openshift-all/deployment-patch.yaml
@@ -11,11 +11,15 @@ spec:
       containers:
         - name: webhooks-extension
           env:
-          # If this endpoint's protocol is https, tls will be enabled on the github webhook
-          # openshift_master_default_subdomain usually of the format 'apps.host.company.com'
+          # WEBHOOK_CALLBACK_URL is the value of the endpoint that Git will deliver webhooks to. 
+          # Exposed via a Route or Ingress; needs to be set at install time. 
           - name: WEBHOOK_CALLBACK_URL
             value: https://el-tekton-webhooks-eventlistener-tekton-pipelines.{openshift_master_default_subdomain}
-          # If the WEBHOOK_CALLBACK_URL's protocol is https, should tls verification be enabled/disabled?
-          # See https://github.com/tektoncd/experimental/issues/399
+
+          # Set WEBHOOK_SSL_VERIFICATION_ENABLED to "true" if the Route or Ingress in front of WEBHOOK_CALLBACK_URL is protected
+          # by an HTTPS endpoint signed by a certificate that your Git server accepts. 
+          - name: WEBHOOK_SSL_VERIFICATION_ENABLED
+            value: "false"
+
           - name: PLATFORM
             value: openshift

--- a/webhooks-extension/overlays/plainkube-all/deployment-patch.yaml
+++ b/webhooks-extension/overlays/plainkube-all/deployment-patch.yaml
@@ -11,5 +11,12 @@ spec:
       containers:
         - name: webhooks-extension
           env:
+          # WEBHOOK_CALLBACK_URL is the value of the endpoint that Git will deliver webhooks to. 
+          # Exposed via a Route or Ingress; needs to be set at install time. 
           - name: WEBHOOK_CALLBACK_URL
-            value: http://listener.IPADDRESS.nip.io
+            value: "http://listener.IPADDRESS.nip.io"
+
+          # Set WEBHOOK_SSL_VERIFICATION_ENABLED to "true" if the Route or Ingress in front of WEBHOOK_CALLBACK_URL is protected
+          # by an HTTPS endpoint signed by a certificate that your Git server accepts. 
+          - name: WEBHOOK_SSL_VERIFICATION_ENABLED
+            value: "false"

--- a/webhooks-extension/pkg/endpoints/git.go
+++ b/webhooks-extension/pkg/endpoints/git.go
@@ -16,10 +16,11 @@ package endpoints
 import (
 	"errors"
 	"fmt"
-	logging "github.com/tektoncd/experimental/webhooks-extension/pkg/logging"
-	"github.com/tektoncd/experimental/webhooks-extension/pkg/utils"
 	"os"
 	"strings"
+
+	logging "github.com/tektoncd/experimental/webhooks-extension/pkg/logging"
+	"github.com/tektoncd/experimental/webhooks-extension/pkg/utils"
 )
 
 type GitWebhook interface {
@@ -78,7 +79,7 @@ func addOrRemoveWebhook(hook webhook, org, repo, action string, r Resource) (err
 func (r Resource) createGitProviderForWebhook(hook webhook, org, reponame string) (GitProvider, error) {
 	// Get extra git option to skip ssl verification
 	sslVerify := true
-	ssl := os.Getenv("SSL_VERIFICATION_ENABLED")
+	ssl := os.Getenv("WEBHOOK_SSL_VERIFICATION_ENABLED")
 	if strings.ToLower(ssl) == "false" {
 		sslVerify = false
 	}

--- a/webhooks-extension/pkg/endpoints/webhook.go
+++ b/webhooks-extension/pkg/endpoints/webhook.go
@@ -24,6 +24,8 @@ import (
 	"errors"
 	"fmt"
 
+	"math/rand"
+
 	restful "github.com/emicklei/go-restful"
 	routesv1 "github.com/openshift/api/route/v1"
 	logging "github.com/tektoncd/experimental/webhooks-extension/pkg/logging"
@@ -38,7 +40,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/certificate/csr"
-	"math/rand"
 
 	"net/http"
 	"os"
@@ -333,9 +334,9 @@ func (r Resource) getParams(webhook webhook) (webhookParams, monitorParams []pip
 	}
 
 	sslVerify := true
-	ssl := os.Getenv("SSL_VERIFICATION_ENABLED")
+	ssl := os.Getenv("GIT_SSL_VERIFICATION_ENABLED")
 	if strings.ToLower(ssl) == "false" {
-		logging.Log.Warn("SSL_VERIFICATION_ENABLED SET TO FALSE")
+		logging.Log.Warn("GIT_SSL_VERIFICATION_ENABLED SET TO FALSE")
 		sslVerify = false
 	}
 

--- a/webhooks-extension/pkg/endpoints/webhook_test.go
+++ b/webhooks-extension/pkg/endpoints/webhook_test.go
@@ -220,7 +220,7 @@ func TestGetParams(t *testing.T) {
 	}
 
 	r := dummyResource()
-	os.Setenv("SSL_VERIFICATION_ENABLED", "true")
+	os.Setenv("GIT_SSL_VERIFICATION_ENABLED", "true")
 	for _, tt := range testcases {
 		hookParams, monitorParams := r.getParams(tt.Webhook)
 		expectedHookParams, expectedMonitorParams := getExpectedParams(tt.Webhook, r, tt.expectedProvider, tt.expectedAPIURL)
@@ -482,7 +482,7 @@ func TestCreateEventListener(t *testing.T) {
 				t.Errorf("trigger %+v unexpected", trigger)
 			}
 			// Check params on monitor
-			os.Setenv("SSL_VERIFICATION_ENABLED", "true")
+			os.Setenv("GIT_SSL_VERIFICATION_ENABLED", "true")
 			_, expectedMonitorParams := getExpectedParams(hook, r, "github", "https://api.github.com/")
 			wextMonitorBindingFound := false
 			for _, monitorBinding := range trigger.Bindings {
@@ -813,7 +813,7 @@ func getExpectedParams(hook webhook, r *Resource, expectedProvider, expectedAPIU
 	org = org[0:strings.Index(org, "/")]
 	repo := url[strings.LastIndex(url, "/")+1:]
 
-	sslverify := os.Getenv("SSL_VERIFICATION_ENABLED")
+	sslverify := os.Getenv("GIT_SSL_VERIFICATION_ENABLED")
 	insecureAsBool, _ := strconv.ParseBool(sslverify)
 	insecureAsString := strconv.FormatBool(!insecureAsBool)
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Split SSL_VERIFICATION_ENABLED into two settings. 
GIT_SSL_VERIFICATION_ENABLED=true by default. 
WEBHOOK_SSL_VERIFICATION_ENABLED=false by default

Setting WEBHOOK_SSL_VERIFICATION_ENABLED=true by default would break many users whose Route and Ingress endpoints are not signed by certificates that GitHub / GitLab will accept without installing additional certificates into Git, which only a limited number of people are typically able to do. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
