### PR TITLE
[helm/dashboard] Add support for namespace bound or cluster wide RBAC

### DIFF
--- a/helm/dashboard/Chart.yaml
+++ b/helm/dashboard/Chart.yaml
@@ -15,7 +15,7 @@
 name: dashboard
 icon: https://tekton.dev/images/tekton-horizontal-color.png
 apiVersion: v1
-version: 0.6.3
+version: 0.6.4
 appVersion: 0.6.1
 home: https://github.com/tektoncd/dashboard
 keywords:

--- a/helm/dashboard/README.md
+++ b/helm/dashboard/README.md
@@ -83,7 +83,7 @@ helm uninstall my-dashboard --namespace tekton
 
 ## Version
 
-Current chart version is `0.6.3`
+Current chart version is `0.6.4`
 
 ## Chart Values
 
@@ -112,6 +112,7 @@ Current chart version is `0.6.3`
 | `fullnameOverride` | string | Fully override resource generated names | `""` |
 | `nameOverride` | string | Partially override resource generated names | `""` |
 | `rbac.create` | bool | Create RBAC resources | `true` |
+| `rbac.namespaces` | string | List of namespaces to be accessible from the dashboard backend (leave empty to allow cluster-wide access) | `nil` |
 | `rbac.serviceAccountName` | string | Name of the service account to use when rbac.create is false | `nil` |
 | `version` | string | Tekton dashboard version used to add labels on deployments, pods and services | `"v0.6.1"` |
 

--- a/helm/dashboard/templates/rolebinding.yaml
+++ b/helm/dashboard/templates/rolebinding.yaml
@@ -13,21 +13,25 @@
 # limitations under the License.
 
 {{- if .Values.rbac.create }}
-{{- if not .Values.rbac.namespaces }}
+{{- if .Values.rbac.namespaces }}
+{{- range .Values.rbac.namespaces }}
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: {{ template "dashboard.fullname" . }}
+  name: {{ template "dashboard.fullname" $ }}
+  namespace: {{ . }}
   labels:
-    {{- include "dashboard.baseLabels" . | nindent 4 }}
-    {{- include "dashboard.helmLabels" . | nindent 4 }}
+    {{- include "dashboard.baseLabels" $ | nindent 4 }}
+    {{- include "dashboard.helmLabels" $ | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "dashboard.fullname" . }}
+  name: {{ template "dashboard.fullname" $ }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "dashboard.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    name: {{ template "dashboard.serviceAccountName" $ }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/dashboard/values.yaml
+++ b/helm/dashboard/values.yaml
@@ -28,6 +28,9 @@ rbac:
   # rbac.serviceAccountName -- Name of the service account to use when rbac.create is false
   serviceAccountName:
 
+  # rbac.namespaces -- List of namespaces to be accessible from the dashboard backend (leave empty to allow cluster-wide access)
+  namespaces:
+
 customResourceDefinitions:
   # customResourceDefinitions.create -- Create CRDs
   create: true


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This pull request adds support for namespaces bound or cluster wide RBAC.

The user can choose to limit the namespaces that can be accessed by the dashboard by the dashboard backend.

If no namespaces are set, the deployment is considered cluster wide and the entire cluster is accessible.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
