### PR TITLE
[WIP] Add operator helm chart

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -23,7 +23,7 @@ The following charts are available, please look in the chart directories for the
 | Tekton Pipelines | [chart documentation](./pipeline/README.md) |
 | Tekton Dashboard | [chart documentation](./dashboard/README.md) |
 | Tekton Triggers | [chart documentation](./triggers/README.md) |
-| Tekton Operator | TODO |
+| Tekton Operator | [chart documentation](./operator/README.md) |
 
 ## Kubernetes Versions
 

--- a/helm/operator/Chart.yaml
+++ b/helm/operator/Chart.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: operator
+icon: https://tekton.dev/images/tekton-horizontal-color.png
+apiVersion: v1
+version: 0.0.0
+appVersion: 0.0.0
+home: https://github.com/tektoncd/operator
+keywords:
+  - helm
+  - tekton operator
+maintainers:
+  - name: eddycharly
+    email: ceb@agriconomie.com
+description: |
+  This chart bootstraps installation of [tekton operator](https://github.com/tektoncd/operator).

--- a/helm/operator/README.md
+++ b/helm/operator/README.md
@@ -1,0 +1,113 @@
+
+
+# Tekton Operator Helm Chart
+
+TODO
+
+## Requirements
+
+* [Helm](https://helm.sh/) v2 or v3
+* Kubernetes >= 1.15 (it's driven by the version of Tekton Pipelines installed)
+* Depending on the configuration you will need admin access to be able to install the CRDs
+
+## Description
+
+TODO
+
+## Installing
+
+- Add the Tekton helm charts repo
+
+**TODO** this is not yet available, maybe document how to install from sources
+
+```bash
+helm repo add tekton https://charts.tekton.dev
+```
+
+- Install (or upgrade)
+
+```bash
+# This will install Tekton Operator in the tekton namespace (with a my-operator release name)
+
+# Helm v2
+helm upgrade --install my-operator --namespace tekton tekton/operator
+# Helm v3
+helm upgrade --install my-operator --namespace tekton tekton/operator --set customResourceDefinitions.create=false
+```
+
+- Install (or upgrade) without CRDs (assuming CRDs have already been deployed by an admin)
+
+```bash
+# This will install Tekton Operator in the tekton namespace (with a my-operator release name)
+
+# Helm v2
+helm upgrade --install my-operator --namespace tekton tekton/operator --set customResourceDefinitions.create=false
+# Helm v3
+helm upgrade --install my-operator --namespace tekton tekton/operator --set customResourceDefinitions.create=false --skip-crds
+```
+
+- Install (or upgrade) without creating RBAC resources (assuming RBAC resources have been created by an admin)
+
+```bash
+# This will install Tekton Operator in the tekton namespace (with a my-operator release name)
+
+# Helm v2
+helm upgrade --install my-operator --namespace tekton tekton/operator --set rbac.create=false --set rbac.serviceAccountName=svcAccountName
+# Helm v3
+helm upgrade --install my-operator --namespace tekton tekton/operator --set customResourceDefinitions.create=false --set rbac.create=false --set rbac.serviceAccountName=svcAccountName
+```
+
+Look [below](#chart-values) for the list of all available options and their corresponding description.
+
+## Uninstalling
+
+To uninstall the chart, simply delete the release.
+
+```bash
+# This will uninstall Tekton Operator in the tekton namespace (assuming a my-operator release name)
+
+# Helm v2
+helm delete --purge my-operator
+# Helm v3
+helm uninstall my-operator --namespace tekton
+```
+
+## Version
+
+Current chart version is `0.0.0`
+
+## Chart Values
+
+
+| Key | Type | Description | Default |
+|-----|------|-------------|---------|
+| `controller.affinity` | object | Operator affinity rules | `{}` |
+| `controller.annotations` | object | Operator pod annotations | See [values.yaml](./values.yaml) |
+| `controller.image.pullPolicy` | string | Operator docker image pull policy | `"IfNotPresent"` |
+| `controller.image.repository` | string | Operator docker image repository | `"gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/manager"` |
+| `controller.image.tag` | string | Operator docker image tag | `"v0.6.0"` |
+| `controller.nodeSelector` | object | Operator node selector | `{}` |
+| `controller.readOnly` | bool | Drives running the Operator in read only mode | `false` |
+| `controller.resources` | object | Operator resource limits and requests | `{}` |
+| `controller.securityContext` | object | Operator pods security context | `{}` |
+| `controller.tolerations` | list | Operator tolerations | `[]` |
+| `customResourceDefinitions.create` | bool | Create CRDs | `true` |
+| `fullnameOverride` | string | Fully override resource generated names | `""` |
+| `nameOverride` | string | Partially override resource generated names | `""` |
+| `rbac.create` | bool | Create RBAC resources | `true` |
+| `rbac.serviceAccountName` | string | Name of the service account to use when rbac.create is false | `nil` |
+| `version` | string | Tekton triggers version used to add labels on deployments, pods and services | `"v0.0.0"` |
+
+
+You can look directly at the [values.yaml](./values.yaml) file to look at the options and their default values.
+
+## Try it out
+
+TODO
+
+---
+
+Except as otherwise noted, the content of this page is licensed under the
+[Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
+and code samples are licensed under the
+[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/helm/operator/README.md.gotmpl
+++ b/helm/operator/README.md.gotmpl
@@ -1,0 +1,98 @@
+{{ define "chart.valuesTable" }}
+| Key | Type | Description | Default |
+|-----|------|-------------|---------|
+{{- range .Values }}
+| `{{ .Key }}` | {{ .Type }} | {{ .Description }} | {{ .Default }} |
+{{- end }}
+{{ end }}
+
+# Tekton Operator Helm Chart
+
+TODO
+
+## Requirements
+
+* [Helm](https://helm.sh/) v2 or v3
+* Kubernetes >= 1.15 (it's driven by the version of Tekton Pipelines installed)
+* Depending on the configuration you will need admin access to be able to install the CRDs
+
+## Description
+
+TODO
+
+## Installing
+
+- Add the Tekton helm charts repo
+
+**TODO** this is not yet available, maybe document how to install from sources
+
+```bash
+helm repo add tekton https://charts.tekton.dev
+```
+
+- Install (or upgrade)
+
+```bash
+# This will install Tekton Operator in the tekton namespace (with a my-operator release name)
+
+# Helm v2
+helm upgrade --install my-operator --namespace tekton tekton/operator
+# Helm v3
+helm upgrade --install my-operator --namespace tekton tekton/operator --set customResourceDefinitions.create=false
+```
+
+- Install (or upgrade) without CRDs (assuming CRDs have already been deployed by an admin)
+
+```bash
+# This will install Tekton Operator in the tekton namespace (with a my-operator release name)
+
+# Helm v2
+helm upgrade --install my-operator --namespace tekton tekton/operator --set customResourceDefinitions.create=false
+# Helm v3
+helm upgrade --install my-operator --namespace tekton tekton/operator --set customResourceDefinitions.create=false --skip-crds
+```
+
+- Install (or upgrade) without creating RBAC resources (assuming RBAC resources have been created by an admin)
+
+```bash
+# This will install Tekton Operator in the tekton namespace (with a my-operator release name)
+
+# Helm v2
+helm upgrade --install my-operator --namespace tekton tekton/operator --set rbac.create=false --set rbac.serviceAccountName=svcAccountName
+# Helm v3
+helm upgrade --install my-operator --namespace tekton tekton/operator --set customResourceDefinitions.create=false --set rbac.create=false --set rbac.serviceAccountName=svcAccountName
+```
+
+Look [below](#chart-values) for the list of all available options and their corresponding description.
+
+## Uninstalling
+
+To uninstall the chart, simply delete the release.
+
+```bash
+# This will uninstall Tekton Operator in the tekton namespace (assuming a my-operator release name)
+
+# Helm v2
+helm delete --purge my-operator
+# Helm v3
+helm uninstall my-operator --namespace tekton
+```
+
+## Version
+
+{{ template "chart.versionLine" . }}
+
+{{ template "chart.valuesSection" . }}
+
+You can look directly at the [values.yaml](./values.yaml) file to look at the options and their default values.
+
+## Try it out
+
+TODO
+
+---
+
+Except as otherwise noted, the content of this page is licensed under the
+[Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
+and code samples are licensed under the
+[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/helm/operator/crds/addon.yaml
+++ b/helm/operator/crds/addon.yaml
@@ -1,0 +1,90 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: addons.operator.tekton.dev
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: Addon
+    listKind: AddonList
+    plural: addons
+    singular: addon
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: >-
+            APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
+          type: string
+        kind:
+          description: >-
+            Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            version:
+              description: >-
+                INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
+              type: string
+          required:
+            - version
+          type: object
+        status:
+          properties:
+            conditions:
+              description: installation status sorted in reverse chronological order
+              items:
+                properties:
+                  code:
+                    description: >-
+                      Code indicates the status of installation of addon
+                      resources Valid values are:
+                        - error
+                        - installing
+                        - installed
+                    type: string
+                  details:
+                    description: Additional details about the Code
+                    type: string
+                  version:
+                    description: The version of installed addon
+                    type: string
+                required:
+                  - code
+                  - version
+                type: object
+              type: array
+          type: object
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true

--- a/helm/operator/crds/config.yaml
+++ b/helm/operator/crds/config.yaml
@@ -1,0 +1,75 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: config.operator.tekton.dev
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: Config
+    listKind: ConfigList
+    plural: config
+    singular: config
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            targetNamespace:
+              description: namespace where tekton pipelines will be installed
+              type: string
+          required:
+            - targetNamespace
+          type: object
+        status:
+          properties:
+            conditions:
+              description: installation status sorted in reverse chronological order
+              items:
+                properties:
+                  code:
+                    description: Code indicates the status of installation of pipeline resources.
+                    type: string
+                  details:
+                    description: Additional details about the Code
+                    type: string
+                  version:
+                    description: The version of tekton pipelines
+                    type: string
+                required:
+                  - code
+                  - version
+                type: object
+              type: array
+          type: object
+  additionalPrinterColumns:
+    - JSONPath: .status.conditions[0].code
+      name: status
+      type: string
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true

--- a/helm/operator/templates/NOTES.txt
+++ b/helm/operator/templates/NOTES.txt
@@ -1,0 +1,4 @@
+Tekton operator has been installed successfully.
+To verify that the controller has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ template "operator.name" . }},app.kubernetes.io/component=controller,app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/operator/templates/_helpers.tpl
+++ b/helm/operator/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "operator.serviceAccountName" -}}
+{{- if .Values.rbac.create -}}
+{{- template "operator.fullname" . -}}
+{{- else -}}
+{{- required "A service account name is required" .Values.rbac.serviceAccountName -}}
+{{- end -}}
+{{- end -}}

--- a/helm/operator/templates/clusterrole.yaml
+++ b/helm/operator/templates/clusterrole.yaml
@@ -1,0 +1,200 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.rbac.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "operator.fullname" . }}
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+      - pods/log
+      - limitranges
+    verbs:
+      - '*'
+  - apiGroups:
+      - extensions
+      - apps
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch  
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+      - deployments/finalizers
+    verbs:
+      - '*'
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - build.knative.dev
+    resources:
+      - builds
+      - buildtemplates
+      - clusterbuildtemplates
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - deployments/finalizers
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+      - use
+  - apiGroups:
+      - operator.tekton.dev
+    resources:
+      - '*'
+      - addons
+    verbs:
+      - '*'
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - dashboard.tekton.dev
+    resources:
+      - '*'
+      - addons
+    verbs:
+      - '*'
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+{{- end }}

--- a/helm/operator/templates/clusterrolebinding.yaml
+++ b/helm/operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "operator.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "operator.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/operator/templates/controller_deployment.yaml
+++ b/helm/operator/templates/controller_deployment.yaml
@@ -1,0 +1,84 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "operator.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "operator.name" . }}
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "operator.chart" . }}
+    operator.tekton.dev/release: {{ .Values.version | quote }}
+    version: {{ .Values.version | quote }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "operator.name" . }}
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      {{- with .Values.controller.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ template "operator.name" . }}
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        helm.sh/chart: {{ template "operator.chart" . }}
+        operator.tekton.dev/release: {{ .Values.version | quote }}
+        version: {{ .Values.version | quote }}
+    spec:
+      serviceAccountName: {{ template "operator.serviceAccountName" . }}
+      {{- with .Values.controller.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: operator
+          image: {{ printf "%s:%s" .Values.controller.image.repository .Values.controller.image.tag | quote }}
+          imagePullPolicy: {{ .Values.controller.image.pullPolicy | quote }}
+          command:
+            - tekton-operator
+          env:
+            - name: WATCH_NAMESPACE
+              value: ''
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: {{ template "operator.name" . }}
+          {{- with .Values.controller.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/helm/operator/templates/serviceaccount.yaml
+++ b/helm/operator/templates/serviceaccount.yaml
@@ -1,0 +1,20 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "operator.serviceAccountName" . }}
+{{- end }}

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -1,0 +1,67 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# version -- Tekton triggers version used to add labels on deployments, pods and services
+version: v0.0.0
+
+# nameOverride -- Partially override resource generated names
+nameOverride: ""
+
+# fullnameOverride -- Fully override resource generated names
+fullnameOverride: ""
+
+rbac:
+  # rbac.create -- Create RBAC resources
+  create: true
+
+  # rbac.serviceAccountName -- Name of the service account to use when rbac.create is false
+  serviceAccountName:
+
+customResourceDefinitions:
+  # customResourceDefinitions.create -- Create CRDs
+  create: true
+
+controller:
+  image:
+    # controller.image.repository -- Operator docker image repository
+    repository: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/manager
+
+    # controller.image.tag -- Operator docker image tag
+    tag: v0.6.0
+
+    # controller.image.pullPolicy -- Operator docker image pull policy
+    pullPolicy: IfNotPresent
+
+  # controller.readOnly -- Drives running the Operator in read only mode
+  readOnly: false
+
+  # controller.annotations -- Operator pod annotations
+  # @default -- See [values.yaml](./values.yaml)
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+
+  # controller.nodeSelector -- Operator node selector
+  nodeSelector: {}
+
+  # controller.affinity -- Operator affinity rules
+  affinity: {}
+
+  # controller.tolerations -- Operator tolerations
+  tolerations: []
+
+  # controller.resources -- Operator resource limits and requests
+  resources: {}
+
+  # controller.securityContext -- Operator pods security context
+  securityContext: {}


### PR DESCRIPTION
This pull request adds a helm chart for Tekton Operator.

It is a follow up from the previous PRs #494, #505 and #513.
Helm chart support was proposed here: tektoncd/plumbing#278

This is work in progress, remaining TODOs:
- [ ] doc
- [ ] tests

NOTES:
- this is the tekton component i know very little about
- at first sight there is no available image, needs to be created manually (see https://github.com/tektoncd/operator/blob/2f1260abd08bffa39cc6e774cf7528c1c3ae0a37/deploy/operator.yaml#L19)