### PR TITLE
Use go-containerregistry to parse image references

### DIFF
--- a/oci/go.mod
+++ b/oci/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/deislabs/oras v0.8.1
 	github.com/fsouza/go-dockerclient v1.6.1 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/google/go-containerregistry v0.0.0-20200115214256-379933c9c22b
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07 // indirect
 	github.com/mattn/go-shellwords v1.0.10 // indirect

--- a/oci/pkg/action/pull.go
+++ b/oci/pkg/action/pull.go
@@ -4,23 +4,26 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/tektoncd/experimental/oci/pkg/oci"
 )
 
 // Pull will perform the `pull` action by retrieving a specific named Tekton resource from the specified OCI image.
-func Pull(ref string, kind string, name string) error {
+func Pull(r string, kind string, n string) error {
 	// Validate the parameters.
-	if ref == "" || kind == "" || name == "" {
+	if r == "" || kind == "" || n == "" {
 		return errors.New("must specify an image reference, kind, and resource name")
 	}
 
-	imageReference, err := oci.ValidateImageName(ref)
+	ref, err := name.ParseReference(r)
 	if err != nil {
 		return err
 	}
 
-	contents, err := oci.PullImage(*imageReference, kind, name)
+	contents, err := oci.PullImage(ref, kind, n)
+	if err != nil {
+		return err
+	}
 	fmt.Print(string(contents))
-
 	return nil
 }

--- a/oci/pkg/action/push.go
+++ b/oci/pkg/action/push.go
@@ -3,15 +3,16 @@ package action
 import (
 	"errors"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/tektoncd/experimental/oci/pkg/oci"
 )
 
 // Push will perform the `push` action by recursively reading all of the
 // Tekton specs passed in, bundling it into an image, and pushing the result
 // to an OCI-compliant repository.
-func Push(ref string, filePaths []string) error {
+func Push(r string, filePaths []string) error {
 	// Validate the parameters.
-	if ref == "" || len(filePaths) == 0 {
+	if r == "" || len(filePaths) == 0 {
 		return errors.New("must specify a valid image name and file paths")
 	}
 
@@ -20,10 +21,10 @@ func Push(ref string, filePaths []string) error {
 		return err
 	}
 
-	name, err := oci.ValidateImageName(ref)
+	ref, err := name.ParseReference(r)
 	if err != nil {
 		return err
 	}
 
-	return oci.PushImage(*name, resources)
+	return oci.PushImage(ref, resources)
 }

--- a/oci/pkg/oci/image.go
+++ b/oci/pkg/oci/image.go
@@ -3,13 +3,13 @@ package oci
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/containerd/containerd/remotes/docker"
 	orascontent "github.com/deislabs/oras/pkg/content"
 	orascontext "github.com/deislabs/oras/pkg/context"
 	"github.com/deislabs/oras/pkg/oras"
+	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -19,83 +19,9 @@ func init() {
 	orascontext.GetLogger(context.Background()).Logger.SetLevel(logrus.ErrorLevel)
 }
 
-// ImageReference is a generic wrapper around the parts of an OCI image name. Not all of the fields exist for every
-// image.
-type ImageReference struct {
-	FullName string
-	Name     string
-	Registry string
-	Hash     string
-	Tag      string
-}
-
-// ValidateImageName will return nil if name is a valid, fully qualified image reference. This is based on
-// https://github.com/helm/helm/blob/7ffc879f137bd3a69eea53349b01f05e3d1d2385/internal/experimental/registry/reference.go#L48
-func ValidateImageName(name string) (*ImageReference, error) {
-	if name == "" {
-		return nil, fmt.Errorf("%s is not a valid image name", name)
-	}
-
-	return getNameParts(name)
-}
-
-// getNameParts will attempt to return a { "hostname/image-name", "tag or sha" } list of the provided image name. There maybe less than the full 2 elements if one of the parts isn't included in the original name.
-func getNameParts(name string) (*ImageReference, error) {
-	ref := ImageReference{
-		FullName: name,
-	}
-
-	remainingName := name
-
-	// First we split the @ since only the sha form is expected to have this.
-	shaParts := strings.Split(name, "@")
-	if len(shaParts) > 2 {
-		return nil, fmt.Errorf("invalid image name %s, too many @ symbols", name)
-	}
-	if len(shaParts) == 2 {
-		// We have a sha-tagged image name so we can return this split as is.
-		ref.Hash = shaParts[1]
-		remainingName = shaParts[0]
-	}
-
-	// Try splitting on : to see if this is image has a tag.
-	nameParts := strings.Split(remainingName, ":")
-	if len(nameParts) > 3 {
-		return nil, fmt.Errorf("invalid image name %s, too many : symbols", name)
-	}
-	if len(nameParts) == 3 {
-		// There was a tag and also a port on the domain, eg { localhost, 5000/my-image, tag-1 }.
-		ref.Tag = nameParts[2]
-		remainingName = strings.Join(nameParts[:2], ":")
-	}
-	if len(nameParts) == 2 {
-		// Either there was only a port and no tag, or only a tag.
-		if _, err := strconv.Atoi(strings.Split(nameParts[1], "/")[0]); err != nil {
-			// We could not parse the beginning part of the second index as a number so it isn't a port. The situation was
-			// { my-domain.com/image, tag-1 } instead of { localhost, 5000/my-image }.
-			ref.Tag = nameParts[1]
-			remainingName = nameParts[0]
-		} else {
-			ref.Tag = "latest"
-			// If there was no tag, remainingName = localhost:5000/my-image
-		}
-	}
-	if len(nameParts) == 1 {
-		// We didn't have a tag or port.
-		ref.Tag = "latest"
-	}
-
-	// Finally, break out the registry url from the image name.
-	registryParts := strings.Split(remainingName, "/")
-	ref.Registry = registryParts[0]
-	ref.Name = registryParts[1]
-
-	return &ref, nil
-}
-
 // PushImage will publish the given ImageReference and the provided resources in the proper format to an external OCI
 // registry.
-func PushImage(name ImageReference, contents []ParsedTektonResource) error {
+func PushImage(name name.Reference, contents []ParsedTektonResource) error {
 	resolver := docker.NewResolver(docker.ResolverOptions{})
 	memoryStore := orascontent.NewMemoryStore()
 	descriptors := []v1.Descriptor{}
@@ -109,7 +35,7 @@ func PushImage(name ImageReference, contents []ParsedTektonResource) error {
 		descriptors = append(descriptors, descriptor)
 	}
 
-	pushName := getPushName(name)
+	pushName := name.String()
 	desc, err := oras.Push(
 		context.Background(),
 		resolver,
@@ -127,14 +53,14 @@ func PushImage(name ImageReference, contents []ParsedTektonResource) error {
 }
 
 // PullImage will fetch the image and return the Tekton resource specified by the kind and name.
-func PullImage(ref ImageReference, kind string, name string) ([]byte, error) {
+func PullImage(ref name.Reference, kind string, name string) ([]byte, error) {
 	resolver := docker.NewResolver(docker.ResolverOptions{})
 	memoryStore := orascontent.NewMemoryStore()
 
 	_, _, err := oras.Pull(
 		context.Background(),
 		resolver,
-		ref.FullName,
+		ref.String(),
 		memoryStore,
 		oras.WithPullEmptyNameAllowed(),
 		oras.WithAllowedMediaTypes(TektonMediaTypes()),
@@ -158,8 +84,4 @@ func getLayerName(kind string, name string) string {
 
 func getLayerMediaType(resource ParsedTektonResource) string {
 	return fmt.Sprintf("application/vnd.cdf.tekton.catalog.%s.v1alpha1+yaml", strings.ToLower(resource.Kind.Kind))
-}
-
-func getPushName(name ImageReference) string {
-	return fmt.Sprintf("%s/%s:%s", name.Registry, name.Name, name.Tag)
 }


### PR DESCRIPTION
@sthaha @pierretasci

# Changes

Instead of parsing image ref strings ourselves, use go-containerregistry which has extensive support and tests for image ref parsing.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
