### PR TITLE
[Webhooks] Always use Dashboard service

### DIFF
--- a/webhooks-extension/pkg/endpoints/webhook.go
+++ b/webhooks-extension/pkg/endpoints/webhook.go
@@ -450,12 +450,8 @@ func (r Resource) getDashboardURL(installNs string) string {
 
 	toReturn := "http://localhost:9097/"
 
-	// TODO: app.kubernetes.io/part-of should be configurable (in case of multiple deployments)
+	// TODO: app.kubernetes.io/instance should be configurable (in case of multiple deployments)
 	labelLookup := "app.kubernetes.io/part-of=tekton-dashboard,app.kubernetes.io/component=dashboard,app.kubernetes.io/name=dashboard"
-	if "openshift" == os.Getenv("PLATFORM") {
-		// TODO: selector for openshift ?
-		labelLookup = "app=tekton-dashboard-internal"
-	}
 
 	services, err := r.K8sClient.CoreV1().Services(installNs).List(metav1.ListOptions{LabelSelector: labelLookup})
 	if err != nil {

--- a/webhooks-extension/pkg/endpoints/webhook_test.go
+++ b/webhooks-extension/pkg/endpoints/webhook_test.go
@@ -93,7 +93,10 @@ func TestGetServiceDashboardURL(t *testing.T) {
 func TestGetOpenshiftServiceDashboardURL(t *testing.T) {
 	r := dummyResource()
 	labels := map[string]string{
-		"app": "tekton-dashboard-internal",
+		"app.kubernetes.io/name":      "dashboard",
+		"app.kubernetes.io/component": "dashboard",
+		"app.kubernetes.io/instance":  "default",
+		"app.kubernetes.io/part-of":   "tekton-dashboard",
 	}
 	svc := createDashboardService("fake-openshift-dashboard", labels)
 	_, err := r.K8sClient.CoreV1().Services(installNs).Create(svc)
@@ -104,7 +107,7 @@ func TestGetOpenshiftServiceDashboardURL(t *testing.T) {
 	dashboard := r.getDashboardURL(installNs)
 
 	if dashboard != "http://fake-openshift-dashboard:1234/v1/namespaces/default/endpoints" {
-		t.Errorf("Dashboard URL not http://fake-dashboard:1234/v1/namespaces/default/endpoints.  URL was %s", dashboard)
+		t.Errorf("Dashboard URL not http://fake-openshift-dashboard:1234/v1/namespaces/default/endpoints.  URL was %s", dashboard)
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR is related to the changes in the dashboard here https://github.com/tektoncd/dashboard/pull/1443.
The dashboard service should be available on both k8s and openshift, the secure service is replaced by `tekton-dashboard-proxy` and the openshift `Route` points to the proxy.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
