### PR TITLE
Add dashboard helm chart

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -21,7 +21,7 @@ The following charts are available, please look in the chart directories for the
 | Tekton chart | Chart link |
 |---|---|
 | Tekton Pipelines | [chart documentation](./pipeline/README.md) |
-| Tekton Dashboard | TODO |
+| Tekton Dashboard | [chart documentation](./dashboard/README.md) |
 | Tekton Triggers | TODO |
 | Tekton Operator | TODO |
 

--- a/helm/dashboard/Chart.yaml
+++ b/helm/dashboard/Chart.yaml
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: pipeline
+name: dashboards
 apiVersion: v1
 version: 0.0.1
-appVersion: 0.11.0
-home: https://github.com/tektoncd/pipeline
+appVersion: 0.6.0
+home: https://github.com/tektoncd/dashboard
 keywords:
   - helm
-  - tekton pipeline
+  - tekton dashboard
 maintainers:
   - name: eddycharly
     email: ceb@agriconomie.com
 description: |
-  This chart bootstraps installation of [tekton pipeline](https://github.com/tektoncd/pipeline).
+  This chart bootstraps installation of [tekton dashboard](https://github.com/tektoncd/dashboard).

--- a/helm/dashboard/Chart.yaml
+++ b/helm/dashboard/Chart.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: dashboards
+name: dashboard
 apiVersion: v1
 version: 0.0.1
 appVersion: 0.6.0

--- a/helm/dashboard/README.md
+++ b/helm/dashboard/README.md
@@ -11,10 +11,17 @@ This helm chart is a lightweight way to deploy, configure and run Tekton Dashboa
 * [Helm](https://helm.sh/) v2 or v3
 * Kubernetes >= 1.15 (it's driven by the version of Tekton Pipelines installed)
 * Depending on the configuration you will need admin access to be able to install the CRDs
+* Tekton Pipelines deployed in the target cluster (see [Tekton Pipelines Helm Chart](../pipeline/README.md))
 
 ## Description
 
-TODO
+This chart deploys the Tekton Dashboard. It should run on k8s as well as OpenShift.
+
+It includes various options to create rbac resources, control pods placement and resources, etc...
+
+All options are documented in the [Chart Values](#chart-values) section.
+
+Various configuration examples are document in the [Try it out](#try-it-out) section.
 
 ## Installing
 
@@ -109,7 +116,54 @@ You can look directly at the [values.yaml](./values.yaml) file to look at the op
 
 ## Try it out
 
-TODO
+This chart should deploy correctly with default values.
+
+You will find examples below of how to customize the deployment of a release with various options. The list of examples is by no means exhaustive, it tries to cover the most used cases.
+
+If you feel something is incomplete, missing or incorrect please open an issue and we'll do our best to improve this documentation.
+
+### Deploy Tekton Pipelines
+
+Before deploying Tekton Dashboard you should have Tekton Pipelines deployed.
+
+You can use Helm to deploy Tekton Pipelines on you cluster, see [Installing](../pipeline/README.md#installing) instructions.
+
+### Configure pod resources
+
+Create a yaml file called `pod-resources.yaml` looking like this (the name doesn't really matters):
+
+```yaml
+dashboard:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 1
+      memory: 256m
+```
+
+Use the previously created file to pass the values to helm:
+
+```bash
+# This will install Tekton Dashboard in the tekton namespace (with a my-dashboard release name)
+
+# Helm v2
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --values pod-resources.yaml
+# Helm v3
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --values pod-resources.yaml --set customResourceDefinitions.create=false
+```
+
+### Deploy a read only dashboard
+
+```bash
+# This will install Tekton Dashboard in the tekton namespace (with a my-dashboard release name)
+
+# Helm v2
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --set dashboard.readOnly=true
+# Helm v3
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --set dashboard.readOnly=true --set customResourceDefinitions.create=false
+```
 
 ---
 

--- a/helm/dashboard/README.md
+++ b/helm/dashboard/README.md
@@ -1,0 +1,119 @@
+
+
+# Tekton Dashboard Helm Chart
+
+The [Tekton Dashboard](https://github.com/tektoncd/dashboard) is a general purpose, web-based UI for [Tekton Pipelines](https://github.com/tektoncd/pipeline).
+
+This helm chart is a lightweight way to deploy, configure and run Tekton Dashboard on a k8s cluster.
+
+## Requirements
+
+* [Helm](https://helm.sh/) v2 or v3
+* Kubernetes >= 1.15 (it's driven by the version of Tekton Pipelines installed)
+* Depending on the configuration you will need admin access to be able to install the CRDs
+
+## Description
+
+TODO
+
+## Installing
+
+- Add the Tekton helm charts repo
+
+**TODO** this is not yet available, maybe document how to install from sources
+
+```bash
+helm repo add tekton https://charts.tekton.dev
+```
+
+- Install (or upgrade)
+
+```bash
+# This will install Tekton Dashboard in the tekton namespace (with a my-dashboard release name)
+
+# Helm v2
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard
+# Helm v3
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --set customResourceDefinitions.create=false
+```
+
+- Install (or upgrade) without CRDs (assuming CRDs have already been deployed by an admin)
+
+```bash
+# This will install Tekton Dashboard in the tekton namespace (with a my-dashboard release name)
+
+# Helm v2
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --set customResourceDefinitions.create=false
+# Helm v3
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --set customResourceDefinitions.create=false --skip-crds
+```
+
+- Install (or upgrade) without creating RBAC resources (assuming RBAC resources have been created by an admin)
+
+```bash
+# This will install Tekton Dashboard in the tekton namespace (with a my-dashboard release name)
+
+# Helm v2
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --set rbac.create=false --set rbac.serviceAccountName=svcAccountName
+# Helm v3
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --set customResourceDefinitions.create=false --set rbac.create=false --set rbac.serviceAccountName=svcAccountName
+```
+
+Look [below](#chart-values) for the list of all available options and their corresponding description.
+
+## Uninstalling
+
+To uninstall the chart, simply delete the release.
+
+```bash
+# This will uninstall Tekton Dashboard in the tekton namespace (assuming a my-dashboard release name)
+
+# Helm v2
+helm delete --purge my-dashboard
+# Helm v3
+helm uninstall my-dashboard --namespace tekton
+```
+
+## Version
+
+Current chart version is `0.0.1`
+
+## Chart Values
+
+
+| Key | Type | Description | Default |
+|-----|------|-------------|---------|
+| `customResourceDefinitions.create` | bool | Create CRDs | `true` |
+| `dashboard.affinity` | object | Dashboard affinity rules | `{}` |
+| `dashboard.annotations` | object | Dashboard pod annotations | See [values.yaml](./values.yaml) |
+| `dashboard.image.pullPolicy` | string | Dashboard docker image pull policy | `"IfNotPresent"` |
+| `dashboard.image.repository` | string | Dashboard docker image repository | `"gcr.io/tekton-releases/github.com/tektoncd/dashboard/cmd/dashboard"` |
+| `dashboard.image.tag` | string | Dashboard docker image tag | `"v0.6.0"` |
+| `dashboard.nodeSelector` | object | Dashboard node selector | `{}` |
+| `dashboard.readOnly` | bool | Drives running the dashboard in read only mode | `false` |
+| `dashboard.resources` | object | Dashboard resource limits and requests | `{}` |
+| `dashboard.securityContext` | object | Dashboard pods security context | `{}` |
+| `dashboard.service.annotations` | object | Dashboard service annotations | `{}` |
+| `dashboard.service.port` | int | Dashboard service port | `9097` |
+| `dashboard.service.portName` | string |  | `"http"` |
+| `dashboard.service.type` | string | Dashboard service type | `"ClusterIP"` |
+| `dashboard.tolerations` | list | Dashboard tolerations | `[]` |
+| `fullnameOverride` | string | Fully override resource generated names | `""` |
+| `nameOverride` | string | Partially override resource generated names | `""` |
+| `rbac.create` | bool | Create RBAC resources | `true` |
+| `rbac.serviceAccountName` | string | Name of the service account to use when rbac.create is false | `nil` |
+| `version` | string | Tekton dashboard version used to add labels on deployments, pods and services | `"v0.6.0"` |
+
+
+You can look directly at the [values.yaml](./values.yaml) file to look at the options and their default values.
+
+## Try it out
+
+TODO
+
+---
+
+Except as otherwise noted, the content of this page is licensed under the
+[Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
+and code samples are licensed under the
+[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/helm/dashboard/README.md.gotmpl
+++ b/helm/dashboard/README.md.gotmpl
@@ -1,0 +1,100 @@
+{{ define "chart.valuesTable" }}
+| Key | Type | Description | Default |
+|-----|------|-------------|---------|
+{{- range .Values }}
+| `{{ .Key }}` | {{ .Type }} | {{ .Description }} | {{ .Default }} |
+{{- end }}
+{{ end }}
+
+# Tekton Dashboard Helm Chart
+
+The [Tekton Dashboard](https://github.com/tektoncd/dashboard) is a general purpose, web-based UI for [Tekton Pipelines](https://github.com/tektoncd/pipeline).
+
+This helm chart is a lightweight way to deploy, configure and run Tekton Dashboard on a k8s cluster.
+
+## Requirements
+
+* [Helm](https://helm.sh/) v2 or v3
+* Kubernetes >= 1.15 (it's driven by the version of Tekton Pipelines installed)
+* Depending on the configuration you will need admin access to be able to install the CRDs
+
+## Description
+
+TODO
+
+## Installing
+
+- Add the Tekton helm charts repo
+
+**TODO** this is not yet available, maybe document how to install from sources
+
+```bash
+helm repo add tekton https://charts.tekton.dev
+```
+
+- Install (or upgrade)
+
+```bash
+# This will install Tekton Dashboard in the tekton namespace (with a my-dashboard release name)
+
+# Helm v2
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard
+# Helm v3
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --set customResourceDefinitions.create=false
+```
+
+- Install (or upgrade) without CRDs (assuming CRDs have already been deployed by an admin)
+
+```bash
+# This will install Tekton Dashboard in the tekton namespace (with a my-dashboard release name)
+
+# Helm v2
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --set customResourceDefinitions.create=false
+# Helm v3
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --set customResourceDefinitions.create=false --skip-crds
+```
+
+- Install (or upgrade) without creating RBAC resources (assuming RBAC resources have been created by an admin)
+
+```bash
+# This will install Tekton Dashboard in the tekton namespace (with a my-dashboard release name)
+
+# Helm v2
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --set rbac.create=false --set rbac.serviceAccountName=svcAccountName
+# Helm v3
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --set customResourceDefinitions.create=false --set rbac.create=false --set rbac.serviceAccountName=svcAccountName
+```
+
+Look [below](#chart-values) for the list of all available options and their corresponding description.
+
+## Uninstalling
+
+To uninstall the chart, simply delete the release.
+
+```bash
+# This will uninstall Tekton Dashboard in the tekton namespace (assuming a my-dashboard release name)
+
+# Helm v2
+helm delete --purge my-dashboard
+# Helm v3
+helm uninstall my-dashboard --namespace tekton
+```
+
+## Version
+
+{{ template "chart.versionLine" . }}
+
+{{ template "chart.valuesSection" . }}
+
+You can look directly at the [values.yaml](./values.yaml) file to look at the options and their default values.
+
+## Try it out
+
+TODO
+
+---
+
+Except as otherwise noted, the content of this page is licensed under the
+[Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
+and code samples are licensed under the
+[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/helm/dashboard/README.md.gotmpl
+++ b/helm/dashboard/README.md.gotmpl
@@ -17,10 +17,17 @@ This helm chart is a lightweight way to deploy, configure and run Tekton Dashboa
 * [Helm](https://helm.sh/) v2 or v3
 * Kubernetes >= 1.15 (it's driven by the version of Tekton Pipelines installed)
 * Depending on the configuration you will need admin access to be able to install the CRDs
+* Tekton Pipelines deployed in the target cluster (see [Tekton Pipelines Helm Chart](../pipeline/README.md))
 
 ## Description
 
-TODO
+This chart deploys the Tekton Dashboard. It should run on k8s as well as OpenShift.
+
+It includes various options to create rbac resources, control pods placement and resources, etc...
+
+All options are documented in the [Chart Values](#chart-values) section.
+
+Various configuration examples are document in the [Try it out](#try-it-out) section.
 
 ## Installing
 
@@ -90,7 +97,54 @@ You can look directly at the [values.yaml](./values.yaml) file to look at the op
 
 ## Try it out
 
-TODO
+This chart should deploy correctly with default values.
+
+You will find examples below of how to customize the deployment of a release with various options. The list of examples is by no means exhaustive, it tries to cover the most used cases.
+
+If you feel something is incomplete, missing or incorrect please open an issue and we'll do our best to improve this documentation.
+
+### Deploy Tekton Pipelines
+
+Before deploying Tekton Dashboard you should have Tekton Pipelines deployed.
+
+You can use Helm to deploy Tekton Pipelines on you cluster, see [Installing](../pipeline/README.md#installing) instructions.
+
+### Configure pod resources
+
+Create a yaml file called `pod-resources.yaml` looking like this (the name doesn't really matters):
+
+```yaml
+dashboard:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 1
+      memory: 256m
+```
+
+Use the previously created file to pass the values to helm:
+
+```bash
+# This will install Tekton Dashboard in the tekton namespace (with a my-dashboard release name)
+
+# Helm v2
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --values pod-resources.yaml
+# Helm v3
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --values pod-resources.yaml --set customResourceDefinitions.create=false
+```
+
+### Deploy a read only dashboard
+
+```bash
+# This will install Tekton Dashboard in the tekton namespace (with a my-dashboard release name)
+
+# Helm v2
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --set dashboard.readOnly=true
+# Helm v3
+helm upgrade --install my-dashboard --namespace tekton tekton/dashboard --set dashboard.readOnly=true --set customResourceDefinitions.create=false
+```
 
 ---
 

--- a/helm/dashboard/crds/extension.yaml
+++ b/helm/dashboard/crds/extension.yaml
@@ -12,16 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: pipeline
-apiVersion: v1
-version: 0.0.1
-appVersion: 0.11.0
-home: https://github.com/tektoncd/pipeline
-keywords:
-  - helm
-  - tekton pipeline
-maintainers:
-  - name: eddycharly
-    email: ceb@agriconomie.com
-description: |
-  This chart bootstraps installation of [tekton pipeline](https://github.com/tektoncd/pipeline).
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: extensions.dashboard.tekton.dev
+spec:
+  group: dashboard.tekton.dev
+  names:
+    categories:
+    - tekton
+    - tekton-dashboard
+    kind: Extension
+    plural: extensions
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/helm/dashboard/templates/NOTES.txt
+++ b/helm/dashboard/templates/NOTES.txt
@@ -1,0 +1,4 @@
+Tekton dashboard have been installed successfully.
+To verify that the controller has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ template "dashboard.name" . }},app.kubernetes.io/component=controller,app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/dashboard/templates/_helpers.tpl
+++ b/helm/dashboard/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dashboard.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dashboard.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dashboard.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "dashboard.serviceAccountName" -}}
+{{- if .Values.rbac.create -}}
+{{- template "dashboard.fullname" . -}}
+{{- else -}}
+{{- required "A service account name is required" .Values.rbac.serviceAccountName -}}
+{{- end -}}
+{{- end -}}

--- a/helm/dashboard/templates/clusterrole.yaml
+++ b/helm/dashboard/templates/clusterrole.yaml
@@ -1,0 +1,244 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.rbac.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "dashboard.fullname" . }}
+rules:
+  {{- if not .Values.dashboard.readOnly }}
+  - apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+    verbs:
+      - update
+      - patch
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+    verbs:
+      - create
+      - update
+      - delete
+      - patch
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - extensions
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - update
+      - delete
+      - patch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - tasks
+      - clustertasks
+      - taskruns
+      - pipelines
+      - pipelineruns
+      - pipelineresources
+      - conditions
+    verbs:
+      - create
+      - update
+      - delete
+      - patch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - taskruns/finalizers
+      - pipelineruns/finalizers
+    verbs:
+      - create
+      - update
+      - delete
+      - patch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - tasks/status
+      - clustertasks/status
+      - taskruns/status
+      - pipelines/status
+      - pipelineruns/status
+    verbs:
+      - create
+      - update
+      - delete
+      - patch
+  - apiGroups:
+      - dashboard.tekton.dev
+    resources:
+      - extensions
+    verbs:
+      - create
+      - update
+      - delete
+      - patch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - eventlisteners
+      - triggerbindings
+      - triggertemplates
+    verbs:
+      - create
+      - update
+      - delete
+      - patch
+      - add
+  {{- end }}
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - extensions
+      - apps
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - pods/log
+      - namespaces
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - tasks
+      - clustertasks
+      - taskruns
+      - pipelines
+      - pipelineruns
+      - pipelineresources
+      - conditions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - taskruns/finalizers
+      - pipelineruns/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - tasks/status
+      - clustertasks/status
+      - taskruns/status
+      - pipelines/status
+      - pipelineruns/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - dashboard.tekton.dev
+    resources:
+      - extensions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - eventlisteners
+      - triggerbindings
+      - triggertemplates
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}

--- a/helm/dashboard/templates/clusterrolebinding.yaml
+++ b/helm/dashboard/templates/clusterrolebinding.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: pipeline
-apiVersion: v1
-version: 0.0.1
-appVersion: 0.11.0
-home: https://github.com/tektoncd/pipeline
-keywords:
-  - helm
-  - tekton pipeline
-maintainers:
-  - name: eddycharly
-    email: ceb@agriconomie.com
-description: |
-  This chart bootstraps installation of [tekton pipeline](https://github.com/tektoncd/pipeline).
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "dashboard.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "dashboard.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "dashboard.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/dashboard/templates/customresourcedefinitions.yaml
+++ b/helm/dashboard/templates/customresourcedefinitions.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,16 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: pipeline
-apiVersion: v1
-version: 0.0.1
-appVersion: 0.11.0
-home: https://github.com/tektoncd/pipeline
-keywords:
-  - helm
-  - tekton pipeline
-maintainers:
-  - name: eddycharly
-    email: ceb@agriconomie.com
-description: |
-  This chart bootstraps installation of [tekton pipeline](https://github.com/tektoncd/pipeline).
+{{- if .Values.customResourceDefinitions.create }}
+{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
+{{ $.Files.Get $path }}
+---
+{{- end }}
+{{- end }}

--- a/helm/dashboard/templates/dashboard_deployment.yaml
+++ b/helm/dashboard/templates/dashboard_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-      {{- with .Values.controller.annotations }}
+      {{- with .Values.dashboard.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/dashboard/templates/dashboard_deployment.yaml
+++ b/helm/dashboard/templates/dashboard_deployment.yaml
@@ -1,0 +1,97 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "dashboard.fullname" . }}-controller
+  labels:
+    app.kubernetes.io/name: {{ template "dashboard.name" . }}
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "dashboard.chart" . }}
+    dashboard.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "dashboard.name" . }}
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      {{- with .Values.controller.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ template "dashboard.name" . }}
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        helm.sh/chart: {{ template "dashboard.chart" . }}
+        dashboard.tekton.dev/release: {{ .Values.version | quote }}
+        version: {{ .Values.version | quote }}
+    spec:
+      serviceAccountName: {{ template "dashboard.serviceAccountName" . }}
+      {{- with .Values.dashboard.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: dashboard
+          image: {{ printf "%s:%s" .Values.dashboard.image.repository .Values.dashboard.image.tag | quote }}
+          imagePullPolicy: {{ .Values.dashboard.image.pullPolicy | quote }}
+          env:
+            - name: PORT
+              value: "9097"
+            - name: READ_ONLY
+              value: {{ .Values.dashboard.readOnly | quote }}
+            - name: WEB_RESOURCES_DIR
+              value: /var/run/ko/web
+            - name: PIPELINE_RUN_SERVICE_ACCOUNT
+              value: ""
+            - name: INSTALLED_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          {{- with .Values.dashboard.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - containerPort: 9097
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 9097
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 9097

--- a/helm/dashboard/templates/dashboard_pipeline.yaml
+++ b/helm/dashboard/templates/dashboard_pipeline.yaml
@@ -1,0 +1,51 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline0
+  namespace: tekton-pipelines
+spec:
+  params:
+    - default: /workspace/git-source
+      description: The path to the resource files to apply
+      name: pathToResourceFiles
+      type: string
+    - default: .
+      description: The directory from which resources are to be applied
+      name: apply-directory
+      type: string
+    - default: tekton-pipelines
+      description: The namespace in which to create the resources being imported
+      name: target-namespace
+      type: string
+  resources:
+    - name: git-source
+      type: git
+  tasks:
+    - name: pipeline0-task
+      params:
+        - name: pathToResourceFiles
+          value: $(params.pathToResourceFiles)
+        - name: apply-directory
+          value: $(params.apply-directory)
+        - name: target-namespace
+          value: $(params.target-namespace)
+      resources:
+        inputs:
+          - name: git-source
+            resource: git-source
+      taskRef:
+        name: pipeline0-task

--- a/helm/dashboard/templates/dashboard_pipeline.yaml
+++ b/helm/dashboard/templates/dashboard_pipeline.yaml
@@ -16,7 +16,6 @@ apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: pipeline0
-  namespace: tekton-pipelines
 spec:
   params:
     - default: /workspace/git-source
@@ -27,7 +26,7 @@ spec:
       description: The directory from which resources are to be applied
       name: apply-directory
       type: string
-    - default: tekton-pipelines
+    - default: {{ .Release.Namespace | quote }}
       description: The namespace in which to create the resources being imported
       name: target-namespace
       type: string

--- a/helm/dashboard/templates/dashboard_service.yaml
+++ b/helm/dashboard/templates/dashboard_service.yaml
@@ -1,0 +1,41 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "dashboard.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "dashboard.name" . }}
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "dashboard.chart" . }}
+    dashboard.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+  {{- with .Values.dashboard.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.dashboard.service.type }}
+  ports:
+    - name: {{ .Values.dashboard.service.portName }}
+      port: {{ .Values.dashboard.service.port }}
+      protocol: TCP
+      targetPort: 9097
+  selector:
+    app.kubernetes.io/name: {{ template "dashboard.name" . }}
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/dashboard/templates/dashboard_task.yaml
+++ b/helm/dashboard/templates/dashboard_task.yaml
@@ -16,7 +16,6 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: pipeline0-task
-  namespace: tekton-pipelines
 spec:
   params:
     - default: /workspace/git-source
@@ -27,7 +26,7 @@ spec:
       description: The directory from which resources are to be applied
       name: apply-directory
       type: string
-    - default: tekton-pipelines
+    - default: {{ .Release.Namespace | quote }}
       description: The namespace where created resources will go
       name: target-namespace
       type: string

--- a/helm/dashboard/templates/dashboard_task.yaml
+++ b/helm/dashboard/templates/dashboard_task.yaml
@@ -1,0 +1,48 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: pipeline0-task
+  namespace: tekton-pipelines
+spec:
+  params:
+    - default: /workspace/git-source
+      description: The path to the resource files to apply
+      name: pathToResourceFiles
+      type: string
+    - default: .
+      description: The directory from which resources are to be applied
+      name: apply-directory
+      type: string
+    - default: tekton-pipelines
+      description: The namespace where created resources will go
+      name: target-namespace
+      type: string
+  resources:
+    inputs:
+      - name: git-source
+        type: git
+  steps:
+    - args:
+        - apply
+        - -f
+        - $(inputs.params.pathToResourceFiles)/$(inputs.params.apply-directory)
+        - -n
+        - $(inputs.params.target-namespace)
+      command:
+        - kubectl
+      image: lachlanevenson/k8s-kubectl@sha256:95043fa03abd84fe1aed0b72f7991b379fdcd28fa77a1a163ec9ecd04bc33358
+      name: kubectl-apply

--- a/helm/dashboard/templates/serviceaccount.yaml
+++ b/helm/dashboard/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,16 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: pipeline
+{{- if .Values.rbac.create }}
 apiVersion: v1
-version: 0.0.1
-appVersion: 0.11.0
-home: https://github.com/tektoncd/pipeline
-keywords:
-  - helm
-  - tekton pipeline
-maintainers:
-  - name: eddycharly
-    email: ceb@agriconomie.com
-description: |
-  This chart bootstraps installation of [tekton pipeline](https://github.com/tektoncd/pipeline).
+kind: ServiceAccount
+metadata:
+  name: {{ template "dashboard.serviceAccountName" . }}
+{{- end }}

--- a/helm/dashboard/values.yaml
+++ b/helm/dashboard/values.yaml
@@ -1,0 +1,80 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# version -- Tekton dashboard version used to add labels on deployments, pods and services
+version: v0.6.0
+
+# nameOverride -- Partially override resource generated names
+nameOverride: ""
+
+# fullnameOverride -- Fully override resource generated names
+fullnameOverride: ""
+
+rbac:
+  # rbac.create -- Create RBAC resources
+  create: true
+
+  # rbac.serviceAccountName -- Name of the service account to use when rbac.create is false
+  serviceAccountName:
+
+customResourceDefinitions:
+  # customResourceDefinitions.create -- Create CRDs
+  create: true
+
+dashboard:
+  image:
+    # dashboard.image.repository -- Dashboard docker image repository
+    repository: gcr.io/tekton-releases/github.com/tektoncd/dashboard/cmd/dashboard
+
+    # dashboard.image.tag -- Dashboard docker image tag
+    tag: v0.6.0
+
+    # dashboard.image.pullPolicy -- Dashboard docker image pull policy
+    pullPolicy: IfNotPresent
+
+  # dashboard.readOnly -- Drives running the dashboard in read only mode
+  readOnly: false
+
+  # dashboard.annotations -- Dashboard pod annotations
+  # @default -- See [values.yaml](./values.yaml)
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+
+  # dashboard.nodeSelector -- Dashboard node selector
+  nodeSelector: {}
+
+  # dashboard.affinity -- Dashboard affinity rules
+  affinity: {}
+
+  # dashboard.tolerations -- Dashboard tolerations
+  tolerations: []
+
+  # dashboard.resources -- Dashboard resource limits and requests
+  resources: {}
+
+  # dashboard.securityContext -- Dashboard pods security context
+  securityContext: {}
+
+  service:
+    # dashboard.service.type -- Dashboard service type
+    type: ClusterIP
+
+    # dashboard.service.annotations -- Dashboard service annotations
+    annotations: {}
+
+    # dashboard.service.port -- Dashboard service port
+    port: 9097
+
+    # dashboard.service.service.portName -- Dashboard service port name
+    portName: http

--- a/helm/pipeline/README.md
+++ b/helm/pipeline/README.md
@@ -255,7 +255,7 @@ Find below the list of supported config maps and their corresponding config key:
 
 Please look in [values.yaml](./values.yaml) to find the default values for each config map.
 
-### Configure Pod Resources
+### Configure pod resources
 
 Controller and Webhook pod resources are configured independently.
 

--- a/helm/pipeline/README.md.gotmpl
+++ b/helm/pipeline/README.md.gotmpl
@@ -204,7 +204,7 @@ Find below the list of supported config maps and their corresponding config key:
 
 Please look in [values.yaml](./values.yaml) to find the default values for each config map.
 
-### Configure Pod Resources
+### Configure pod resources
 
 Controller and Webhook pod resources are configured independently.
 


### PR DESCRIPTION
This pull request adds a helm chart for Tekton Dashboard.

It is a follow up from the previous PR #494.
Helm chart support was proposed here: https://github.com/tektoncd/plumbing/issues/278

This is work in progress, remaining TODOs:
- [x] doc
- [x] tests (tested with kind)

Minor issues:
- Namespace `tekton-pipelines` is hardcoded in a few places (see https://github.com/tektoncd/dashboard/pull/1262)

I will try to make the dashboard not dependent of hardcoded namespaces and will update the chart accordingly.