### PR TITLE
Add pipeline helm chart

### DIFF
--- a/helm/OWNERS
+++ b/helm/OWNERS
@@ -1,0 +1,4 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+# - eddycharly

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,39 @@
+# Tekton Kubernetes Helm Charts
+
+This functionality is in beta and is subject to change.
+
+## Helm charts repository
+
+**TODO** this is not yet available, maybe document how to install from sources
+
+The Tekton helm charts repository is available here: `https://charts.tekton.dev`.
+
+Add the Tekton helm charts repo:
+
+```bash
+helm repo add tekton https://charts.tekton.dev
+```
+
+## Helm charts
+
+The following charts are available, please look in the chart directories for the documentation of each chart.
+
+| Tekton chart | Chart link |
+|---|---|
+| Tekton Pipelines | [chart documentation](./pipeline/README.md) |
+| Tekton Dashboard | TODO |
+| Tekton Triggers | TODO |
+| Tekton Operator | TODO |
+
+## Kubernetes Versions
+
+The kubernetes versions compatible with the charts are driven by the version of Tekton to be deployed.
+Please look at the Tekton documentation to know the kubernetes versions supported.
+
+Openshift compatibility should also be supported.
+
+## Helm versions
+
+The charts should be compatilbe with both helm v2 and v3.
+
+Note that some parameters apply to only one version of helm, this will be stated in the chart documentation.

