### PR TITLE
Fix wrong namespace for monitor TaskRun on OpenShift

### DIFF
--- a/webhooks-extension/base/400-monitor-triggertemplate.yaml
+++ b/webhooks-extension/base/400-monitor-triggertemplate.yaml
@@ -47,7 +47,6 @@ spec:
     kind: PipelineResource
     metadata:
       name: pull-request-$(uid)
-      namespace: tekton-pipelines
     spec:
       type: pullRequest
       params:
@@ -63,7 +62,6 @@ spec:
     kind: TaskRun
     metadata:
       generateName: monitor-taskrun-
-      namespace: tekton-pipelines
     spec:
       serviceAccountName: tekton-webhooks-extension
       taskRef:


### PR DESCRIPTION
Closes https://github.com/tektoncd/experimental/issues/552

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

By omitting the namespace for templated resources, they sit in the template's namespace - which is openshift-pipelines on OpenShift, overridden correctly

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
