### PR TITLE
Add triggers helm chart

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -22,7 +22,7 @@ The following charts are available, please look in the chart directories for the
 |---|---|
 | Tekton Pipelines | [chart documentation](./pipeline/README.md) |
 | Tekton Dashboard | [chart documentation](./dashboard/README.md) |
-| Tekton Triggers | TODO |
+| Tekton Triggers | [chart documentation](./triggers/README.md) |
 | Tekton Operator | TODO |
 
 ## Kubernetes Versions

--- a/helm/triggers/Chart.yaml
+++ b/helm/triggers/Chart.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: triggers
+apiVersion: v1
+version: 0.4.0
+appVersion: 0.4.0
+home: https://github.com/tektoncd/triggers
+keywords:
+  - helm
+  - tekton triggers
+maintainers:
+  - name: eddycharly
+    email: ceb@agriconomie.com
+description: |
+  This chart bootstraps installation of [tekton triggers](https://github.com/tektoncd/triggers).

--- a/helm/triggers/README.md
+++ b/helm/triggers/README.md
@@ -1,0 +1,363 @@
+
+
+# Tekton Triggers Helm Chart
+
+[Triggers](https://github.com/tektoncd/triggers) is a Kubernetes Custom Resource Defintion (CRD) controller that allows you to extract information from events payloads (a "trigger") to create Kubernetes resources.
+
+## Requirements
+
+* [Helm](https://helm.sh/) v2 or v3
+* Kubernetes >= 1.15 (it's driven by the version of Tekton Pipelines installed)
+* Depending on the configuration you will need admin access to be able to install the CRDs
+* Tekton Pipelines deployed in the target cluster (see [Tekton Pipelines Helm Chart](../pipeline/README.md))
+
+## Description
+
+This chart deploys the Tekton Triggers controller and optionnaly the associated webhook (it's strongly recommended to deploy both). It should run on k8s as well as OpenShift.
+
+It includes various options to expose metrics and/or profiling endpoints, create rbac resources, run in high availabilty mode, control pods placement and resources, etc...
+
+All options are documented in the [Chart Values](#chart-values) section.
+
+Various configuration examples are document in the [Try it out](#try-it-out) section.
+
+An additional guide is available in the [Production grade configuration](#production-grade-configuration) section to help deploying Tekton Triggers in a highlly available and secure mode.
+
+## Installing
+
+- Add the Tekton helm charts repo
+
+**TODO** this is not yet available, maybe document how to install from sources
+
+```bash
+helm repo add tekton https://charts.tekton.dev
+```
+
+- Install (or upgrade)
+
+```bash
+# This will install Tekton Triggers in the tekton namespace (with a my-triggers release name)
+
+# Helm v2
+helm upgrade --install my-triggers --namespace tekton tekton/triggers
+# Helm v3
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set customResourceDefinitions.create=false
+```
+
+- Install (or upgrade) without CRDs (assuming CRDs have already been deployed by an admin)
+
+```bash
+# This will install Tekton Triggers in the tekton namespace (with a my-triggers release name)
+
+# Helm v2
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set customResourceDefinitions.create=false
+# Helm v3
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set customResourceDefinitions.create=false --skip-crds
+```
+
+- Install (or upgrade) without creating RBAC resources (assuming RBAC resources have been created by an admin)
+
+```bash
+# This will install Tekton Triggers in the tekton namespace (with a my-triggers release name)
+
+# Helm v2
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set rbac.create=false --set rbac.serviceAccountName=svcAccountName
+# Helm v3
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set customResourceDefinitions.create=false --set rbac.create=false --set rbac.serviceAccountName=svcAccountName
+```
+
+Look [below](#chart-values) for the list of all available options and their corresponding description.
+
+## Uninstalling
+
+To uninstall the chart, simply delete the release.
+
+```bash
+# This will uninstall Tekton Triggers in the tekton namespace (assuming a my-triggers release name)
+
+# Helm v2
+helm delete --purge my-triggers
+# Helm v3
+helm uninstall my-triggers --namespace tekton
+```
+
+## Version
+
+Current chart version is `0.4.0`
+
+## Chart Values
+
+
+| Key | Type | Description | Default |
+|-----|------|-------------|---------|
+| `config.logging` | object | Configuration for logging (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md) | See [values.yaml](./values.yaml) |
+| `config.observability` | object | Configuration for observability (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md) | See [values.yaml](./values.yaml) |
+| `controller.affinity` | object | Controller affinity rules | `{}` |
+| `controller.annotations` | object | Controller pod annotations | See [values.yaml](./values.yaml) |
+| `controller.args` | list | Controller arguments | See [values.yaml](./values.yaml) |
+| `controller.image.pullPolicy` | string | Controller docker image pull policy | `"IfNotPresent"` |
+| `controller.image.repository` | string | Controller docker image repository | `"gcr.io/tekton-releases/github.com/tektoncd/triggers/cmd/controller"` |
+| `controller.image.tag` | string | Controller docker image tag | `"v0.4.0"` |
+| `controller.metrics.enabled` | bool | Enable controller metrics service | `true` |
+| `controller.metrics.port` | int | Controller metrics service port | `9090` |
+| `controller.metrics.portName` | string |  | `"metrics"` |
+| `controller.nodeSelector` | object | Controller node selector | `{}` |
+| `controller.resources` | object | Controller resource limits and requests | `{}` |
+| `controller.securityContext` | object | Controller pods security context | `{}` |
+| `controller.service.annotations` | object | Controller service annotations | `{}` |
+| `controller.service.type` | string | Controller service type | `"ClusterIP"` |
+| `controller.tolerations` | list | Controller tolerations | `[]` |
+| `customResourceDefinitions.create` | bool | Create CRDs | `true` |
+| `fullnameOverride` | string | Fully override resource generated names | `""` |
+| `nameOverride` | string | Partially override resource generated names | `""` |
+| `podSecurityPolicy.enabled` | bool | Enable pod security policy | `false` |
+| `rbac.create` | bool | Create RBAC resources | `true` |
+| `rbac.serviceAccountName` | string | Name of the service account to use when rbac.create is false | `nil` |
+| `version` | string | Tekton triggers version used to add labels on deployments, pods and services | `"v0.4.0"` |
+| `webhook.affinity` | object | Webhook affinity rules | `{}` |
+| `webhook.annotations` | object | Webhook pod annotations | See [values.yaml](./values.yaml) |
+| `webhook.enabled` | bool | Enable webhook | `true` |
+| `webhook.image.pullPolicy` | string | Webhook docker image pull policy | `"IfNotPresent"` |
+| `webhook.image.repository` | string | Webhook docker image repository | `"gcr.io/tekton-releases/github.com/tektoncd/triggers/cmd/webhook"` |
+| `webhook.image.tag` | string | Webhook docker image tag | `"v0.4.0"` |
+| `webhook.metrics.enabled` | bool | Enable webhook metrics service | `true` |
+| `webhook.metrics.port` | int | Webhook metrics service port | `9090` |
+| `webhook.metrics.portName` | string | Webhook metrics service port name | `"http-metrics"` |
+| `webhook.nodeSelector` | object | Webhook node selector | `{}` |
+| `webhook.podDisruptionBudget.ennabled` | bool |  | `false` |
+| `webhook.podDisruptionBudget.maxUnavailable` | int | Maximum unavailable webhook pods | `1` |
+| `webhook.podDisruptionBudget.minAvailable` | int | Minimum available webhook pods | `1` |
+| `webhook.profiling.enabled` | bool | Enable pebhook profiling service | `true` |
+| `webhook.profiling.port` | int | Webhook profiling service port | `8008` |
+| `webhook.profiling.portName` | string | Webhook profiling service port name | `"http-profiling"` |
+| `webhook.replicas` | int | Webhook replicas | `1` |
+| `webhook.resources` | object | Webhook resource limits and requests | `{}` |
+| `webhook.securityContext` | object | Webhook pods security context | `{}` |
+| `webhook.service.annotations` | object | Webhook service annotations | `{}` |
+| `webhook.service.type` | string | Webhook service type | `"ClusterIP"` |
+| `webhook.tolerations` | list | Webhook tolerations | `[]` |
+| `webhook.updateStrategy` | object | Webhook pods update strategy | `{}` |
+
+
+You can look directly at the [values.yaml](./values.yaml) file to look at the options and their default values.
+
+## Try it out
+
+This chart should deploy correctly with default values.
+
+You will find examples below of how to customize the deployment of a release with various options. The list of examples is by no means exhaustive, it tries to cover the most used cases.
+
+If you feel something is incomplete, missing or incorrect please open an issue and we'll do our best to improve this documentation.
+
+### Disable webhook deployment (not recommended)
+
+This will prevent validation and resource updates if using an old version of the CRDs.
+
+```bash
+# This will install Tekton Triggers in the tekton namespace (with a my-triggers release name)
+
+# Helm v2
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set webhook.enabled=false
+# Helm v3
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set webhook.enabled=false --set customResourceDefinitions.create=false
+```
+
+### Configure pod resources
+
+Controller and Webhook pod resources are configured independently.
+
+Create a yaml file called `pod-resources.yaml` looking like this (the name doesn't really matters):
+
+```yaml
+controller:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 1
+      memory: 256m
+webhook:
+  resources:
+    requests:
+      cpu: 0.2
+      memory: 100m
+    limits:
+      cpu: 0.5
+      memory: 200m
+```
+
+Use the previously created file to pass the values to helm:
+
+```bash
+# This will install Tekton Triggers in the tekton namespace (with a my-triggers release name)
+
+# Helm v2
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --values pod-resources.yaml
+# Helm v3
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --values pod-resources.yaml --set customResourceDefinitions.create=false
+```
+
+### Configure number of webhook replicas
+
+Only Webhook pod replicas can be configured, the controller doesn't support more than 1 replica.
+
+```bash
+# This will install Tekton Triggers in the tekton namespace (with a my-triggers release name)
+
+# Helm v2
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set webhook.replicas=3
+# Helm v3
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set webhook.replicas=3 --set customResourceDefinitions.create=false
+```
+
+### Enable prometheus scraping
+
+To let prometheus scrape the metrics endpoints, we need to set annotations on the controller and/or webhook services.
+
+This can be done using the `controller.service.annotations` and `webhook.service.annotations` options.
+
+Create a yaml file called `service-annotations.yaml` looking like this (the name doesn't really matters):
+
+```yaml
+controller:
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+webhook:
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+```
+
+Use the previously created file to pass the values to helm:
+
+```bash
+# This will install Tekton Triggers in the tekton namespace (with a my-triggers release name)
+
+# Helm v2
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --values service-annotations.yaml
+# Helm v3
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --values service-annotations.yaml --set customResourceDefinitions.create=false
+```
+
+## Production grade configuration
+
+An example configuration is available in [values-production.yaml](./values-production.yaml).
+
+Deploy with:
+
+```bash
+# This will install Tekton Triggers in the tekton namespace (with a my-triggers release name)
+
+# Helm v2
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --values values-production.yaml
+# Helm v3
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --values values-production.yaml --set customResourceDefinitions.create=false
+```
+
+- Enable pod security policy
+
+```yaml
+podSecurityPolicy:
+  enabled: true
+```
+
+- Configure controller/webhook pod resources
+
+Depending on the size and load of your cluster, requests and/or limits values will need to be adjusted.
+
+```yaml
+controller:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 0.5
+      memory: 128m
+webhook:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 0.5
+      memory: 128m
+```
+
+- Prevent cluster autoscaler to evict controller
+
+```yaml
+controller:
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+```
+
+- Enable metrics scraping
+
+```yaml
+controller:
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+  metrics:
+    enabled: true
+    port: 9090
+    portName: metrics
+webhook:
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+  metrics:
+    enabled: true
+    port: 9090
+    portName: metrics
+```
+
+- Configure webhook replicas and affinity
+
+Depending on your k8s platform and cluster topology, you should ensure that more than one webhook pod is running.
+
+Webhook pods should be distributed across data centers/availability zones.
+
+```yaml
+webhook:
+  replicas: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: webhook
+              app.kubernetes.io/instance: my-triggers
+          topologyKey: failure-domain.beta.kubernetes.io/zone
+```
+
+- Configure webhook pod disruption budget and update strategy
+
+To ensure there is always a minimum number of webhook pods running, you should configure a pod disruption budget.
+
+```yaml
+webhook:
+  podDisruptionBudget:
+    ennabled: true
+    minAvailable: 1
+    maxUnavailable: 1
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+```
+
+---
+
+Except as otherwise noted, the content of this page is licensed under the
+[Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
+and code samples are licensed under the
+[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/helm/triggers/README.md.gotmpl
+++ b/helm/triggers/README.md.gotmpl
@@ -1,0 +1,317 @@
+{{ define "chart.valuesTable" }}
+| Key | Type | Description | Default |
+|-----|------|-------------|---------|
+{{- range .Values }}
+| `{{ .Key }}` | {{ .Type }} | {{ .Description }} | {{ .Default }} |
+{{- end }}
+{{ end }}
+
+# Tekton Triggers Helm Chart
+
+[Triggers](https://github.com/tektoncd/triggers) is a Kubernetes Custom Resource Defintion (CRD) controller that allows you to extract information from events payloads (a "trigger") to create Kubernetes resources.
+
+## Requirements
+
+* [Helm](https://helm.sh/) v2 or v3
+* Kubernetes >= 1.15 (it's driven by the version of Tekton Pipelines installed)
+* Depending on the configuration you will need admin access to be able to install the CRDs
+* Tekton Pipelines deployed in the target cluster (see [Tekton Pipelines Helm Chart](../pipeline/README.md))
+
+## Description
+
+This chart deploys the Tekton Triggers controller and optionnaly the associated webhook (it's strongly recommended to deploy both). It should run on k8s as well as OpenShift.
+
+It includes various options to expose metrics and/or profiling endpoints, create rbac resources, run in high availabilty mode, control pods placement and resources, etc...
+
+All options are documented in the [Chart Values](#chart-values) section.
+
+Various configuration examples are document in the [Try it out](#try-it-out) section.
+
+An additional guide is available in the [Production grade configuration](#production-grade-configuration) section to help deploying Tekton Triggers in a highlly available and secure mode.
+
+## Installing
+
+- Add the Tekton helm charts repo
+
+**TODO** this is not yet available, maybe document how to install from sources
+
+```bash
+helm repo add tekton https://charts.tekton.dev
+```
+
+- Install (or upgrade)
+
+```bash
+# This will install Tekton Triggers in the tekton namespace (with a my-triggers release name)
+
+# Helm v2
+helm upgrade --install my-triggers --namespace tekton tekton/triggers
+# Helm v3
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set customResourceDefinitions.create=false
+```
+
+- Install (or upgrade) without CRDs (assuming CRDs have already been deployed by an admin)
+
+```bash
+# This will install Tekton Triggers in the tekton namespace (with a my-triggers release name)
+
+# Helm v2
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set customResourceDefinitions.create=false
+# Helm v3
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set customResourceDefinitions.create=false --skip-crds
+```
+
+- Install (or upgrade) without creating RBAC resources (assuming RBAC resources have been created by an admin)
+
+```bash
+# This will install Tekton Triggers in the tekton namespace (with a my-triggers release name)
+
+# Helm v2
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set rbac.create=false --set rbac.serviceAccountName=svcAccountName
+# Helm v3
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set customResourceDefinitions.create=false --set rbac.create=false --set rbac.serviceAccountName=svcAccountName
+```
+
+Look [below](#chart-values) for the list of all available options and their corresponding description.
+
+## Uninstalling
+
+To uninstall the chart, simply delete the release.
+
+```bash
+# This will uninstall Tekton Triggers in the tekton namespace (assuming a my-triggers release name)
+
+# Helm v2
+helm delete --purge my-triggers
+# Helm v3
+helm uninstall my-triggers --namespace tekton
+```
+
+## Version
+
+{{ template "chart.versionLine" . }}
+
+{{ template "chart.valuesSection" . }}
+
+You can look directly at the [values.yaml](./values.yaml) file to look at the options and their default values.
+
+## Try it out
+
+This chart should deploy correctly with default values.
+
+You will find examples below of how to customize the deployment of a release with various options. The list of examples is by no means exhaustive, it tries to cover the most used cases.
+
+If you feel something is incomplete, missing or incorrect please open an issue and we'll do our best to improve this documentation.
+
+### Disable webhook deployment (not recommended)
+
+This will prevent validation and resource updates if using an old version of the CRDs.
+
+```bash
+# This will install Tekton Triggers in the tekton namespace (with a my-triggers release name)
+
+# Helm v2
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set webhook.enabled=false
+# Helm v3
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set webhook.enabled=false --set customResourceDefinitions.create=false
+```
+
+### Configure pod resources
+
+Controller and Webhook pod resources are configured independently.
+
+Create a yaml file called `pod-resources.yaml` looking like this (the name doesn't really matters):
+
+```yaml
+controller:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 1
+      memory: 256m
+webhook:
+  resources:
+    requests:
+      cpu: 0.2
+      memory: 100m
+    limits:
+      cpu: 0.5
+      memory: 200m
+```
+
+Use the previously created file to pass the values to helm:
+
+```bash
+# This will install Tekton Triggers in the tekton namespace (with a my-triggers release name)
+
+# Helm v2
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --values pod-resources.yaml
+# Helm v3
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --values pod-resources.yaml --set customResourceDefinitions.create=false
+```
+
+### Configure number of webhook replicas
+
+Only Webhook pod replicas can be configured, the controller doesn't support more than 1 replica.
+
+```bash
+# This will install Tekton Triggers in the tekton namespace (with a my-triggers release name)
+
+# Helm v2
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set webhook.replicas=3
+# Helm v3
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --set webhook.replicas=3 --set customResourceDefinitions.create=false
+```
+
+### Enable prometheus scraping
+
+To let prometheus scrape the metrics endpoints, we need to set annotations on the controller and/or webhook services.
+
+This can be done using the `controller.service.annotations` and `webhook.service.annotations` options.
+
+Create a yaml file called `service-annotations.yaml` looking like this (the name doesn't really matters):
+
+```yaml
+controller:
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+webhook:
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+```
+
+Use the previously created file to pass the values to helm:
+
+```bash
+# This will install Tekton Triggers in the tekton namespace (with a my-triggers release name)
+
+# Helm v2
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --values service-annotations.yaml
+# Helm v3
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --values service-annotations.yaml --set customResourceDefinitions.create=false
+```
+
+## Production grade configuration
+
+An example configuration is available in [values-production.yaml](./values-production.yaml).
+
+Deploy with:
+
+```bash
+# This will install Tekton Triggers in the tekton namespace (with a my-triggers release name)
+
+# Helm v2
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --values values-production.yaml
+# Helm v3
+helm upgrade --install my-triggers --namespace tekton tekton/triggers --values values-production.yaml --set customResourceDefinitions.create=false
+```
+
+- Enable pod security policy
+
+```yaml
+podSecurityPolicy:
+  enabled: true
+```
+
+- Configure controller/webhook pod resources
+
+Depending on the size and load of your cluster, requests and/or limits values will need to be adjusted.
+
+```yaml
+controller:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 0.5
+      memory: 128m
+webhook:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 0.5
+      memory: 128m
+```
+
+- Prevent cluster autoscaler to evict controller
+
+```yaml
+controller:
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+```
+
+- Enable metrics scraping
+
+```yaml
+controller:
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+  metrics:
+    enabled: true
+    port: 9090
+    portName: metrics
+webhook:
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+  metrics:
+    enabled: true
+    port: 9090
+    portName: metrics
+```
+
+- Configure webhook replicas and affinity
+
+Depending on your k8s platform and cluster topology, you should ensure that more than one webhook pod is running.
+
+Webhook pods should be distributed across data centers/availability zones.
+
+```yaml
+webhook:
+  replicas: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: webhook
+              app.kubernetes.io/instance: my-triggers
+          topologyKey: failure-domain.beta.kubernetes.io/zone
+```
+
+- Configure webhook pod disruption budget and update strategy
+
+To ensure there is always a minimum number of webhook pods running, you should configure a pod disruption budget.
+
+```yaml
+webhook:
+  podDisruptionBudget:
+    ennabled: true
+    minAvailable: 1
+    maxUnavailable: 1
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+```
+
+---
+
+Except as otherwise noted, the content of this page is licensed under the
+[Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
+and code samples are licensed under the
+[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/helm/triggers/crds/clustertriggerbinding.yaml
+++ b/helm/triggers/crds/clustertriggerbinding.yaml
@@ -1,0 +1,37 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clustertriggerbindings.triggers.tekton.dev
+spec:
+  group: triggers.tekton.dev
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  names:
+    kind: ClusterTriggerBinding
+    plural: clustertriggerbindings
+    singular: clustertriggerbinding
+    shortNames:
+      - ctb
+    categories:
+      - tekton
+      - tekton-triggers
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/helm/triggers/crds/eventlistener.yaml
+++ b/helm/triggers/crds/eventlistener.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: eventlisteners.triggers.tekton.dev
+spec:
+  group: triggers.tekton.dev
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  names:
+    kind: EventListener
+    plural: eventlisteners
+    singular: eventlistener
+    shortNames:
+      - el
+    categories:
+      - tekton
+      - tekton-triggers
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/helm/triggers/crds/triggerbinding.yaml
+++ b/helm/triggers/crds/triggerbinding.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: triggerbindings.triggers.tekton.dev
+spec:
+  group: triggers.tekton.dev
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  names:
+    kind: TriggerBinding
+    plural: triggerbindings
+    singular: triggerbinding
+    shortNames:
+      - tb
+    categories:
+      - tekton
+      - tekton-triggers
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/helm/triggers/crds/triggertemplate.yaml
+++ b/helm/triggers/crds/triggertemplate.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: triggertemplates.triggers.tekton.dev
+spec:
+  group: triggers.tekton.dev
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  names:
+    kind: TriggerTemplate
+    plural: triggertemplates
+    singular: triggertemplate
+    shortNames:
+      - tt
+    categories:
+      - tekton
+      - tekton-triggers
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/helm/triggers/templates/NOTES.txt
+++ b/helm/triggers/templates/NOTES.txt
@@ -1,0 +1,4 @@
+Tekton triggers have been installed successfully.
+To verify that the controller has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ template "triggers.name" . }},app.kubernetes.io/component=controller,app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/triggers/templates/_helpers.tpl
+++ b/helm/triggers/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "triggers.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "triggers.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "triggers.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "triggers.serviceAccountName" -}}
+{{- if .Values.rbac.create -}}
+{{- template "triggers.fullname" . -}}
+{{- else -}}
+{{- required "A service account name is required" .Values.rbac.serviceAccountName -}}
+{{- end -}}
+{{- end -}}

--- a/helm/triggers/templates/clusterrole.yaml
+++ b/helm/triggers/templates/clusterrole.yaml
@@ -1,0 +1,146 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.rbac.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "triggers.fullname" . }}
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - secrets
+      - services
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - deployments/finalizers
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - triggers.tekton.dev
+    resources:
+      - clustertriggerbindings
+      - eventlisteners
+      - triggerbindings
+      - triggertemplates
+      - eventlisteners/finalizers
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - triggers.tekton.dev
+    resources:
+      - clustertriggerbindings/status
+      - eventlisteners/status
+      - triggerbindings/status
+      - triggertemplates/status
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  {{- if .Values.podSecurityPolicy.enabled }}
+  - apiGroups: 
+      - policy
+    resources: 
+      - podsecuritypolicies
+    resourceNames: 
+      - {{ template "triggers.fullname" . }}
+    verbs: 
+      - use
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "triggers.fullname" . }}-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+rules:
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - clustertriggerbindings
+      - eventlisteners
+      - triggerbindings
+      - triggertemplates
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "triggers.fullname" . }}-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+rules:
+- apiGroups:
+    - tekton.dev
+  resources:
+    - clustertriggerbindings
+    - eventlisteners
+    - triggerbindings
+    - triggertemplates
+  verbs:
+    - get
+    - list
+    - watch
+{{- end }}

--- a/helm/triggers/templates/clusterrolebinding.yaml
+++ b/helm/triggers/templates/clusterrolebinding.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "triggers.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "triggers.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "triggers.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/triggers/templates/configmaps.yaml
+++ b/helm/triggers/templates/configmaps.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "triggers.fullname" . }}-logging
+data:
+{{ .Values.config.logging | toYaml | indent 2 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "triggers.fullname" . }}-observability
+data:
+{{ .Values.config.observability | toYaml | indent 2 }}

--- a/helm/triggers/templates/controller_deployment.yaml
+++ b/helm/triggers/templates/controller_deployment.yaml
@@ -1,0 +1,93 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "triggers.fullname" . }}-controller
+  labels:
+    app.kubernetes.io/name: {{ template "triggers.name" . }}
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "triggers.chart" . }}
+    triggers.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "triggers.name" . }}
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      {{- with .Values.controller.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ template "triggers.name" . }}
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        helm.sh/chart: {{ template "triggers.chart" . }}
+        triggers.tekton.dev/release: {{ .Values.version | quote }}
+        version: {{ .Values.version | quote }}
+    spec:
+      serviceAccountName: {{ template "triggers.serviceAccountName" . }}
+      {{- with .Values.controller.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: controller
+          image: {{ printf "%s:%s" .Values.controller.image.repository .Values.controller.image.tag | quote }}
+          imagePullPolicy: {{ .Values.controller.image.pullPolicy | quote }}
+          args:
+          {{- range .Values.controller.args }}
+            - {{ . | quote }}
+          {{- end }}
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: {{ template "triggers.fullname" . }}-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: {{ template "triggers.fullname" . }}-observability
+            - name: METRICS_DOMAIN
+              value: tekton.dev/triggers
+          {{- with .Values.controller.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.controller.metrics.enabled }}
+          ports:
+            - containerPort: 9090
+              protocol: TCP
+          {{- end }}

--- a/helm/triggers/templates/controller_service.yaml
+++ b/helm/triggers/templates/controller_service.yaml
@@ -1,0 +1,43 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.controller.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "triggers.fullname" . }}-controller
+  labels:
+    app.kubernetes.io/name: {{ template "triggers.name" . }}
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "triggers.chart" . }}
+    triggers.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+  {{- with .Values.controller.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.controller.service.type }}
+  ports:
+    - name: {{ .Values.controller.metrics.portName }}
+      port: {{ .Values.controller.metrics.port }}
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    app.kubernetes.io/name: {{ template "triggers.name" . }}
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/triggers/templates/customresourcedefinitions.yaml
+++ b/helm/triggers/templates/customresourcedefinitions.yaml
@@ -1,0 +1,20 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.customResourceDefinitions.create }}
+{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
+{{ $.Files.Get $path }}
+---
+{{- end }}
+{{- end }}

--- a/helm/triggers/templates/podsecuritypolicy.yaml
+++ b/helm/triggers/templates/podsecuritypolicy.yaml
@@ -1,0 +1,49 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "triggers.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "triggers.name" . }}
+    helm.sh/chart: {{ template "triggers.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+    - emptyDir
+    - configMap
+    - secret
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: MustRunAs
+    ranges:
+      - min: 1
+        max: 65535
+{{- end }}

--- a/helm/triggers/templates/serviceaccount.yaml
+++ b/helm/triggers/templates/serviceaccount.yaml
@@ -1,0 +1,20 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "triggers.serviceAccountName" . }}
+{{- end }}

--- a/helm/triggers/templates/webhook_admission.yaml
+++ b/helm/triggers/templates/webhook_admission.yaml
@@ -1,0 +1,99 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## TODO
+
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: webhook-certs
+#   namespace: tekton-pipelines
+#   labels:
+#     pipeline.tekton.dev/release: devel
+# # The data is populated at install time.
+# ---
+{{- if .Values.webhook.enabled }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ template "triggers.fullname" . }}-validation
+  labels:
+    app.kubernetes.io/name: {{ template "triggers.name" . }}
+    app.kubernetes.io/component: admission
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "triggers.chart" . }}
+    triggers.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+webhooks:
+  - name: validation.webhook.triggers.tekton.dev
+    admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: {{ template "triggers.fullname" . }}-webhook
+        namespace: {{ .Release.Namespace }}
+    failurePolicy: Fail
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ template "triggers.fullname" . }}-webhook
+  labels:
+    app.kubernetes.io/name: {{ template "triggers.name" . }}
+    app.kubernetes.io/component: admission
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "triggers.chart" . }}
+    triggers.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+webhooks:
+  - name: webhook.triggers.tekton.dev
+    admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: {{ template "triggers.fullname" . }}-webhook
+        namespace: {{ .Release.Namespace }}
+    failurePolicy: Fail
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ template "triggers.fullname" . }}-config
+  labels:
+    app.kubernetes.io/name: {{ template "triggers.name" . }}
+    app.kubernetes.io/component: admission
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "triggers.chart" . }}
+    triggers.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+webhooks:
+  - name: config.webhook.triggers.tekton.dev
+    admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: {{ template "triggers.fullname" . }}-webhook
+        namespace: {{ .Release.Namespace }}
+    failurePolicy: Fail
+    sideEffects: None
+    namespaceSelector:
+      matchExpressions:
+        - key: triggers.tekton.dev/release
+          operator: Exists
+{{- end }}

