### PR TITLE
Add CLI and Write support to Tekton Generators

### DIFF
--- a/generators/cmd/cli/cmd/root.go
+++ b/generators/cmd/cli/cmd/root.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "tkn-gen",
+	Short: "This is the CLI for tekton generators",
+	Long: `tkn-gen will allow you to generate Tekton spec from the given simple spec. 
+			It also contains support for managing generated configuration.`,
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/generators/cmd/cli/cmd/show.go
+++ b/generators/cmd/cli/cmd/show.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"generators/pkg/writer"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var filename string
+var showCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show generated configuration.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(filename) == 0 {
+			cmd.Help()
+			return nil
+		}
+
+		if err := writer.WriteToDisk(filename, os.Stdout); err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func init() {
+	showCmd.Flags().StringVarP(&filename, "filename", "f", "", "spec file")
+	rootCmd.AddCommand(showCmd)
+}

--- a/generators/cmd/cli/cmd/write.go
+++ b/generators/cmd/cli/cmd/write.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"errors"
+	"generators/pkg/writer"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var specFilename string
+var outputFilename string
+var writeCmd = &cobra.Command{
+	Use:   "write",
+	Short: "Write generated configuration to disk.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(specFilename) == 0 {
+			return errors.New("No input file specified")
+		}
+
+		file, err := os.Create(outputFilename)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		return writer.WriteToDisk(specFilename, file)
+	},
+}
+
+func init() {
+	writeCmd.Flags().StringVarP(&specFilename, "filename", "f", "", "input spec file")
+	writeCmd.Flags().StringVarP(&outputFilename, "output", "o", "gen-task.yaml", "generated config file")
+	rootCmd.AddCommand(writeCmd)
+}

--- a/generators/cmd/main.go
+++ b/generators/cmd/main.go
@@ -1,19 +1,7 @@
 package main
 
-import (
-	"fmt"
-	"log"
-	"os"
-
-	"generators/pkg/parser"
-)
+import "generators/cmd/cli/cmd"
 
 func main() {
-	fmt.Println("Yaml Parser Demo:")
-	products, err := parser.Parse(os.Stdin)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Println(products)
+	cmd.Execute()
 }

--- a/generators/go.mod
+++ b/generators/go.mod
@@ -4,9 +4,11 @@ go 1.14
 
 require (
 	github.com/google/go-cmp v0.4.1
+	github.com/spf13/cobra v0.0.6
 	github.com/tektoncd/pipeline v0.13.2
 	k8s.io/api v0.17.6
 	k8s.io/apimachinery v0.17.6
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (

--- a/generators/go.sum
+++ b/generators/go.sum
@@ -817,6 +817,7 @@ github.com/spf13/cobra v0.0.0-20180319062004-c439c4fa0937/go.mod h1:1l0Ry5zgKvJa
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v0.0.6 h1:breEStsVwemnKh2/s6gMvSdMEkwW0sK8vGStnlVBMCs=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=

--- a/generators/pkg/generator/generate.go
+++ b/generators/pkg/generator/generate.go
@@ -14,7 +14,7 @@ type GitHubSpec struct {
 
 // GenerateTask generates Tekton Task spec
 // from simplified GithubSpec configs.
-func GenerateTask(spec GitHubSpec) (v1beta1.Task, error) {
+func GenerateTask(spec GitHubSpec) v1beta1.Task {
 	var task v1beta1.Task
 	task.Spec.Steps = spec.Steps
 	task.Spec.Workspaces = append(task.Spec.Workspaces,
@@ -23,5 +23,5 @@ func GenerateTask(spec GitHubSpec) (v1beta1.Task, error) {
 			MountPath: "/input",
 		},
 	)
-	return task, nil
+	return task
 }

--- a/generators/pkg/generator/generate_test.go
+++ b/generators/pkg/generator/generate_test.go
@@ -31,12 +31,8 @@ func TestGenerateTask(t *testing.T) {
 				"--destination=gcr.io/wlynch-test/kaniko-test",
 				"--verbosity=debug"},
 		}}}}
-	got, err := GenerateTask(spec)
-	if err != nil {
-		t.Fatalf("error from 'GenerateTask': %v", err)
-	}
-
-	if diff := cmp.Diff(got, want); diff != "" {
+	got := GenerateTask(spec)
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Tasks mismatch (-want +got):\n %s", diff)
 	}
 }

--- a/generators/pkg/parser/parser.go
+++ b/generators/pkg/parser/parser.go
@@ -3,24 +3,26 @@
 package parser
 
 import (
+	"fmt"
+	"generators/pkg/generator"
 	"io"
+	"io/ioutil"
 
-	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
 )
 
-type products struct {
-	Items []int    `json:"items,omitempty"`
-	Names []string `json:"names,omitempty"`
-}
-
 // Parse parses a yaml file from io.Reader and stores the
