### PR TITLE
Use Triggers 0.4 (not a release candidate) in Gopkg yaml

### DIFF
--- a/webhooks-extension/Gopkg.lock
+++ b/webhooks-extension/Gopkg.lock
@@ -236,7 +236,7 @@
   version = "v0.11.0"
 
 [[projects]]
-  digest = "1:6f0a8462160c7a87d9cdb98961b1e1910e6e91d448c8fb3e8923472a2c15e56a"
+  digest = "1:65ea6f76fb07726cf5c8ed73381e06e330152a1ee4f9a36957afdf40499c2280"
   name = "github.com/tektoncd/triggers"
   packages = [
     "pkg/apis/triggers/v1alpha1",
@@ -247,8 +247,8 @@
     "pkg/client/clientset/versioned/typed/triggers/v1alpha1/fake",
   ]
   pruneopts = "UT"
-  revision = "8553105c5d93e9a4a14307f40c53c7ec4dea5383"
-  version = "v0.4.0-rc1"
+  revision = "b85308d5da5af5e13a4f7c01f3c3baef3d1368bd"
+  version = "v0.4.0"
 
 [[projects]]
   digest = "1:4be983745b731611c52a01c36fff692ca62ca7793386c8bf3ade886cce0450a2"

--- a/webhooks-extension/Gopkg.toml
+++ b/webhooks-extension/Gopkg.toml
@@ -1,6 +1,6 @@
 [[override]]
   name = "github.com/tektoncd/triggers"
-  version = "v0.4.0-rc1"
+  version = "v0.4.0"
 
 [[override]]
   name = "knative.dev/pkg"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Now Triggers 0.4 is a thing we shouldn't be pinning to a release candidate version, tested this morning in a fresh environment and all continues to work fine

# Changes

toml file changed, dep ensured to give us the new lock file contents

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