--- a/helm/triggers/templates/webhook_deployment.yaml
+++ b/helm/triggers/templates/webhook_deployment.yaml
@@ -1,0 +1,101 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.webhook.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "triggers.fullname" . }}-webhook
+  labels:
+    app.kubernetes.io/name: {{ template "triggers.name" . }}
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "triggers.chart" . }}
+    triggers.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+spec:
+  replicas: {{ .Values.webhook.replicas }}
+  {{- with .Values.webhook.updateStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "triggers.name" . }}
+      app.kubernetes.io/component: webhook
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      {{- with .Values.webhook.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ template "triggers.name" . }}
+        app.kubernetes.io/component: webhook
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        helm.sh/chart: {{ template "triggers.chart" . }}
+        triggers.tekton.dev/release: {{ .Values.version | quote }}
+        version: {{ .Values.version | quote }}
+    spec:
+      serviceAccountName: {{ template "triggers.serviceAccountName" . }}
+      {{- with .Values.webhook.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhook.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhook.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhook.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: webhook
+          image: {{ printf "%s:%s" .Values.webhook.image.repository .Values.webhook.image.tag | quote }}
+          imagePullPolicy: {{ .Values.webhook.image.pullPolicy | quote }}
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: {{ template "triggers.fullname" . }}-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: {{ template "triggers.fullname" . }}-observability
+            - name: WEBHOOK_SERVICE_NAME
+              value: {{ template "triggers.fullname" . }}-webhook
+            - name: METRICS_DOMAIN
+              value: tekton.dev/triggers
+          securityContext:
+            allowPrivilegeEscalation: false
+          {{- with .Values.webhook.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+            - name: https-webhook
+              containerPort: 8443
+{{- end }}

--- a/helm/triggers/templates/webhook_poddisruptionbudget.yaml
+++ b/helm/triggers/templates/webhook_poddisruptionbudget.yaml
@@ -1,0 +1,42 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if and .Values.webhook.enabled .Values.webhook.podDisruptionBudget.enabled }}
+{{- if gt (.Values.webhook.replicas | int) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "triggers.fullname" . }}-webhook
+  labels:
+    app.kubernetes.io/name: {{ template "triggers.name" . }}
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "triggers.chart" . }}
+    triggers.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "triggers.name" . }}
+      app.kubernetes.io/component: webhook
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.webhook.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.webhook.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.webhook.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.webhook.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/triggers/templates/webhook_service.yaml
+++ b/helm/triggers/templates/webhook_service.yaml
@@ -1,0 +1,55 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.webhook.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "triggers.fullname" . }}-webhook
+  labels:
+    app.kubernetes.io/name: {{ template "triggers.name" . }}
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "triggers.chart" . }}
+    triggers.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+  {{- with .Values.webhook.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.webhook.service.type }}
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+    {{- if .Values.webhook.metrics.enabled }}
+    - name: {{ .Values.webhook.metrics.portName }}
+      port: {{ .Values.webhook.metrics.port }}
+      protocol: TCP
+      targetPort: 9090
+    {{- end }}
+    {{- if .Values.webhook.profiling.enabled }}
+    - name: {{ .Values.webhook.profiling.portName }}
+      port: {{ .Values.webhook.profiling.port }}
+      protocol: TCP
+      targetPort: 8008
+    {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ template "triggers.name" . }}
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/triggers/values-production.yaml
+++ b/helm/triggers/values-production.yaml
@@ -1,0 +1,79 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+podSecurityPolicy:
+  enabled: true
+
+controller:
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 0.5
+      memory: 128m
+
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+
+  metrics:
+    enabled: true
+    port: 9090
+    portName: metrics
+
+webhook:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 128m
+    limits:
+      cpu: 0.5
+      memory: 128m
+
+  replicas: 3
+
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: webhook
+              app.kubernetes.io/instance: my-triggers
+          topologyKey: failure-domain.beta.kubernetes.io/zone
+
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9090'
+
+  metrics:
+    enabled: true
+    port: 9090
+    portName: metrics
+
+  podDisruptionBudget:
+    ennabled: true
+    minAvailable: 1
+    maxUnavailable: 1
+
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1