-// result in the products struct
-func Parse(r io.Reader) (products, error) {
-	reader := yaml.NewYAMLToJSONDecoder(r)
-	res := products{}
-	err := reader.Decode(&res)
+// result in the GitHubSpec struct
+func Parse(r io.Reader) (generator.GitHubSpec, error) {
+	spec, err := ioutil.ReadAll(r)
+
 	if err != nil {
-		return res, err
+		return generator.GitHubSpec{}, fmt.Errorf("fail to read from the input: %w", err)
 	}
+	res := generator.GitHubSpec{}
+	if err := yaml.Unmarshal(spec, &res); err != nil {
+		return res, fmt.Errorf("fail to unmarshal from the input: %w", err)
+	}
+
 	return res, nil
 }

--- a/generators/pkg/parser/testdata/spec-full.yaml
+++ b/generators/pkg/parser/testdata/spec-full.yaml
@@ -1,0 +1,14 @@
+kind: GitHub
+metadata:
+  name: github-build
+spec:
+  url: "https://github.com/wlynch/test"
+  steps:
+    - name: build
+      image: gcr.io/kaniko-project/executor:latest
+      command:
+        - /kaniko/executor
+      args:
+        - --context=dir://$(workspaces.input.path)/src
+        - --destination=gcr.io/wlynch-test/kaniko-test
+        - --verbosity=debug

--- a/generators/pkg/parser/testdata/spec.yaml
+++ b/generators/pkg/parser/testdata/spec.yaml
@@ -1,0 +1,11 @@
+url: "https://github.com/wlynch/test"
+steps:
+  - name: build
+    image: gcr.io/kaniko-project/executor:latest
+    command:
+      - /kaniko/executor
+    args:
+      - --context=dir://$(workspaces.input.path)/src
+      - --destination=gcr.io/wlynch-test/kaniko-test
+      - --verbosity=debug
+  

--- a/generators/pkg/writer/testdata/spec.yaml
+++ b/generators/pkg/writer/testdata/spec.yaml
@@ -1,0 +1,10 @@
+url: "https://github.com/wlynch/test"
+steps:
+  - name: build
+    image: gcr.io/kaniko-project/executor:latest
+    command:
+      - /kaniko/executor
+    args:
+      - --context=dir://$(workspaces.input.path)/src
+      - --destination=gcr.io/wlynch-test/kaniko-test
+      - --verbosity=debug

--- a/generators/pkg/writer/testdata/task.yaml
+++ b/generators/pkg/writer/testdata/task.yaml
@@ -1,0 +1,16 @@
+metadata:
+  creationTimestamp: null
+spec:
+  steps:
+  - args:
+    - --context=dir://$(workspaces.input.path)/src
+    - --destination=gcr.io/wlynch-test/kaniko-test
+    - --verbosity=debug
+    command:
+    - /kaniko/executor
+    image: gcr.io/kaniko-project/executor:latest
+    name: build
+    resources: {}
+  workspaces:
+  - mountPath: /input
+    name: input

--- a/generators/pkg/writer/write.go
+++ b/generators/pkg/writer/write.go
@@ -1,0 +1,38 @@
+// Package writer provides a method to write the generated task
+// to the yaml document.
+package writer
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"generators/pkg/generator"
+	"generators/pkg/parser"
+
+	"sigs.k8s.io/yaml"
+)
+
+// WriteToDisk writes the generated task
+// to the io.Writer
+func WriteToDisk(filename string, writer io.Writer) error {
+	file, err := os.Open(filename)
+	if err != nil {
+		return fmt.Errorf("unable to open the file from %s. check if the file exists: %w", filename, err)
+	}
+	defer file.Close()
+
+	spec, err := parser.Parse(file)
+	if err != nil {
+		return fmt.Errorf("unable to parse the file from %s: %w", filename, err)
+	}
+
+	task := generator.GenerateTask(spec)
+	data, err := yaml.Marshal(&task)
+	if err != nil {
+		return fmt.Errorf("unable to marshal the file from %s: %w", filename, err)
+	}
+
+	_, err = writer.Write(data)
+	return err
+}

--- a/generators/pkg/writer/write_test.go
+++ b/generators/pkg/writer/write_test.go
@@ -1,0 +1,26 @@
+package writer
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestWriteToDisk(t *testing.T) {
+	buf := new(bytes.Buffer)
+	if err := WriteToDisk("./testdata/spec.yaml", buf); err != nil {
+		t.Fatalf("error from 'WriteToDisk': %v", err)
+	}
+	got := buf.Bytes()
+
+	path := "./testdata/task.yaml"
+	want, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatalf("fail to read file %s: %v", path, err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("WriteToDisk mismatch (-want +got):\n %s", diff)
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
I am working on [Tekton Generators](https://github.com/tektoncd/pipeline/issues/2590).

This project aims at generating Tekton spec from simplified configs, which will help users bootstrap pipelines in a configurable way. 

I want to make some changes to this project:

1. To help users interact with generators, add the CLI command `show` to it.
2. Add support for writing output to disk. 


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
