### PR TITLE
Add script to check helm docs are up to date

### DIFF
--- a/helm/.hack/check-helm-docs.sh
+++ b/helm/.hack/check-helm-docs.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+# This script is meant to be run inside a container running jnorwood/helm-docs image
+
+apk add -u git
+
+helm-docs
+
+OUTOFDATE=$(git status --porcelain)
+
+if [ ! -z "$OUTOFDATE" ]; then
+    echo "helm charts doc is out of date, please run `helm-docs` to generate the new docs before pushing your changes"
+
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This pull request adds a shell script to verify that helm docs are up to date.

This will be used in a prow job to validate helm docs against pull requests.

The related `tektoncd/plumbing` issue is here: https://github.com/tektoncd/plumbing/issues/309