### PR TITLE
Use npm run build_ko in DEVELOPMENT instructions

### DIFF
--- a/webhooks-extension/DEVELOPMENT.md
+++ b/webhooks-extension/DEVELOPMENT.md
@@ -8,20 +8,20 @@ Use `npm ci` when installing from source to install with a clean set of dependen
 
 If modifying the UI code and wanting to deploy your updated version:
 
-1) Run `npm run build` this will create a new file in the dist directory. Note that this does require `yq`, so grab that too
+1) Run `npm run build_ko` this will create a new file in the dist directory. Note that this does require `yq`, so grab that too
 2) Reinstall the extension. It will automatically be picked up by the running dashboard. Use
 
 ```
 kustomize build overlays/development | ko apply -f -
 ```
 
-if developing on a plain Kubernetes system, or 
+if developing on a plain Kubernetes system, or
 
 ```
 kustomize build overlays/openshift-development | ko apply -f -
 ```
 
-if developing against OpenShift or OKD. 
+if developing against OpenShift or OKD.
 
 ## Linting
 


### PR DESCRIPTION
# Changes

I think that this is supposed to read `npm run build_ko` instead of `npm
run build`.

/cc @a-roberts 
/cc @dibbles 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
