### PR TITLE
Handle and provide guidance when TriggerBindings are missing for a webhook

### DIFF
--- a/webhooks-extension/base/300-extension-service.yaml
+++ b/webhooks-extension/base/300-extension-service.yaml
@@ -8,12 +8,12 @@ metadata:
     tekton-dashboard-extension: "true"
   annotations:
     tekton-dashboard-display-name: Webhooks
-    tekton-dashboard-endpoints: "webhooks.web"
-    tekton-dashboard-bundle-location: "web/extension.86386c2c.js"
+    tekton-dashboard-endpoints: webhooks.web
+    tekton-dashboard-bundle-location: web/extension.c1ed3779.js
 spec:
   type: NodePort
   ports:
-    - port: 8080
-      targetPort: 8080
+  - port: 8080
+    targetPort: 8080
   selector:
     app: webhooks-extension

--- a/webhooks-extension/docs/ManagedEventListener.md
+++ b/webhooks-extension/docs/ManagedEventListener.md
@@ -1,0 +1,43 @@
+# Important considerations of using the Webhooks Extension
+
+A managed EventListener is provided that should not be modified.
+
+When you create a webhook, a number of Trigger resources are referenced in the EventListener that's created or updated as more webhooks are added.
+
+If these Trigger resources can no longer be found (be it through deletion or changed RBAC policies), broken webhooks will display in the table of webhooks and these will not be able to be deleted through the user-interface. In addition, you'll likely face trouble creating new webhooks referencing the same Pipeline and Git repository.
+
+Procedure (with example below):
+1) If the TriggerBinding exists somewhere as yaml, reapply it into the install namespace for the webhooks extension.
+2) If the TriggerBinding is a generated one (name starts with `wext` (lowercase), create an empty one with that name).
+3) Create any upfront provided TriggerBindings again. For example, if your pipeline was called `simple-pipeline-2`, you will be using `simple-pipeline-2-pullrequest-binding` and `simple-pipeline-2-push-binding`.
+
+Here's example yaml you would apply to recreate the TriggerBindings such that deletion can happen successfully. This also serves to demonstrate the naming pattern used so you can identify the impacted webhook.
+
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: wext-myhook-*unique string here*
+  namespace: tekton-pipelines
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: wext-monitor-task-github-binding-*unique string here*
+  namespace: tekton-pipelines
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: simple-pipeline-2-pullrequest-binding
+  namespace: tekton-pipelines
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: simple-pipeline-2-push-binding
+  namespace: tekton-pipelines
+```
+
+You'll then be able to delete the webhook normally through the user-interface.

--- a/webhooks-extension/package-lock.json
+++ b/webhooks-extension/package-lock.json
@@ -1533,9 +1533,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
       "dev": true
     },
     "acorn-globals": {
@@ -3374,9 +3374,9 @@
           }
         },
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }
@@ -6660,9 +6660,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
           "dev": true
         },
         "parse5": {
@@ -7211,9 +7211,9 @@
       },
       "dependencies": {
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }
@@ -7371,9 +7371,9 @@
       },
       "dependencies": {
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }
@@ -8798,9 +8798,9 @@
       }
     },
     "react": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
-      "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+      "version": "16.13.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.13.0.tgz",
+      "integrity": "sha512-TSavZz2iSLkq5/oiE7gnFzmURKZMltmi193rm5HEoUDAXpzT9Kzw6oNZnGoai/4+fUnm7FqS5dwgUL34TujcWQ==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",

--- a/webhooks-extension/package.json
+++ b/webhooks-extension/package.json
@@ -52,7 +52,7 @@
     "node-sass": "^4.13.1",
     "npm-run-all": "^4.1.5",
     "prop-types": "^15.7.2",
-    "react": "^16.12.0",
+    "react": "^16.13.0",
     "react-app-polyfill": "^1.0.0",
     "react-dom": "^16.8.6",
     "react-redux": "^7.0.1",

--- a/webhooks-extension/pkg/endpoints/webhook_test.go
+++ b/webhooks-extension/pkg/endpoints/webhook_test.go
@@ -390,12 +390,6 @@ func TestGetMonitorBindingName(t *testing.T) {
 			expectedError: "no repository URL provided on call to GetGitProviderAndAPIURL",
 		},
 		{
-			repoURL:             "http://foo.gitlab.com/wibble/fish",
-			monitorTask:         "",
-			expectedBindingName: "",
-			expectedError:       "no monitor task set on call to getMonitorBindingName",
-		},
-		{
 			repoURL:             "https://hungry.dinosaur.com/wibble/fish",
 			monitorTask:         "monitor-task",
 			expectedBindingName: "",

--- a/webhooks-extension/src/components/WebhookDisplayTable/WebhookDisplayTable.js
+++ b/webhooks-extension/src/components/WebhookDisplayTable/WebhookDisplayTable.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -186,11 +186,11 @@ export class WebhookDisplayTable extends Component {
 
         if (displayTimeoutWarningNotification) {
           notificationStatusToSet = 'warning'
-          notificationMessageToSet = 'Warning - timed out waiting to delete webhooks and potentially PipelineRuns: manually check the resources were deleted.';
+          notificationMessageToSet = 'Warning - timed out waiting to delete webhooks and potentially PipelineRuns: manually check the resources were deleted. See https://github.com/tektoncd/experimental/blob/master/webhooks-extension/docs/ManagedEventListener.md for more details.';
         } else {
           notificationStatusToSet = 'error'
           notificationMessageToSet =  'An error occurred deleting webhook(s).';
-          notificationFullMessage = 'Check the webhook(s) existed and both the dashboard and extension pods are healthy.';
+          notificationFullMessage = 'Check the webhook(s) existed and both the dashboard and extension pods are healthy. See https://github.com/tektoncd/experimental/blob/master/webhooks-extension/docs/ManagedEventListener.md for more details.';
         }
         this.setState({
           showNotificationOnTable: true,
@@ -225,7 +225,6 @@ export class WebhookDisplayTable extends Component {
   }
 
   render() {
-
       if (this.state.webhooks.length === 0 && this.state.isLoaded) {
         return (
           // There are no webhooks, so redirect to the create panel


### PR DESCRIPTION
For https://github.com/tektoncd/experimental/issues/489

This also fixes over 37,000 low sev vulns (React and Acorn)

# Changes

Documentation and Go code changes to:

1) Pick up the namespace even if no TriggerBindings are found for a webhook (essential as it's used for the deletion)
2) Assume monitor-task was in use by the webhook, todo should we mention if it's not? Is anyone really using another monitor task? If so then it's tricky because of the assumption it's called `monitor-task` with the Go changes here
3) Avoid the need to modify the EventListener incase an in-use TriggerBinding is accidentally delated
4) Avoid the need to delete the entire EventListener/Ingress to get back to a healthy state

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._

Note - needs rebase and tidy before I mark as ready for a review