### PR TITLE
Ignore empty content when decoding

### DIFF
--- a/oci/pkg/oci/bundle.go
+++ b/oci/pkg/oci/bundle.go
@@ -109,6 +109,12 @@ func readPath(filePath string) ([]ParsedTektonResource, error) {
 
 	resources := make([]ParsedTektonResource, 0, len(entities))
 	for _, entity := range entities {
+
+		// ignore blank
+		if strings.TrimSpace(entity) == "" {
+			continue
+		}
+
 		resource, err := decodeObject(entity)
 		if err != nil {
 			// We are not going to bail if we find an unparseable resource, rather, we will just skip it.


### PR DESCRIPTION
A valid yaml that starts with `---` generates a warning as `readPath`
splits the file at `---` and tries to decode the first empty string
which results in a warning.

This patch fixes the issue by ignoring all empty strings (including
those that are just while spaces)

Signed-off-by: Sunil Thaha <sthaha@redhat.com>

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [🙅‍♂ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