--- a/helm/pipeline/Chart.yaml
+++ b/helm/pipeline/Chart.yaml
@@ -1,0 +1,29 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: pipeline
+apiVersion: v1
+version: 0.0.1
+appVersion: 0.11.0
+home: https://github.com/tektoncd/pipeline
+keywords:
+  - helm
+  - tekton pipeline
+maintainers:
+  - name: eddycharly
+    email: ceb@agriconomie.com
+description: |
+  This chart bootstraps installation of [tekton pipeline](https://github.com/tektoncd/pipeline).
+
+  It can optionnaly install the fpipeline webhook component.

--- a/helm/pipeline/README.md
+++ b/helm/pipeline/README.md
@@ -1,0 +1,456 @@
+
+
+# Tekton Pipelines Helm Chart
+
+The [Tekton Pipelines](https://github.com/tektoncd/pipeline) project provides k8s-style resources for declaring CI/CD-style pipelines.
+
+This helm chart is a lightweight way to deploy, configure and run Tekton Pipelines on a k8s cluster.
+
+## Requirements
+
+* [Helm](https://helm.sh/) v2 or v3
+* Kubernetes >= 1.15 (it's driven by the version of Tekton Pipelines installed)
+* Depending on the configuration you will need admin access to be able to install the CRDs
+
+## Description
+
+This chart deploys the Tekton Pipelines controller and optionnaly the associated webhook (it's strongly recommended to deploy both). It should run on k8s as well as OpenShift.
+
+It includes various options to expose metrics and/or profiling endpoints, create rbac resources, run in high availabilty mode, control pods placement and resources, etc...
+
+All options are documented in the [Chart Values](#chart-values) section.
+
+Various configuration examples are document in the [Try it out](#try-it-out) section.
+
+An additional guide is available in the [Production grade configuration](#production-grade-configuration) section to help deploying Tekton Pipelines in a highlly available and secure mode.
+
+## Installing
+
+- Add the Tekton helm charts repo
+
+**TODO** this is not yet available, maybe document how to install from sources
+
+```bash
+helm repo add tekton https://charts.tekton.dev
+```
+
+- Install (or upgrade)
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set customResourceDefinitions.create=false
+```
+
+- Install (or upgrade) without CRDs (assuming CRDs have already been deployed by an admin)
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set customResourceDefinitions.create=false
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set customResourceDefinitions.create=false --skip-crds
+```
+
+- Install (or upgrade) without creating RBAC resources (assuming RBAC resources have been created by an admin)
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set rbac.create=false --set rbac.serviceAccountName=svcAccountName
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set customResourceDefinitions.create=false --set rbac.create=false --set rbac.serviceAccountName=svcAccountName
+```
+
+Look [below](#chart-values) for the list of all available options and their corresponding description.
+
+## Uninstalling
+
+To uninstall the chart, simply delete the release.
+
+```bash
+# This will uninstall Tekton Pipelines in the tekton namespace (assuming a my-pipeline release name)
+
+# Helm v2
+helm delete --purge my-pipeline
+# Helm v3
+helm uninstall my-pipeline --namespace tekton
+```
+
+## Version
+
+Current chart version is `0.0.1`
+
+## Chart Values
+
+
+| Key | Type | Description | Default |
+|-----|------|-------------|---------|
+| `controller.affinity` | object | Controller affinity rules | `{}` |
+| `controller.annotations` | object | Controller pod annotations | See [values.yaml](./values.yaml) |
+| `controller.args` | list | Controller arguments | See [values.yaml](./values.yaml) |
+| `controller.config.artifactBucket` | object | Controller configuration for artifact bucket (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md) | See [values.yaml](./values.yaml) |
+| `controller.config.artifactPvc` | object | Controller configuration for artifact pvc (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md) | See [values.yaml](./values.yaml) |
+| `controller.config.defaults` | object | Controller configuration for default values (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md) | See [values.yaml](./values.yaml) |
+| `controller.config.featureFlags` | object | Controller configuration for feature flags | See [values.yaml](./values.yaml) |
+| `controller.config.leaderElection` | object | Controller configuration for leader election | See [values.yaml](./values.yaml) |
+| `controller.config.logging` | object | Controller configuration for logging (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md) | See [values.yaml](./values.yaml) |
+| `controller.config.observability` | object | Controller configuration for observability (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md) | See [values.yaml](./values.yaml) |
+| `controller.image.pullPolicy` | string | Controller docker image pull policy | `"IfNotPresent"` |
+| `controller.image.repository` | string | Controller docker image repository | `"gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller"` |
+| `controller.image.tag` | string | Controller docker image tag | `"v0.11.0"` |
+| `controller.metrics.enabled` | bool | Enable controller metrics service | `true` |
+| `controller.metrics.port` | int | Controller metrics service port | `9090` |
+| `controller.metrics.portName` | string |  | `"metrics"` |
+| `controller.nodeSelector` | object | Controller node selector | `{}` |
+| `controller.resources` | object | Controller resource limits and requests | `{}` |
+| `controller.securityContext` | object | Controller pods security context | `{}` |
+| `controller.service.annotations` | object | Controller service annotations | `{}` |
+| `controller.service.type` | string | Controller service type | `"ClusterIP"` |
+| `controller.tolerations` | list | Controller tolerations | `[]` |
+| `customResourceDefinitions.create` | bool | Create CRDs | `true` |
+| `fullnameOverride` | string | Fully override resource generated names | `""` |
+| `nameOverride` | string | Partially override resource generated names | `""` |
+| `podSecurityPolicy.enabled` | bool | Enable pod security policy | `false` |
+| `rbac.create` | bool | Create RBAC resources | `true` |
+| `rbac.serviceAccountName` | string | Name of the service account to use when rbac.create is false | `nil` |
+| `version` | string | Tekton pipelines version used to add labels on deployments, pods and services | `"v0.11.0"` |
+| `webhook.affinity` | object | Webhook affinity rules | `{}` |
+| `webhook.annotations` | object | Webhook pod annotations | See [values.yaml](./values.yaml) |
+| `webhook.enabled` | bool | Enable webhook | `true` |
+| `webhook.image.pullPolicy` | string | Webhook docker image pull policy | `"IfNotPresent"` |
+| `webhook.image.repository` | string | Webhook docker image repository | `"gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook"` |
+| `webhook.image.tag` | string | Webhook docker image tag | `"v0.11.0"` |
+| `webhook.metrics.enabled` | bool | Enable webhook metrics service | `true` |
+| `webhook.metrics.port` | int | Webhook metrics service port | `9090` |
+| `webhook.metrics.portName` | string | Webhook metrics service port name | `"http-metrics"` |
+| `webhook.nodeSelector` | object | Webhook node selector | `{}` |
+| `webhook.podDisruptionBudget.ennabled` | bool |  | `false` |
+| `webhook.podDisruptionBudget.maxUnavailable` | int | Maximum unavailable webhook pods | `1` |
+| `webhook.podDisruptionBudget.minAvailable` | int | Minimum available webhook pods | `1` |
+| `webhook.profiling.enabled` | bool | Enable pebhook profiling service | `true` |
+| `webhook.profiling.port` | int | Webhook profiling service port | `8008` |
+| `webhook.profiling.portName` | string | Webhook profiling service port name | `"http-profiling"` |
+| `webhook.replicas` | int | Webhook replicas | `1` |
+| `webhook.resources` | object | Webhook resource limits and requests | `{}` |
+| `webhook.securityContext` | object | Webhook pods security context | `{}` |
+| `webhook.service.annotations` | object | Webhook service annotations | `{}` |
+| `webhook.service.type` | string | Webhook service type | `"ClusterIP"` |
+| `webhook.tolerations` | list | Webhook tolerations | `[]` |
+| `webhook.updateStrategy` | object | Webhook pods update strategy | `{}` |
+
+
+You can look directly at the [values.yaml](./values.yaml) file to look at the options and their default values.
+
+## Try it out
+
+This chart should deploy correctly with default values.
+
+You will find examples below of how to customize the deployment of a release with various options. The list of examples is by no means exhaustive, it tries to cover the most used cases.
+
+If you feel something is incomplete, missing or incorrect please open an issue and we'll do our best to improve this documentation.
+
+### Disable webhook deployment (not recommended)
+
+This will prevent validation and resource updates if using an old version of the CRDs.
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set webhook.enabled=false
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set webhook.enabled=false --set customResourceDefinitions.create=false
+```
+
+### Configure artifact bucket
+
+Look at the [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) doc for more informations about the content of this config map.
+
+Create a yaml file called `config-artifact-bucket.yaml` looking like this (the name doesn't really matters):
+
+```yaml
+location: s3://my-artifact-bucket
+bucket.service.account.secret.name: my-secret
+bucket.service.account.secret.key: boto-config
+bucket.service.account.field.name: BOTO_CONFIG
+```
+
+Use the previously created file to pass the configuration to helm:
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set-file controller.config.artifactBucket=config-artifact-bucket.yaml
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set-file controller.config.artifactBucket=config-artifact-bucket.yaml --set customResourceDefinitions.create=false
+```
+
+### Configure artifact pvc
+
+Look at the [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) doc for more informations about the content of this config map.
+
+Create a yaml file called `config-artifact-pvc.yaml` looking like this (the name doesn't really matters):
+
+```yaml
+size: 1Gi
+```
+
+Use the previously created file to pass the configuration to helm:
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set-file controller.config.artifactPvc=config-artifact-pvc.yaml
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set-file controller.config.artifactPvc=config-artifact-pvc.yaml --set customResourceDefinitions.create=false
+```
+
+### Configure defaults
+
+Look at the [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) doc for more informations about the content of this config map.
+
+Create a yaml file called `config-artifact-defaults.yaml` looking like this (the name doesn't really matters):
+
+```yaml
+default-service-account: my-service-account
+default-pod-template: |
+  nodeSelector:
+    kops.k8s.io/instancegroup: my-node-group
+```
+
+Use the previously created file to pass the configuration to helm:
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set-file controller.config.defaults=config-artifact-defaults.yaml
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set-file controller.config.defaults=config-artifact-defaults.yaml --set customResourceDefinitions.create=false
+```
+
+### Other config maps
+
+Same thing applies for other config maps.
+
+Find below the list of supported config maps and their corresponding config key:
+
+| Config map | Config key | Official documentation
+|---|---|---|
+| artifact bucket | `controller.config.artifactBucket` | [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) |
+| artifact pvc | `controller.config.artifactPvc` | [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) |
+| defaults | `controller.config.defaults` | [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) |
+| feature flags | `controller.config.featureFlags` | [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) |
+| leader election | `controller.config.leaderElection` | [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) |
+| logging | `controller.config.logging` | [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) |
+| observability | `controller.config.observability` | [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) |
+
+Please look in [values.yaml](./values.yaml) to find the default values for each config map.
+
+### Configure Pod Resources
+
+Controller and Webhook pod resources are configured independently.
+
+Create a yaml file called `pod-resources.yaml` looking like this (the name doesn't really matters):
+
+```yaml
+controller:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 1
+      memory: 256m
+webhook:
+  resources:
+    requests:
+      cpu: 0.2
+      memory: 100m
+    limits:
+      cpu: 0.5
+      memory: 200m
+```
+
+Use the previously created file to pass the values to helm:
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --values pod-resources.yaml
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --values pod-resources.yaml --set customResourceDefinitions.create=false
+```
+
+### Configure number of webhook replicas
+
+Only Webhook pod replicas can be configured, the controller doesn't support more than 1 replica.
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set webhook.replicas=3
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set webhook.replicas=3 --set customResourceDefinitions.create=false
+```
+
+### Enable prometheus scraping
+
+To let prometheus scrape the metrics endpoints, we need to set annotations on the controller and/or webhook services.
+
+This can be done using the `controller.service.annotations` and `webhook.service.annotations` options.
+
+Create a yaml file called `service-annotations.yaml` looking like this (the name doesn't really matters):
+
+```yaml
+controller:
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+webhook:
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+```
+
+Use the previously created file to pass the values to helm:
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --values service-annotations.yaml
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --values service-annotations.yaml --set customResourceDefinitions.create=false
+```
+
+## Production grade configuration
+
+An example configuration is available in [values-production.yaml](./values-production.yaml).
+
+Deploy with:
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --values values-production.yaml
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --values values-production.yaml --set customResourceDefinitions.create=false
+```
+
+- Enable pod security policy
+
+```yaml
+podSecurityPolicy:
+  enabled: true
+```
+
+- Configure controller/webhook pod resources
+
+Depending on the size and load of your cluster, requests and/or limits values will need to be adjusted.
+
+```yaml
+controller:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 0.5
+      memory: 128m
+webhook:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 0.5
+      memory: 128m
+```
+
+- Prevent cluster autoscaler to evict controller
+
+```yaml
+controller:
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+```
+
+- Enable metrics scraping
+
+```yaml
+controller:
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+  metrics:
+    enabled: true
+    port: 9090
+    portName: metrics
+webhook:
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+  metrics:
+    enabled: true
+    port: 9090
+    portName: metrics
+```
+
+- Configure webhook replicas and affinity
+
+Depending on your k8s platform and cluster topology, you should ensure that more than one webhook pod is running.
+
+Webhook pods should be distributed across data centers/availability zones.
+
+```yaml
+webhook:
+  replicas: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: webhook
+              app.kubernetes.io/instance: my-pipeline
+          topologyKey: failure-domain.beta.kubernetes.io/zone
+```
+
+- Configure webhook pod disruption budget and update strategy
+
+To ensure there is always a minimum number of webhook pods running, you should configure a pod disruption budget.
+
+```yaml
+webhook:
+  podDisruptionBudget:
+    ennabled: true
+    minAvailable: 1
+    maxUnavailable: 1
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+```
+
+---
+
+Except as otherwise noted, the content of this page is licensed under the
+[Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
+and code samples are licensed under the
+[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/helm/pipeline/README.md.gotmpl
+++ b/helm/pipeline/README.md.gotmpl
@@ -1,0 +1,405 @@
+{{ define "chart.valuesTable" }}
+| Key | Type | Description | Default |
+|-----|------|-------------|---------|
+{{- range .Values }}
+| `{{ .Key }}` | {{ .Type }} | {{ .Description }} | {{ .Default }} |
+{{- end }}
+{{ end }}
+
+# Tekton Pipelines Helm Chart
+
+The [Tekton Pipelines](https://github.com/tektoncd/pipeline) project provides k8s-style resources for declaring CI/CD-style pipelines.
+
+This helm chart is a lightweight way to deploy, configure and run Tekton Pipelines on a k8s cluster.
+
+## Requirements
+
+* [Helm](https://helm.sh/) v2 or v3
+* Kubernetes >= 1.15 (it's driven by the version of Tekton Pipelines installed)
+* Depending on the configuration you will need admin access to be able to install the CRDs
+
+## Description
+
+This chart deploys the Tekton Pipelines controller and optionnaly the associated webhook (it's strongly recommended to deploy both). It should run on k8s as well as OpenShift.
+
+It includes various options to expose metrics and/or profiling endpoints, create rbac resources, run in high availabilty mode, control pods placement and resources, etc...
+
+All options are documented in the [Chart Values](#chart-values) section.
+
+Various configuration examples are document in the [Try it out](#try-it-out) section.
+
+An additional guide is available in the [Production grade configuration](#production-grade-configuration) section to help deploying Tekton Pipelines in a highlly available and secure mode.
+
+## Installing
+
+- Add the Tekton helm charts repo
+
+**TODO** this is not yet available, maybe document how to install from sources
+
+```bash
+helm repo add tekton https://charts.tekton.dev
+```
+
+- Install (or upgrade)
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set customResourceDefinitions.create=false
+```
+
+- Install (or upgrade) without CRDs (assuming CRDs have already been deployed by an admin)
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set customResourceDefinitions.create=false
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set customResourceDefinitions.create=false --skip-crds
+```
+
+- Install (or upgrade) without creating RBAC resources (assuming RBAC resources have been created by an admin)
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set rbac.create=false --set rbac.serviceAccountName=svcAccountName
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set customResourceDefinitions.create=false --set rbac.create=false --set rbac.serviceAccountName=svcAccountName
+```
+
+Look [below](#chart-values) for the list of all available options and their corresponding description.
+
+## Uninstalling
+
+To uninstall the chart, simply delete the release.
+
+```bash
+# This will uninstall Tekton Pipelines in the tekton namespace (assuming a my-pipeline release name)
+
+# Helm v2
+helm delete --purge my-pipeline
+# Helm v3
+helm uninstall my-pipeline --namespace tekton
+```
+
+## Version
+
+{{ template "chart.versionLine" . }}
+
+{{ template "chart.valuesSection" . }}
+
+You can look directly at the [values.yaml](./values.yaml) file to look at the options and their default values.
+
+## Try it out
+
+This chart should deploy correctly with default values.
+
+You will find examples below of how to customize the deployment of a release with various options. The list of examples is by no means exhaustive, it tries to cover the most used cases.
+
+If you feel something is incomplete, missing or incorrect please open an issue and we'll do our best to improve this documentation.
+
+### Disable webhook deployment (not recommended)
+
+This will prevent validation and resource updates if using an old version of the CRDs.
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set webhook.enabled=false
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set webhook.enabled=false --set customResourceDefinitions.create=false
+```
+
+### Configure artifact bucket
+
+Look at the [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) doc for more informations about the content of this config map.
+
+Create a yaml file called `config-artifact-bucket.yaml` looking like this (the name doesn't really matters):
+
+```yaml
+location: s3://my-artifact-bucket
+bucket.service.account.secret.name: my-secret
+bucket.service.account.secret.key: boto-config
+bucket.service.account.field.name: BOTO_CONFIG
+```
+
+Use the previously created file to pass the configuration to helm:
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set-file controller.config.artifactBucket=config-artifact-bucket.yaml
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set-file controller.config.artifactBucket=config-artifact-bucket.yaml --set customResourceDefinitions.create=false
+```
+
+### Configure artifact pvc
+
+Look at the [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) doc for more informations about the content of this config map.
+
+Create a yaml file called `config-artifact-pvc.yaml` looking like this (the name doesn't really matters):
+
+```yaml
+size: 1Gi
+```
+
+Use the previously created file to pass the configuration to helm:
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set-file controller.config.artifactPvc=config-artifact-pvc.yaml
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set-file controller.config.artifactPvc=config-artifact-pvc.yaml --set customResourceDefinitions.create=false
+```
+
+### Configure defaults
+
+Look at the [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) doc for more informations about the content of this config map.
+
+Create a yaml file called `config-artifact-defaults.yaml` looking like this (the name doesn't really matters):
+
+```yaml
+default-service-account: my-service-account
+default-pod-template: |
+  nodeSelector:
+    kops.k8s.io/instancegroup: my-node-group
+```
+
+Use the previously created file to pass the configuration to helm:
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set-file controller.config.defaults=config-artifact-defaults.yaml
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set-file controller.config.defaults=config-artifact-defaults.yaml --set customResourceDefinitions.create=false
+```
+
+### Other config maps
+
+Same thing applies for other config maps.
+
+Find below the list of supported config maps and their corresponding config key:
+
+| Config map | Config key | Official documentation
+|---|---|---|
+| artifact bucket | `controller.config.artifactBucket` | [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) |
+| artifact pvc | `controller.config.artifactPvc` | [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) |
+| defaults | `controller.config.defaults` | [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) |
+| feature flags | `controller.config.featureFlags` | [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) |
+| leader election | `controller.config.leaderElection` | [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) |
+| logging | `controller.config.logging` | [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) |
+| observability | `controller.config.observability` | [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md) |
+
+Please look in [values.yaml](./values.yaml) to find the default values for each config map.
+
+### Configure Pod Resources
+
+Controller and Webhook pod resources are configured independently.
+
+Create a yaml file called `pod-resources.yaml` looking like this (the name doesn't really matters):
+
+```yaml
+controller:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 1
+      memory: 256m
+webhook:
+  resources:
+    requests:
+      cpu: 0.2
+      memory: 100m
+    limits:
+      cpu: 0.5
+      memory: 200m
+```
+
+Use the previously created file to pass the values to helm:
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --values pod-resources.yaml
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --values pod-resources.yaml --set customResourceDefinitions.create=false
+```
+
+### Configure number of webhook replicas
+
+Only Webhook pod replicas can be configured, the controller doesn't support more than 1 replica.
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set webhook.replicas=3
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --set webhook.replicas=3 --set customResourceDefinitions.create=false
+```
+
+### Enable prometheus scraping
+
+To let prometheus scrape the metrics endpoints, we need to set annotations on the controller and/or webhook services.
+
+This can be done using the `controller.service.annotations` and `webhook.service.annotations` options.
+
+Create a yaml file called `service-annotations.yaml` looking like this (the name doesn't really matters):
+
+```yaml
+controller:
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+webhook:
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+```
+
+Use the previously created file to pass the values to helm:
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --values service-annotations.yaml
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --values service-annotations.yaml --set customResourceDefinitions.create=false
+```
+
+## Production grade configuration
+
+An example configuration is available in [values-production.yaml](./values-production.yaml).
+
+Deploy with:
+
+```bash
+# This will install Tekton Pipelines in the tekton namespace (with a my-pipeline release name)
+
+# Helm v2
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --values values-production.yaml
+# Helm v3
+helm upgrade --install my-pipeline --namespace tekton tekton/pipeline --values values-production.yaml --set customResourceDefinitions.create=false
+```
+
+- Enable pod security policy
+
+```yaml
+podSecurityPolicy:
+  enabled: true
+```
+
+- Configure controller/webhook pod resources
+
+Depending on the size and load of your cluster, requests and/or limits values will need to be adjusted.
+
+```yaml
+controller:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 0.5
+      memory: 128m
+webhook:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 0.5
+      memory: 128m
+```
+
+- Prevent cluster autoscaler to evict controller
+
+```yaml
+controller:
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+```
+
+- Enable metrics scraping
+
+```yaml
+controller:
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+  metrics:
+    enabled: true
+    port: 9090
+    portName: metrics
+webhook:
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+  metrics:
+    enabled: true
+    port: 9090
+    portName: metrics
+```
+
+- Configure webhook replicas and affinity
+
+Depending on your k8s platform and cluster topology, you should ensure that more than one webhook pod is running.
+
+Webhook pods should be distributed across data centers/availability zones.
+
+```yaml
+webhook:
+  replicas: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: webhook
+              app.kubernetes.io/instance: my-pipeline
+          topologyKey: failure-domain.beta.kubernetes.io/zone
+```
+
+- Configure webhook pod disruption budget and update strategy
+
+To ensure there is always a minimum number of webhook pods running, you should configure a pod disruption budget.
+
+```yaml
+webhook:
+  podDisruptionBudget:
+    ennabled: true
+    minAvailable: 1
+    maxUnavailable: 1
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+```
+
+---
+
+Except as otherwise noted, the content of this page is licensed under the
+[Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
+and code samples are licensed under the
+[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/helm/pipeline/crds/clustertask.yaml
+++ b/helm/pipeline/crds/clustertask.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clustertasks.tekton.dev
+spec:
+  group: tekton.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  names:
+    kind: ClusterTask
+    plural: clustertasks
+    categories:
+    - tekton
+    - tekton-pipelines
+  scope: Cluster
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/helm/pipeline/crds/condition.yaml
+++ b/helm/pipeline/crds/condition.yaml
@@ -1,0 +1,32 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: conditions.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: Condition
+    plural: conditions
+    categories:
+      - tekton
+      - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/helm/pipeline/crds/image.yaml
+++ b/helm/pipeline/crds/image.yaml
@@ -1,0 +1,35 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: images.caching.internal.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
+spec:
+  group: caching.internal.knative.dev
+  version: v1alpha1
+  names:
+    kind: Image
+    plural: images
+    singular: image
+    categories:
+      - knative-internal
+      - caching
+    shortNames:
+      - img
+  scope: Namespaced
+  subresources:
+    status: {}

--- a/helm/pipeline/crds/pipeline.yaml
+++ b/helm/pipeline/crds/pipeline.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelines.tekton.dev
+spec:
+  group: tekton.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  names:
+    kind: Pipeline
+    plural: pipelines
+    categories:
+    - tekton
+    - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/helm/pipeline/crds/pipelinerun.yaml
+++ b/helm/pipeline/crds/pipelinerun.yaml
@@ -1,0 +1,55 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineruns.tekton.dev
+spec:
+  group: tekton.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  names:
+    kind: PipelineRun
+    plural: pipelineruns
+    categories:
+    - tekton
+    - tekton-pipelines
+    shortNames:
+    - pr
+    - prs
+  scope: Namespaced
+  additionalPrinterColumns:
+    - name: Succeeded
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
+    - name: Reason
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
+    - name: StartTime
+      type: date
+      JSONPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      JSONPath: .status.completionTime
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/helm/pipeline/crds/resource.yaml
+++ b/helm/pipeline/crds/resource.yaml
@@ -1,0 +1,32 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineresources.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: PipelineResource
+    plural: pipelineresources
+    categories:
+    - tekton
+    - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/helm/pipeline/crds/task.yaml
+++ b/helm/pipeline/crds/task.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tasks.tekton.dev
+spec:
+  group: tekton.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  names:
+    kind: Task
+    plural: tasks
+    categories:
+    - tekton
+    - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/helm/pipeline/crds/taskrun.yaml
+++ b/helm/pipeline/crds/taskrun.yaml
@@ -1,0 +1,55 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: taskruns.tekton.dev
+spec:
+  group: tekton.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  names:
+    kind: TaskRun
+    plural: taskruns
+    categories:
+    - tekton
+    - tekton-pipelines
+    shortNames:
+    - tr
+    - trs
+  scope: Namespaced
+  additionalPrinterColumns:
+  - name: Succeeded
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
+  - name: StartTime
+    type: date
+    JSONPath: .status.startTime
+  - name: CompletionTime
+    type: date
+    JSONPath: .status.completionTime
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/helm/pipeline/templates/NOTES.txt
+++ b/helm/pipeline/templates/NOTES.txt
@@ -1,0 +1,4 @@
+Tekton pipelines have been installed successfully.
+To verify that the controller has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ template "pipeline.name" . }},app.kubernetes.io/component=controller,app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/pipeline/templates/_helpers.tpl
+++ b/helm/pipeline/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pipeline.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "pipeline.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pipeline.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "pipeline.serviceAccountName" -}}
+{{- if .Values.rbac.create -}}
+{{- template "pipeline.fullname" . -}}
+{{- else -}}
+{{- required "A service account name is required" .Values.rbac.serviceAccountName -}}
+{{- end -}}
+{{- end -}}

--- a/helm/pipeline/templates/clusterrole.yaml
+++ b/helm/pipeline/templates/clusterrole.yaml
@@ -1,0 +1,183 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.rbac.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "pipeline.fullname" . }}
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - limitranges
+      - pods/log
+      - namespaces
+      - secrets
+      - events
+      - serviceaccounts
+      - configmaps
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups: 
+      - apps
+    resources: 
+      - deployments
+    verbs: 
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups: 
+      - apps
+    resources: 
+      - deployments/finalizers
+    verbs: 
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups: 
+      - admissionregistration.k8s.io
+    resources: 
+      - mutatingwebhookconfigurations
+    verbs: 
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups: 
+      - tekton.dev
+    resources: 
+      - tasks
+      - clustertasks
+      - taskruns
+      - pipelines
+      - pipelineruns
+      - pipelineresources
+      - conditions
+    verbs: 
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups: 
+      - tekton.dev
+    resources: 
+      - taskruns/finalizers
+      - pipelineruns/finalizers
+    verbs: 
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups: 
+      - tekton.dev
+    resources: 
+      - tasks/status
+      - clustertasks/status
+      - taskruns/status
+      - pipelines/status
+      - pipelineruns/status
+      - pipelineresources/status
+    verbs: 
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  {{- if .Values.podSecurityPolicy.enabled }}
+  - apiGroups: 
+      - policy
+    resources: 
+      - podsecuritypolicies
+    resourceNames: 
+      - {{ template "pipeline.fullname" . }}
+    verbs: 
+      - use
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "pipeline.fullname" . }}-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+rules:
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - tasks
+      - taskruns
+      - pipelines
+      - pipelineruns
+      - pipelineresources
+      - conditions
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "pipeline.fullname" . }}-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+rules:
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - tasks
+      - taskruns
+      - pipelines
+      - pipelineruns
+      - pipelineresources
+      - conditions
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}

--- a/helm/pipeline/templates/clusterrolebinding.yaml
+++ b/helm/pipeline/templates/clusterrolebinding.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "pipeline.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "pipeline.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "pipeline.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/pipeline/templates/configmaps.yaml
+++ b/helm/pipeline/templates/configmaps.yaml
@@ -1,0 +1,65 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+data: null
+kind: ConfigMap
+metadata:
+  name: {{ template "pipeline.fullname" . }}-artifact-bucket
+data:
+{{ .Values.controller.config.artifactBucket | toYaml | indent 2 }}
+---
+apiVersion: v1
+data: null
+kind: ConfigMap
+metadata:
+  name: {{ template "pipeline.fullname" . }}-artifact-pvc
+data:
+{{ .Values.controller.config.artifactPvc | toYaml | indent 2 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # name: {{ template "pipeline.fullname" . }}-defaults
+  name: config-defaults
+data:
+{{ .Values.controller.config.defaults | toYaml | indent 2 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "pipeline.fullname" . }}-feature-flags
+data:
+{{ .Values.controller.config.featureFlags | toYaml | indent 2 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "pipeline.fullname" . }}-leader-election
+data:
+{{ .Values.controller.config.leaderElection | toYaml | indent 2 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "pipeline.fullname" . }}-logging
+data:
+{{ .Values.controller.config.logging | toYaml | indent 2 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "pipeline.fullname" . }}-observability
+data:
+{{ .Values.controller.config.observability | toYaml | indent 2 }}

--- a/helm/pipeline/templates/controller_deployment.yaml
+++ b/helm/pipeline/templates/controller_deployment.yaml
@@ -1,0 +1,106 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "pipeline.fullname" . }}-controller
+  labels:
+    app.kubernetes.io/name: {{ template "pipeline.name" . }}
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "pipeline.chart" . }}
+    pipeline.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "pipeline.name" . }}
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      {{- with .Values.controller.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ template "pipeline.name" . }}
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        helm.sh/chart: {{ template "pipeline.chart" . }}
+        pipeline.tekton.dev/release: {{ .Values.version | quote }}
+        version: {{ .Values.version | quote }}
+    spec:
+      serviceAccountName: {{ template "pipeline.serviceAccountName" . }}
+      {{- with .Values.controller.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: controller
+          image: {{ printf "%s:%s" .Values.controller.image.repository .Values.controller.image.tag | quote }}
+          imagePullPolicy: {{ .Values.controller.image.pullPolicy | quote }}
+          args:
+          {{- range .Values.controller.args }}
+            - {{ . | quote }}
+          {{- end }}
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # - name: CONFIG_DEFAULTS_NAME
+            #   value: {{ template "pipeline.fullname" . }}-defaults
+            - name: CONFIG_LOGGING_NAME
+              value: {{ template "pipeline.fullname" . }}-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: {{ template "pipeline.fullname" . }}-observability
+            - name: CONFIG_ARTIFACT_BUCKET_NAME
+              value: {{ template "pipeline.fullname" . }}-artifact-bucket
+            - name: CONFIG_ARTIFACT_PVC_NAME
+              value: {{ template "pipeline.fullname" . }}-artifact-pvc
+            - name: METRICS_DOMAIN
+              value: tekton.dev/pipeline
+          volumeMounts:
+            - mountPath: /etc/config-logging
+              name: config-logging
+          {{- with .Values.controller.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.controller.metrics.enabled }}
+          ports:
+            - containerPort: 9090
+              protocol: TCP
+          {{- end }}
+      volumes:
+        - name: config-logging
+          configMap:
+            name: {{ template "pipeline.fullname" . }}-logging

--- a/helm/pipeline/templates/controller_service.yaml
+++ b/helm/pipeline/templates/controller_service.yaml
@@ -1,0 +1,43 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.controller.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "pipeline.fullname" . }}-controller
+  labels:
+    app.kubernetes.io/name: {{ template "pipeline.name" . }}
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "pipeline.chart" . }}
+    pipeline.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+  {{- with .Values.controller.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.controller.service.type }}
+  ports:
+    - name: {{ .Values.controller.metrics.portName }}
+      port: {{ .Values.controller.metrics.port }}
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    app.kubernetes.io/name: {{ template "pipeline.name" . }}
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/pipeline/templates/customresourcedefinitions.yaml
+++ b/helm/pipeline/templates/customresourcedefinitions.yaml
@@ -1,0 +1,20 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.customResourceDefinitions.create }}
+{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
+{{ $.Files.Get $path }}
+---
+{{- end }}
+{{- end }}

--- a/helm/pipeline/templates/podsecuritypolicy.yaml
+++ b/helm/pipeline/templates/podsecuritypolicy.yaml
@@ -1,0 +1,49 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "pipeline.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "pipeline.name" . }}
+    helm.sh/chart: {{ template "pipeline.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+    - emptyDir
+    - configMap
+    - secret
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: MustRunAs
+    ranges:
+      - min: 1
+        max: 65535
+{{- end }}

--- a/helm/pipeline/templates/serviceaccount.yaml
+++ b/helm/pipeline/templates/serviceaccount.yaml
@@ -1,0 +1,20 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "pipeline.serviceAccountName" . }}
+{{- end }}

--- a/helm/pipeline/templates/webhook_admission.yaml
+++ b/helm/pipeline/templates/webhook_admission.yaml
@@ -1,0 +1,99 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## TODO
+
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: webhook-certs
+#   namespace: tekton-pipelines
+#   labels:
+#     pipeline.tekton.dev/release: devel
+# # The data is populated at install time.
+# ---
+{{- if .Values.webhook.enabled }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ template "pipeline.fullname" . }}-validation
+  labels:
+    app.kubernetes.io/name: {{ template "pipeline.name" . }}
+    app.kubernetes.io/component: admission
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "pipeline.chart" . }}
+    pipeline.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+webhooks:
+  - name: validation.webhook.pipeline.tekton.dev
+    admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: {{ template "pipeline.fullname" . }}-webhook
+        namespace: {{ .Release.Namespace }}
+    failurePolicy: Fail
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ template "pipeline.fullname" . }}-webhook
+  labels:
+    app.kubernetes.io/name: {{ template "pipeline.name" . }}
+    app.kubernetes.io/component: admission
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "pipeline.chart" . }}
+    pipeline.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+webhooks:
+  - name: webhook.pipeline.tekton.dev
+    admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: {{ template "pipeline.fullname" . }}-webhook
+        namespace: {{ .Release.Namespace }}
+    failurePolicy: Fail
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ template "pipeline.fullname" . }}-config
+  labels:
+    app.kubernetes.io/name: {{ template "pipeline.name" . }}
+    app.kubernetes.io/component: admission
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "pipeline.chart" . }}
+    pipeline.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+webhooks:
+  - name: config.webhook.pipeline.tekton.dev
+    admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: {{ template "pipeline.fullname" . }}-webhook
+        namespace: {{ .Release.Namespace }}
+    failurePolicy: Fail
+    sideEffects: None
+    namespaceSelector:
+      matchExpressions:
+        - key: pipeline.tekton.dev/release
+          operator: Exists
+{{- end }}

--- a/helm/pipeline/templates/webhook_deployment.yaml
+++ b/helm/pipeline/templates/webhook_deployment.yaml
@@ -1,0 +1,103 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.webhook.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "pipeline.fullname" . }}-webhook
+  labels:
+    app.kubernetes.io/name: {{ template "pipeline.name" . }}
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "pipeline.chart" . }}
+    pipeline.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+spec:
+  replicas: {{ .Values.webhook.replicas }}
+  {{- with .Values.webhook.updateStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "pipeline.name" . }}
+      app.kubernetes.io/component: webhook
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      {{- with .Values.webhook.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ template "pipeline.name" . }}
+        app.kubernetes.io/component: webhook
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        helm.sh/chart: {{ template "pipeline.chart" . }}
+        pipeline.tekton.dev/release: {{ .Values.version | quote }}
+        version: {{ .Values.version | quote }}
+    spec:
+      serviceAccountName: {{ template "pipeline.serviceAccountName" . }}
+      {{- with .Values.webhook.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhook.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhook.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhook.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: webhook
+          image: {{ printf "%s:%s" .Values.webhook.image.repository .Values.webhook.image.tag | quote }}
+          imagePullPolicy: {{ .Values.webhook.image.pullPolicy | quote }}
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # - name: CONFIG_DEFAULTS_NAME
+            #   value: {{ template "pipeline.fullname" . }}-defaults
+            - name: CONFIG_LOGGING_NAME
+              value: {{ template "pipeline.fullname" . }}-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: {{ template "pipeline.fullname" . }}-observability
+            - name: WEBHOOK_SERVICE_NAME
+              value: {{ template "pipeline.fullname" . }}-webhook
+            - name: METRICS_DOMAIN
+              value: tekton.dev/pipeline
+          securityContext:
+            allowPrivilegeEscalation: false
+          {{- with .Values.webhook.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+            - name: https-webhook
+              containerPort: 8443
+{{- end }}

--- a/helm/pipeline/templates/webhook_poddisruptionbudget.yaml
+++ b/helm/pipeline/templates/webhook_poddisruptionbudget.yaml
@@ -1,0 +1,42 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if and .Values.webhook.enabled .Values.webhook.podDisruptionBudget.enabled }}
+{{- if gt (.Values.webhook.replicas | int) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "pipeline.fullname" . }}-webhook
+  labels:
+    app.kubernetes.io/name: {{ template "pipeline.name" . }}
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "pipeline.chart" . }}
+    pipeline.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "pipeline.name" . }}
+      app.kubernetes.io/component: webhook
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.webhook.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.webhook.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.webhook.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.webhook.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/pipeline/templates/webhook_service.yaml
+++ b/helm/pipeline/templates/webhook_service.yaml
@@ -1,0 +1,55 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.webhook.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "pipeline.fullname" . }}-webhook
+  labels:
+    app.kubernetes.io/name: {{ template "pipeline.name" . }}
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "pipeline.chart" . }}
+    pipeline.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+  {{- with .Values.webhook.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.webhook.service.type }}
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+    {{- if .Values.webhook.metrics.enabled }}
+    - name: {{ .Values.webhook.metrics.portName }}
+      port: {{ .Values.webhook.metrics.port }}
+      protocol: TCP
+      targetPort: 9090
+    {{- end }}
+    {{- if .Values.webhook.profiling.enabled }}
+    - name: {{ .Values.webhook.profiling.portName }}
+      port: {{ .Values.webhook.profiling.port }}
+      protocol: TCP
+      targetPort: 8008
+    {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ template "pipeline.name" . }}
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/pipeline/values-production.yaml
+++ b/helm/pipeline/values-production.yaml
@@ -1,0 +1,79 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+podSecurityPolicy:
+  enabled: true
+
+controller:
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 0.5
+      memory: 128m
+
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+
+  metrics:
+    enabled: true
+    port: 9090
+    portName: metrics
+
+webhook:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 0.5
+      memory: 128m
+
+  replicas: 3
+
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: webhook
+              app.kubernetes.io/instance: my-pipeline
+          topologyKey: failure-domain.beta.kubernetes.io/zone
+
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+
+  metrics:
+    enabled: true
+    port: 9090
+    portName: metrics
+
+  podDisruptionBudget:
+    ennabled: true
+    minAvailable: 1
+    maxUnavailable: 1
+
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1

--- a/helm/pipeline/values.yaml
+++ b/helm/pipeline/values.yaml
@@ -1,0 +1,269 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# version -- Tekton pipelines version used to add labels on deployments, pods and services
+version: v0.11.0
+
+# nameOverride -- Partially override resource generated names
+nameOverride: ""
+
+# fullnameOverride -- Fully override resource generated names
+fullnameOverride: ""
+
+rbac:
+  # rbac.create -- Create RBAC resources
+  create: true
+
+  # rbac.serviceAccountName -- Name of the service account to use when rbac.create is false
+  serviceAccountName:
+
+customResourceDefinitions:
+  # customResourceDefinitions.create -- Create CRDs
+  create: true
+
+podSecurityPolicy:
+  # podSecurityPolicy.enabled -- Enable pod security policy
+  enabled: false
+
+controller:
+  image:
+    # controller.image.repository -- Controller docker image repository
+    repository: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller
+
+    # controller.image.tag -- Controller docker image tag
+    tag: v0.11.0
+
+    # controller.image.pullPolicy -- Controller docker image pull policy
+    pullPolicy: IfNotPresent
+
+  # controller.annotations -- Controller pod annotations
+  # @default -- See [values.yaml](./values.yaml)
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+
+  # controller.nodeSelector -- Controller node selector
+  nodeSelector: {}
+
+  # controller.affinity -- Controller affinity rules
+  affinity: {}
+
+  # controller.tolerations -- Controller tolerations
+  tolerations: []
+
+  # controller.resources -- Controller resource limits and requests
+  resources: {}
+
+  # controller.securityContext -- Controller pods security context
+  securityContext: {}
+
+  # controller.args -- Controller arguments
+  # @default -- See [values.yaml](./values.yaml)
+  args:
+    - -kubeconfig-writer-image
+    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.11.0
+    - -creds-image
+    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.11.0
+    - -git-image
+    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.11.0
+    - -nop-image
+    - tianon/true
+    - -shell-image
+    - busybox
+    - -gsutil-image
+    - google/cloud-sdk
+    - -entrypoint-image
+    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.11.0
+    - -imagedigest-exporter-image
+    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.11.0
+    - -pr-image
+    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init:v0.11.0
+    - -build-gcs-fetcher-image
+    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/vendor/github.com/googlecloudplatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher:v0.11.0
+
+  config:
+    # controller.config.artifactBucket -- Controller configuration for artifact bucket (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md)
+    # @default -- See [values.yaml](./values.yaml)
+    artifactBucket: {}
+
+    # controller.config.artifactPvc -- Controller configuration for artifact pvc (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md)
+    # @default -- See [values.yaml](./values.yaml)
+    artifactPvc: {}
+
+    # controller.config.defaults -- Controller configuration for default values (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md)
+    # @default -- See [values.yaml](./values.yaml)
+    defaults: {}
+
+    # controller.config.featureFlags -- Controller configuration for feature flags
+    # @default -- See [values.yaml](./values.yaml)
+    featureFlags:
+      # Setting this flag to "true" will prevent Tekton overriding your
+      # Task container's $HOME environment variable.
+      #
+      # The default behaviour currently is for Tekton to override the
+      # $HOME environment variable but this will change in an upcoming
+      # release.
+      #
+      # See https://github.com/tektoncd/pipeline/issues/2013 for more
+      # info.
+      disable-home-env-overwrite: "false"
+      # Setting this flag to "true" will prevent Tekton overriding your
+      # Task container's working directory.
+      #
+      # The default behaviour currently is for Tekton to override the
+      # working directory if not set by the user but this will change
+      # in an upcoming release.
+      #
+      # See https://github.com/tektoncd/pipeline/issues/1836 for more
+      # info.
+      disable-working-directory-overwrite: "false"
+
+    # controller.config.leaderElection -- Controller configuration for leader election
+    # @default -- See [values.yaml](./values.yaml)
+    leaderElection:
+      # An inactive but valid configuration follows; see example.
+      resourceLock: "leases"
+      leaseDuration: "15s"
+      renewDeadline: "10s"
+      retryPeriod: "2s"
+
+    # controller.config.logging -- Controller configuration for logging (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md)
+    # @default -- See [values.yaml](./values.yaml)
+    logging:
+      # Common configuration for all knative codebase
+      zap-logger-config: |
+        {
+          "level": "info",
+          "development": false,
+          "sampling": {
+            "initial": 100,
+            "thereafter": 100
+          },
+          "outputPaths": ["stdout"],
+          "errorOutputPaths": ["stderr"],
+          "encoding": "json",
+          "encoderConfig": {
+            "timeKey": "",
+            "levelKey": "level",
+            "nameKey": "logger",
+            "callerKey": "caller",
+            "messageKey": "msg",
+            "stacktraceKey": "stacktrace",
+            "lineEnding": "",
+            "levelEncoder": "",
+            "timeEncoder": "",
+            "durationEncoder": "",
+            "callerEncoder": ""
+          }
+        }
+      # Log level overrides
+      loglevel.controller: "info"
+      loglevel.webhook: "info"
+
+    # controller.config.observability -- Controller configuration for observability (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md)
+    # @default -- See [values.yaml](./values.yaml)
+    observability: {}
+
+  service:
+    # controller.service.type -- Controller service type
+    type: ClusterIP
+
+    # controller.service.annotations -- Controller service annotations
+    annotations: {}
+
+  metrics:
+    # controller.metrics.enabled -- Enable controller metrics service
+    enabled: true
+
+    # controller.metrics.port -- Controller metrics service port
+    port: 9090
+
+    # controller.metrics.service.portName -- Controller metrics service port name
+    portName: metrics
+
+webhook:
+  # webhook.enabled -- Enable webhook
+  enabled: true
+
+  image:
+    # webhook.image.repository -- Webhook docker image repository
+    repository: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook
+
+    # webhook.image.tag -- Webhook docker image tag
+    tag: v0.11.0
+
+    # webhook.image.pullPolicy -- Webhook docker image pull policy
+    pullPolicy: IfNotPresent
+
+  # webhook.replicas -- Webhook replicas
+  replicas: 1
+
+  # webhook.annotations -- Webhook pod annotations
+  # @default -- See [values.yaml](./values.yaml)
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+
+  # webhook.nodeSelector -- Webhook node selector
+  nodeSelector: {}
+
+  # webhook.affinity -- Webhook affinity rules
+  affinity: {}
+
+  # webhook.tolerations -- Webhook tolerations
+  tolerations: []
+
+  # webhook.resources -- Webhook resource limits and requests
+  resources: {}
+
+  # webhook.updateStrategy -- Webhook pods update strategy
+  updateStrategy: {}
+
+  # webhook.securityContext -- Webhook pods security context
+  securityContext: {}
+
+  podDisruptionBudget:
+    # webhook.podDisruptionBudget.enabled -- Enable pod disruption budget for webhook
+    ennabled: false
+
+    # webhook.podDisruptionBudget.minAvailable -- Minimum available webhook pods
+    minAvailable: 1
+
+    # webhook.podDisruptionBudget.maxUnavailable -- Maximum unavailable webhook pods
+    maxUnavailable: 1
+
+  service:
+    # webhook.service.type -- Webhook service type
+    type: ClusterIP
+
+    # webhook.service.annotations -- Webhook service annotations
+    annotations: {}
+
+  metrics:
+    # webhook.metrics.enabled -- Enable webhook metrics service
+    enabled: true
+
+    # webhook.metrics.port -- Webhook metrics service port
+    port: 9090
+
+    # webhook.metrics.portName -- Webhook metrics service port name
+    portName: http-metrics
+
+  profiling:
+    # webhook.profiling.enabled -- Enable pebhook profiling service
+    enabled: true
+
+    # webhook.profiling.port -- Webhook profiling service port
+    port: 8008
+
+    # webhook.profiling.portName -- Webhook profiling service port name
+    portName: http-profiling

--- a/helm/repo-sync.sh
+++ b/helm/repo-sync.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is greatly inspired form https://github.com/helm/charts/tree/master/test
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly HELM_URL=https://storage.googleapis.com/kubernetes-helm
+readonly HELM_TARBALL=helm-v2.9.1-linux-amd64.tar.gz
+# TODO
+readonly REPO_URL=https://charts.tekton.dev/
+readonly GCS_BUCKET=gs://charts.tekton.dev
+
+main() {
+    setup_helm_client
+    authenticate
+
+    if ! sync_repo . "$GCS_BUCKET" "$REPO_URL"; then
+        log_error "Not all charts could be packaged and synced!"
+    fi
+}
+
+setup_helm_client() {
+    echo "Setting up Helm client..."
+
+    curl --user-agent curl-ci-sync -sSL -o "$HELM_TARBALL" "$HELM_URL/$HELM_TARBALL"
+    tar xzfv "$HELM_TARBALL"
+
+    PATH="$(pwd)/linux-amd64/:$PATH"
+
+    helm init --client-only
+    helm repo add incubator "$INCUBATOR_REPO_URL"
+}
+
+authenticate() {
+    echo "Authenticating with Google Cloud..."
+    gcloud auth activate-service-account --key-file <(base64 --decode <<< "$SYNC_CREDS")
+}
+
+sync_repo() {
+    local repo_dir="${1?Specify repo dir}"
+    local bucket="${2?Specify repo bucket}"
+    local repo_url="${3?Specify repo url}"
+    local sync_dir="${repo_dir}-sync"
+    local index_dir="${repo_dir}-index"
+
+    echo "Syncing repo '$repo_dir'..."
+
+    mkdir -p "$sync_dir"
+    if ! gsutil cp "$bucket/index.yaml" "$index_dir/index.yaml"; then
+        log_error "Exiting because unable to copy index locally. Not safe to proceed."
+        exit 1
+    fi
+
+    local exit_code=0
+
+    for dir in "$repo_dir"/*; do
+        if helm dependency build "$dir"; then
+            helm package --destination "$sync_dir" "$dir"
+        else
+            log_error "Problem building dependencies. Skipping packaging of '$dir'."
+            exit_code=1
+        fi
+    done
+
+    if helm repo index --url "$repo_url" --merge "$index_dir/index.yaml" "$sync_dir"; then
+        # Move updated index.yaml to sync folder so we don't push the old one again
+        mv -f "$sync_dir/index.yaml" "$index_dir/index.yaml"
+
+        gsutil -m rsync "$sync_dir" "$bucket"
+
+        # Make sure index.yaml is synced last
+        gsutil cp "$index_dir/index.yaml" "$bucket"
+    else
+        log_error "Exiting because unable to update index. Not safe to push update."
+        exit 1
+    fi
+
+    ls -l "$sync_dir"
+
+    return "$exit_code"
+}
+
+log_error() {
+    printf '\e[31mERROR: %s\n\e[39m' "$1" >&2
+}
+
+main


### PR DESCRIPTION
This PR proposes to add a helm chart for tekton.

This was proposed here https://github.com/tektoncd/plumbing/issues/278.

The helm chart doesn't include dashboard, triggers, or operator. I will make separate charts for them in separate PRs. This one focuses only on pipeline.

The pipeline version used to create the chart is  v0.11.0-rc2. Supporting v0.10 is imho not worth the effort, by the time this chart is released v0.11 will probably be out.

This is work in progress, things not implemented yet :
- [x] pod disruption budget (to be removed if pods don't allow more than 1 replica)
- [x] support  admission webhooks
- [x] flag to enable/disable metrics
- [x] support for pre created service accounts in case rbac creation is disabled
- [x] support for customizing service type/annotations
- [x] flag to enable/disable pod security policy
- [x] helm v2/v3 support
- [x] update strategy configuration
- [x] pod security context
- [x] update to version v0.11.0-rc2
- [ ] ~~support for ingress~~ (not relevant)
- [ ] ~~more crds options~~ (useless)
- [x] add bash script to sync repo
- [x] add prow job to sync repo when pushed on master
- [x] improve generated doc with helm-docs
- [x] improve documentation
- [ ] ~~liveness probes~~ (no probes available yet see https://github.com/tektoncd/pipeline/issues/1586)
- [ ] ~~readiness probes~~ (no probes available yet see https://github.com/tektoncd/pipeline/issues/1586)
- [x] document a production grade configuration
- [x] update to v0.11.0
- [x] add prow presubmit to lint helm charts (https://github.com/tektoncd/plumbing/pull/289)
- [ ] add prow presubmit to check helm docs is up to date
- [ ] create bucket and update docs
- [ ] add prow postsubmit (on master) to sync/publish helm charts

Feedback welcome, thanks.