--- a/helm/triggers/values.yaml
+++ b/helm/triggers/values.yaml
@@ -1,0 +1,249 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# version -- Tekton triggers version used to add labels on deployments, pods and services
+version: v0.4.0
+
+# nameOverride -- Partially override resource generated names
+nameOverride: ""
+
+# fullnameOverride -- Fully override resource generated names
+fullnameOverride: ""
+
+rbac:
+  # rbac.create -- Create RBAC resources
+  create: true
+
+  # rbac.serviceAccountName -- Name of the service account to use when rbac.create is false
+  serviceAccountName:
+
+customResourceDefinitions:
+  # customResourceDefinitions.create -- Create CRDs
+  create: true
+
+podSecurityPolicy:
+  # podSecurityPolicy.enabled -- Enable pod security policy
+  enabled: false
+
+config:
+  # config.logging -- Configuration for logging (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md)
+  # @default -- See [values.yaml](./values.yaml)
+  logging:
+    # Common configuration for all knative codebase
+    zap-logger-config: |
+      {
+        "level": "info",
+        "development": false,
+        "sampling": {
+          "initial": 100,
+          "thereafter": 100
+        },
+        "outputPaths": ["stdout"],
+        "errorOutputPaths": ["stderr"],
+        "encoding": "json",
+        "encoderConfig": {
+          "timeKey": "",
+          "levelKey": "level",
+          "nameKey": "logger",
+          "callerKey": "caller",
+          "messageKey": "msg",
+          "stacktraceKey": "stacktrace",
+          "lineEnding": "",
+          "levelEncoder": "",
+          "timeEncoder": "",
+          "durationEncoder": "",
+          "callerEncoder": ""
+        }
+      }
+    # Log level overrides
+    loglevel.controller: "info"
+    loglevel.webhook: "info"
+    loglevel.eventlistener: "info"
+
+  # config.observability -- Configuration for observability (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md)
+  # @default -- See [values.yaml](./values.yaml)
+  observability:
+    _example: |
+      ################################
+      #                              #
+      #    EXAMPLE CONFIGURATION     #
+      #                              #
+      ################################
+
+      # This block is not actually functional configuration,
+      # but serves to illustrate the available configuration
+      # options and document them in a way that is accessible
+      # to users that `kubectl edit` this config map.
+      #
+      # These sample configuration options may be copied out of
+      # this example block and unindented to be in the data block
+      # to actually change the configuration.
+
+      # metrics.backend-destination field specifies the system metrics destination.
+      # It supports either prometheus (the default) or stackdriver.
+      # Note: Using stackdriver will incur additional charges
+      metrics.backend-destination: prometheus
+
+      # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
+      # field is optional. When running on GCE, application default credentials will be
+      # used if this field is not provided.
+      metrics.stackdriver-project-id: "<your stackdriver project id>"
+
+      # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
+      # Stackdriver using "global" resource type and custom metric type if the
+      # metrics are not supported by "knative_revision" resource type. Setting this
+      # flag to "true" could cause extra Stackdriver charge.
+      # If metrics.backend-destination is not Stackdriver, this is ignored.
+      metrics.allow-stackdriver-custom-metrics: "false"
+
+
+controller:
+  image:
+    # controller.image.repository -- Controller docker image repository
+    repository: gcr.io/tekton-releases/github.com/tektoncd/triggers/cmd/controller
+
+    # controller.image.tag -- Controller docker image tag
+    tag: v0.4.0
+
+    # controller.image.pullPolicy -- Controller docker image pull policy
+    pullPolicy: IfNotPresent
+
+  # controller.annotations -- Controller pod annotations
+  # @default -- See [values.yaml](./values.yaml)
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+
+  # controller.nodeSelector -- Controller node selector
+  nodeSelector: {}
+
+  # controller.affinity -- Controller affinity rules
+  affinity: {}
+
+  # controller.tolerations -- Controller tolerations
+  tolerations: []
+
+  # controller.resources -- Controller resource limits and requests
+  resources: {}
+
+  # controller.securityContext -- Controller pods security context
+  securityContext: {}
+
+  # controller.args -- Controller arguments
+  # @default -- See [values.yaml](./values.yaml)
+  args:
+    - -logtostderr
+    - -stderrthreshold
+    - INFO
+    - -el-image
+    - gcr.io/tekton-releases/github.com/tektoncd/triggers/cmd/eventlistenersink:v0.4.0
+    - -el-port
+    - 8080
+    - -period-seconds
+    - 10
+    - -failure-threshold
+    - 1
+
+  service:
+    # controller.service.type -- Controller service type
+    type: ClusterIP
+
+    # controller.service.annotations -- Controller service annotations
+    annotations: {}
+
+  metrics:
+    # controller.metrics.enabled -- Enable controller metrics service
+    enabled: true
+
+    # controller.metrics.port -- Controller metrics service port
+    port: 9090
+
+    # controller.metrics.service.portName -- Controller metrics service port name
+    portName: metrics
+
+webhook:
+  # webhook.enabled -- Enable webhook
+  enabled: true
+
+  image:
+    # webhook.image.repository -- Webhook docker image repository
+    repository: gcr.io/tekton-releases/github.com/tektoncd/triggers/cmd/webhook
+
+    # webhook.image.tag -- Webhook docker image tag
+    tag: v0.4.0
+
+    # webhook.image.pullPolicy -- Webhook docker image pull policy
+    pullPolicy: IfNotPresent
+
+  # webhook.replicas -- Webhook replicas
+  replicas: 1
+
+  # webhook.annotations -- Webhook pod annotations
+  # @default -- See [values.yaml](./values.yaml)
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+
+  # webhook.nodeSelector -- Webhook node selector
+  nodeSelector: {}
+
+  # webhook.affinity -- Webhook affinity rules
+  affinity: {}
+
+  # webhook.tolerations -- Webhook tolerations
+  tolerations: []
+
+  # webhook.resources -- Webhook resource limits and requests
+  resources: {}
+
+  # webhook.updateStrategy -- Webhook pods update strategy
+  updateStrategy: {}
+
+  # webhook.securityContext -- Webhook pods security context
+  securityContext: {}
+
+  podDisruptionBudget:
+    # webhook.podDisruptionBudget.enabled -- Enable pod disruption budget for webhook
+    ennabled: false
+
+    # webhook.podDisruptionBudget.minAvailable -- Minimum available webhook pods
+    minAvailable: 1
+
+    # webhook.podDisruptionBudget.maxUnavailable -- Maximum unavailable webhook pods
+    maxUnavailable: 1
+
+  service:
+    # webhook.service.type -- Webhook service type
+    type: ClusterIP
+
+    # webhook.service.annotations -- Webhook service annotations
+    annotations: {}
+
+  metrics:
+    # webhook.metrics.enabled -- Enable webhook metrics service
+    enabled: true
+
+    # webhook.metrics.port -- Webhook metrics service port
+    port: 9090
+
+    # webhook.metrics.portName -- Webhook metrics service port name
+    portName: http-metrics
+
+  profiling:
+    # webhook.profiling.enabled -- Enable pebhook profiling service
+    enabled: true
+
+    # webhook.profiling.port -- Webhook profiling service port
+    port: 8008
+
+    # webhook.profiling.portName -- Webhook profiling service port name
+    portName: http-profiling


### PR DESCRIPTION
This pull request adds a helm chart for Tekton Triggers.

It is a follow up from the previous PRs #494 and #505.
Helm chart support was proposed here: https://github.com/tektoncd/plumbing/issues/278

This is work in progress, remaining TODOs:
- [x] doc
- [x] tests
