### PR TITLE
Implement adding results_id to schema v1

### DIFF
--- a/results/cmd/watcher/main.go
+++ b/results/cmd/watcher/main.go
@@ -107,7 +107,7 @@ func (r *reconciler) Reconcile(ctx context.Context, key string) error {
 		r.logger.Errorf("Error converting to proto: %v", err)
 		return err
 	}
-	if _, err := r.client.UpdateTaskRun(ctx, &pb.UpdateTaskRunRequest{
+	if _, err := r.client.UpdateTaskRunResult(ctx, &pb.UpdateTaskRunRequest{
 		TaskRun: p,
 	}); err != nil {
 		r.logger.Error("Error updating TaskRun %s: %v", name, err)

--- a/results/go.mod
+++ b/results/go.mod
@@ -8,14 +8,13 @@ require (
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/tektoncd/pipeline v0.12.0
 	go.uber.org/zap v1.13.0
-	golang.org/x/crypto v0.0.0-20200206161412-a0c6ece9d31a // indirect
-	google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03
 	google.golang.org/grpc v1.27.0
 	google.golang.org/protobuf v1.21.0
 	k8s.io/api v0.17.3
 	k8s.io/apimachinery v0.17.3
 	k8s.io/client-go v0.17.3
 	knative.dev/pkg v0.0.0-20200306230727-a56a6ea3fa56
+	github.com/google/uuid v1.1.1
 )
 
 // Knative deps (release-0.13)

--- a/results/proto/api.proto
+++ b/results/proto/api.proto
@@ -8,11 +8,16 @@ import "google/protobuf/empty.proto";
 option go_package = "./proto";
 
 service Results {
-  rpc CreateTaskRun (CreateTaskRunRequest) returns (TaskRun) {}
-  rpc UpdateTaskRun (UpdateTaskRunRequest) returns (TaskRun) {}
-  rpc GetTaskRun    (GetTaskRunRequest)    returns (TaskRun) {}
-  rpc DeleteTaskRun (DeleteTaskRunRequest) returns (google.protobuf.Empty) {}  
+  rpc CreateTaskRunResult (CreateTaskRunRequest) returns (TaskRunResult) {}
+  rpc UpdateTaskRunResult (UpdateTaskRunRequest) returns (TaskRunResult) {}
+  rpc GetTaskRunResultResult    (GetTaskRunRequest)    returns (TaskRunResult) {}
+  rpc DeleteTaskRunResult (DeleteTaskRunRequest) returns (google.protobuf.Empty) {}  
   rpc ListTaskRuns  (ListTaskRunsRequest)  returns (ListTaskRunsResponse) {}
+}
+
+message TaskRunResult {
+	TaskRun task_run = 1;
+	string results_id = 2;
 }
 
 message CreateTaskRunRequest {
@@ -21,16 +26,16 @@ message CreateTaskRunRequest {
 }
 
 message DeleteTaskRunRequest {
-	string uid = 1;
+	string results_id = 1;
 }
 
 message UpdateTaskRunRequest {
 	TaskRun task_run = 1;
+	string results_id = 2;
 }
 
 message GetTaskRunRequest {
-	string uid = 1;
-
+	string results_id = 1;
 }
 
 message ListTaskRunsRequest {

--- a/results/proto/proto/api.pb.go
+++ b/results/proto/proto/api.pb.go
@@ -30,6 +30,61 @@ const (
 // of the legacy proto package is being used.
 const _ = proto.ProtoPackageIsVersion4
 
+type TaskRunResult struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TaskRun   *TaskRun `protobuf:"bytes,1,opt,name=task_run,json=taskRun,proto3" json:"task_run,omitempty"`
+	ResultsId string   `protobuf:"bytes,2,opt,name=results_id,json=resultsId,proto3" json:"results_id,omitempty"`
+}
+
+func (x *TaskRunResult) Reset() {
+	*x = TaskRunResult{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_api_proto_msgTypes[0]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TaskRunResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TaskRunResult) ProtoMessage() {}
+
+func (x *TaskRunResult) ProtoReflect() protoreflect.Message {
+	mi := &file_api_proto_msgTypes[0]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TaskRunResult.ProtoReflect.Descriptor instead.
+func (*TaskRunResult) Descriptor() ([]byte, []int) {
+	return file_api_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *TaskRunResult) GetTaskRun() *TaskRun {
+	if x != nil {
+		return x.TaskRun
+	}
+	return nil
+}
+
+func (x *TaskRunResult) GetResultsId() string {
+	if x != nil {
+		return x.ResultsId
+	}
+	return ""
+}
+
 type CreateTaskRunRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -41,7 +96,7 @@ type CreateTaskRunRequest struct {
 func (x *CreateTaskRunRequest) Reset() {
 	*x = CreateTaskRunRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_api_proto_msgTypes[0]
+		mi := &file_api_proto_msgTypes[1]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -54,7 +109,7 @@ func (x *CreateTaskRunRequest) String() string {
 func (*CreateTaskRunRequest) ProtoMessage() {}
 
 func (x *CreateTaskRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_msgTypes[0]
+	mi := &file_api_proto_msgTypes[1]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67,7 +122,7 @@ func (x *CreateTaskRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTaskRunRequest.ProtoReflect.Descriptor instead.
 func (*CreateTaskRunRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_rawDescGZIP(), []int{0}
+	return file_api_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *CreateTaskRunRequest) GetTaskRun() *TaskRun {
@@ -82,13 +137,13 @@ type DeleteTaskRunRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Uid string `protobuf:"bytes,1,opt,name=uid,proto3" json:"uid,omitempty"`
+	ResultsId string `protobuf:"bytes,1,opt,name=results_id,json=resultsId,proto3" json:"results_id,omitempty"`
 }
 
 func (x *DeleteTaskRunRequest) Reset() {
 	*x = DeleteTaskRunRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_api_proto_msgTypes[1]
+		mi := &file_api_proto_msgTypes[2]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -101,7 +156,7 @@ func (x *DeleteTaskRunRequest) String() string {
 func (*DeleteTaskRunRequest) ProtoMessage() {}
 
 func (x *DeleteTaskRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_msgTypes[1]
+	mi := &file_api_proto_msgTypes[2]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -114,12 +169,12 @@ func (x *DeleteTaskRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTaskRunRequest.ProtoReflect.Descriptor instead.
 func (*DeleteTaskRunRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_rawDescGZIP(), []int{1}
+	return file_api_proto_rawDescGZIP(), []int{2}
 }
 
-func (x *DeleteTaskRunRequest) GetUid() string {
+func (x *DeleteTaskRunRequest) GetResultsId() string {
 	if x != nil {
-		return x.Uid
+		return x.ResultsId
 	}
 	return ""
 }
@@ -129,13 +184,14 @@ type UpdateTaskRunRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	TaskRun *TaskRun `protobuf:"bytes,1,opt,name=task_run,json=taskRun,proto3" json:"task_run,omitempty"`
+	TaskRun   *TaskRun `protobuf:"bytes,1,opt,name=task_run,json=taskRun,proto3" json:"task_run,omitempty"`
+	ResultsId string   `protobuf:"bytes,2,opt,name=results_id,json=resultsId,proto3" json:"results_id,omitempty"`
 }
 
 func (x *UpdateTaskRunRequest) Reset() {
 	*x = UpdateTaskRunRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_api_proto_msgTypes[2]
+		mi := &file_api_proto_msgTypes[3]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -148,7 +204,7 @@ func (x *UpdateTaskRunRequest) String() string {
 func (*UpdateTaskRunRequest) ProtoMessage() {}
 
 func (x *UpdateTaskRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_msgTypes[2]
+	mi := &file_api_proto_msgTypes[3]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -161,7 +217,7 @@ func (x *UpdateTaskRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateTaskRunRequest.ProtoReflect.Descriptor instead.
 func (*UpdateTaskRunRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_rawDescGZIP(), []int{2}
+	return file_api_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *UpdateTaskRunRequest) GetTaskRun() *TaskRun {
@@ -171,18 +227,25 @@ func (x *UpdateTaskRunRequest) GetTaskRun() *TaskRun {
 	return nil
 }
 
+func (x *UpdateTaskRunRequest) GetResultsId() string {
+	if x != nil {
+		return x.ResultsId
+	}
+	return ""
+}
+
 type GetTaskRunRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Uid string `protobuf:"bytes,1,opt,name=uid,proto3" json:"uid,omitempty"`
+	ResultsId string `protobuf:"bytes,1,opt,name=results_id,json=resultsId,proto3" json:"results_id,omitempty"`
 }
 
 func (x *GetTaskRunRequest) Reset() {
 	*x = GetTaskRunRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_api_proto_msgTypes[3]
+		mi := &file_api_proto_msgTypes[4]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -195,7 +258,7 @@ func (x *GetTaskRunRequest) String() string {
 func (*GetTaskRunRequest) ProtoMessage() {}
 
 func (x *GetTaskRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_msgTypes[3]
+	mi := &file_api_proto_msgTypes[4]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -208,12 +271,12 @@ func (x *GetTaskRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTaskRunRequest.ProtoReflect.Descriptor instead.
 func (*GetTaskRunRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_rawDescGZIP(), []int{3}
+	return file_api_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *GetTaskRunRequest) GetUid() string {
+func (x *GetTaskRunRequest) GetResultsId() string {
 	if x != nil {
-		return x.Uid
+		return x.ResultsId
 	}
 	return ""
 }
@@ -230,7 +293,7 @@ type ListTaskRunsRequest struct {
 func (x *ListTaskRunsRequest) Reset() {
 	*x = ListTaskRunsRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_api_proto_msgTypes[4]
+		mi := &file_api_proto_msgTypes[5]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -243,7 +306,7 @@ func (x *ListTaskRunsRequest) String() string {
 func (*ListTaskRunsRequest) ProtoMessage() {}
 
 func (x *ListTaskRunsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_msgTypes[4]
+	mi := &file_api_proto_msgTypes[5]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -256,7 +319,7 @@ func (x *ListTaskRunsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTaskRunsRequest.ProtoReflect.Descriptor instead.
 func (*ListTaskRunsRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_rawDescGZIP(), []int{4}
+	return file_api_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ListTaskRunsRequest) GetQuery() string {
@@ -277,7 +340,7 @@ type ListTaskRunsResponse struct {
 func (x *ListTaskRunsResponse) Reset() {
 	*x = ListTaskRunsResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_api_proto_msgTypes[5]
+		mi := &file_api_proto_msgTypes[6]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -290,7 +353,7 @@ func (x *ListTaskRunsResponse) String() string {
 func (*ListTaskRunsResponse) ProtoMessage() {}
 
 func (x *ListTaskRunsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_msgTypes[5]
+	mi := &file_api_proto_msgTypes[6]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -303,7 +366,7 @@ func (x *ListTaskRunsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTaskRunsResponse.ProtoReflect.Descriptor instead.
 func (*ListTaskRunsResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_rawDescGZIP(), []int{5}
+	return file_api_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ListTaskRunsResponse) GetItems() []*TaskRun {
@@ -320,50 +383,62 @@ var file_api_proto_rawDesc = []byte{
 	0x74, 0x6f, 0x6e, 0x1a, 0x0d, 0x74, 0x61, 0x73, 0x6b, 0x72, 0x75, 0x6e, 0x2e, 0x70, 0x72, 0x6f,
 	0x74, 0x6f, 0x1a, 0x1b, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
 	0x62, 0x75, 0x66, 0x2f, 0x65, 0x6d, 0x70, 0x74, 0x79, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22,
-	0x42, 0x0a, 0x14, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e,
-	0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x2a, 0x0a, 0x08, 0x74, 0x61, 0x73, 0x6b, 0x5f,
-	0x72, 0x75, 0x6e, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x0f, 0x2e, 0x74, 0x65, 0x6b, 0x74,
-	0x6f, 0x6e, 0x2e, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x07, 0x74, 0x61, 0x73, 0x6b,
-	0x52, 0x75, 0x6e, 0x22, 0x28, 0x0a, 0x14, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x54, 0x61, 0x73,
-	0x6b, 0x52, 0x75, 0x6e, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x75,
-	0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x75, 0x69, 0x64, 0x22, 0x42, 0x0a,
-	0x14, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x65,
-	0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x2a, 0x0a, 0x08, 0x74, 0x61, 0x73, 0x6b, 0x5f, 0x72, 0x75,
-	0x6e, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x0f, 0x2e, 0x74, 0x65, 0x6b, 0x74, 0x6f, 0x6e,
-	0x2e, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x07, 0x74, 0x61, 0x73, 0x6b, 0x52, 0x75,
-	0x6e, 0x22, 0x25, 0x0a, 0x11, 0x47, 0x65, 0x74, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52,
-	0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x75, 0x69, 0x64, 0x18, 0x01, 0x20,
-	0x01, 0x28, 0x09, 0x52, 0x03, 0x75, 0x69, 0x64, 0x22, 0x2b, 0x0a, 0x13, 0x4c, 0x69, 0x73, 0x74,
-	0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12,
-	0x14, 0x0a, 0x05, 0x71, 0x75, 0x65, 0x72, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05,
-	0x71, 0x75, 0x65, 0x72, 0x79, 0x22, 0x3d, 0x0a, 0x14, 0x4c, 0x69, 0x73, 0x74, 0x54, 0x61, 0x73,
-	0x6b, 0x52, 0x75, 0x6e, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x25, 0x0a,
-	0x05, 0x69, 0x74, 0x65, 0x6d, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x0f, 0x2e, 0x74,
-	0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x05, 0x69,
-	0x74, 0x65, 0x6d, 0x73, 0x32, 0xdf, 0x02, 0x0a, 0x07, 0x52, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x73,
-	0x12, 0x40, 0x0a, 0x0d, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75,
-	0x6e, 0x12, 0x1c, 0x2e, 0x74, 0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e, 0x43, 0x72, 0x65, 0x61, 0x74,
-	0x65, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a,
-	0x0f, 0x2e, 0x74, 0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e,
-	0x22, 0x00, 0x12, 0x40, 0x0a, 0x0d, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x54, 0x61, 0x73, 0x6b,
-	0x52, 0x75, 0x6e, 0x12, 0x1c, 0x2e, 0x74, 0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e, 0x55, 0x70, 0x64,
-	0x61, 0x74, 0x65, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
-	0x74, 0x1a, 0x0f, 0x2e, 0x74, 0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e, 0x54, 0x61, 0x73, 0x6b, 0x52,
-	0x75, 0x6e, 0x22, 0x00, 0x12, 0x3a, 0x0a, 0x0a, 0x47, 0x65, 0x74, 0x54, 0x61, 0x73, 0x6b, 0x52,
-	0x75, 0x6e, 0x12, 0x19, 0x2e, 0x74, 0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e, 0x47, 0x65, 0x74, 0x54,
-	0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x0f, 0x2e,
-	0x74, 0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x22, 0x00,
-	0x12, 0x47, 0x0a, 0x0d, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75,
-	0x6e, 0x12, 0x1c, 0x2e, 0x74, 0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e, 0x44, 0x65, 0x6c, 0x65, 0x74,
-	0x65, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a,
-	0x16, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
-	0x66, 0x2e, 0x45, 0x6d, 0x70, 0x74, 0x79, 0x22, 0x00, 0x12, 0x4b, 0x0a, 0x0c, 0x4c, 0x69, 0x73,
-	0x74, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x73, 0x12, 0x1b, 0x2e, 0x74, 0x65, 0x6b, 0x74,
-	0x6f, 0x6e, 0x2e, 0x4c, 0x69, 0x73, 0x74, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x73, 0x52,
-	0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x1c, 0x2e, 0x74, 0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e,
-	0x4c, 0x69, 0x73, 0x74, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x73, 0x52, 0x65, 0x73, 0x70,
-	0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x42, 0x09, 0x5a, 0x07, 0x2e, 0x2f, 0x70, 0x72, 0x6f, 0x74,
-	0x6f, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x5a, 0x0a, 0x0d, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x65, 0x73, 0x75, 0x6c, 0x74,
+	0x12, 0x2a, 0x0a, 0x08, 0x74, 0x61, 0x73, 0x6b, 0x5f, 0x72, 0x75, 0x6e, 0x18, 0x01, 0x20, 0x01,
+	0x28, 0x0b, 0x32, 0x0f, 0x2e, 0x74, 0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e, 0x54, 0x61, 0x73, 0x6b,
+	0x52, 0x75, 0x6e, 0x52, 0x07, 0x74, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x12, 0x1d, 0x0a, 0x0a,
+	0x72, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x73, 0x5f, 0x69, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x09, 0x72, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x73, 0x49, 0x64, 0x22, 0x42, 0x0a, 0x14, 0x43,
+	0x72, 0x65, 0x61, 0x74, 0x65, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x65, 0x71, 0x75,
+	0x65, 0x73, 0x74, 0x12, 0x2a, 0x0a, 0x08, 0x74, 0x61, 0x73, 0x6b, 0x5f, 0x72, 0x75, 0x6e, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x0f, 0x2e, 0x74, 0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e, 0x54,
+	0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x07, 0x74, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x22,
+	0x35, 0x0a, 0x14, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e,
+	0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x1d, 0x0a, 0x0a, 0x72, 0x65, 0x73, 0x75, 0x6c,
+	0x74, 0x73, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x72, 0x65, 0x73,
+	0x75, 0x6c, 0x74, 0x73, 0x49, 0x64, 0x22, 0x61, 0x0a, 0x14, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65,
+	0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x2a,
+	0x0a, 0x08, 0x74, 0x61, 0x73, 0x6b, 0x5f, 0x72, 0x75, 0x6e, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x0f, 0x2e, 0x74, 0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75,
+	0x6e, 0x52, 0x07, 0x74, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x12, 0x1d, 0x0a, 0x0a, 0x72, 0x65,
+	0x73, 0x75, 0x6c, 0x74, 0x73, 0x5f, 0x69, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09,
+	0x72, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x73, 0x49, 0x64, 0x22, 0x32, 0x0a, 0x11, 0x47, 0x65, 0x74,
+	0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x1d,
+	0x0a, 0x0a, 0x72, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x73, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01,
+	0x28, 0x09, 0x52, 0x09, 0x72, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x73, 0x49, 0x64, 0x22, 0x2b, 0x0a,
+	0x13, 0x4c, 0x69, 0x73, 0x74, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x73, 0x52, 0x65, 0x71,
+	0x75, 0x65, 0x73, 0x74, 0x12, 0x14, 0x0a, 0x05, 0x71, 0x75, 0x65, 0x72, 0x79, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x09, 0x52, 0x05, 0x71, 0x75, 0x65, 0x72, 0x79, 0x22, 0x3d, 0x0a, 0x14, 0x4c, 0x69,
+	0x73, 0x74, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e,
+	0x73, 0x65, 0x12, 0x25, 0x0a, 0x05, 0x69, 0x74, 0x65, 0x6d, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28,
+	0x0b, 0x32, 0x0f, 0x2e, 0x74, 0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e, 0x54, 0x61, 0x73, 0x6b, 0x52,
+	0x75, 0x6e, 0x52, 0x05, 0x69, 0x74, 0x65, 0x6d, 0x73, 0x32, 0x8f, 0x03, 0x0a, 0x07, 0x52, 0x65,
+	0x73, 0x75, 0x6c, 0x74, 0x73, 0x12, 0x4c, 0x0a, 0x13, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x54,
+	0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x12, 0x1c, 0x2e, 0x74,
+	0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x54, 0x61, 0x73, 0x6b,
+	0x52, 0x75, 0x6e, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x15, 0x2e, 0x74, 0x65, 0x6b,
+	0x74, 0x6f, 0x6e, 0x2e, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x65, 0x73, 0x75, 0x6c,
+	0x74, 0x22, 0x00, 0x12, 0x4c, 0x0a, 0x13, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x54, 0x61, 0x73,
+	0x6b, 0x52, 0x75, 0x6e, 0x52, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x12, 0x1c, 0x2e, 0x74, 0x65, 0x6b,
+	0x74, 0x6f, 0x6e, 0x2e, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75,
+	0x6e, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x15, 0x2e, 0x74, 0x65, 0x6b, 0x74, 0x6f,
+	0x6e, 0x2e, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x22,
+	0x00, 0x12, 0x4c, 0x0a, 0x16, 0x47, 0x65, 0x74, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52,
+	0x65, 0x73, 0x75, 0x6c, 0x74, 0x52, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x12, 0x19, 0x2e, 0x74, 0x65,
+	0x6b, 0x74, 0x6f, 0x6e, 0x2e, 0x47, 0x65, 0x74, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52,
+	0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x15, 0x2e, 0x74, 0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e,
+	0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x22, 0x00, 0x12,
+	0x4d, 0x0a, 0x13, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e,
+	0x52, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x12, 0x1c, 0x2e, 0x74, 0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e,
+	0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x52, 0x65, 0x71,
+	0x75, 0x65, 0x73, 0x74, 0x1a, 0x16, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6d, 0x70, 0x74, 0x79, 0x22, 0x00, 0x12, 0x4b,
+	0x0a, 0x0c, 0x4c, 0x69, 0x73, 0x74, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e, 0x73, 0x12, 0x1b,
+	0x2e, 0x74, 0x65, 0x6b, 0x74, 0x6f, 0x6e, 0x2e, 0x4c, 0x69, 0x73, 0x74, 0x54, 0x61, 0x73, 0x6b,
+	0x52, 0x75, 0x6e, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x1c, 0x2e, 0x74, 0x65,
+	0x6b, 0x74, 0x6f, 0x6e, 0x2e, 0x4c, 0x69, 0x73, 0x74, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x75, 0x6e,
+	0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x42, 0x09, 0x5a, 0x07, 0x2e,
+	0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -378,36 +453,38 @@ func file_api_proto_rawDescGZIP() []byte {
 	return file_api_proto_rawDescData
 }
 
-var file_api_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_api_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_api_proto_goTypes = []interface{}{
-	(*CreateTaskRunRequest)(nil), // 0: tekton.CreateTaskRunRequest
-	(*DeleteTaskRunRequest)(nil), // 1: tekton.DeleteTaskRunRequest
-	(*UpdateTaskRunRequest)(nil), // 2: tekton.UpdateTaskRunRequest
-	(*GetTaskRunRequest)(nil),    // 3: tekton.GetTaskRunRequest
-	(*ListTaskRunsRequest)(nil),  // 4: tekton.ListTaskRunsRequest
-	(*ListTaskRunsResponse)(nil), // 5: tekton.ListTaskRunsResponse
-	(*TaskRun)(nil),              // 6: tekton.TaskRun
-	(*empty.Empty)(nil),          // 7: google.protobuf.Empty
+	(*TaskRunResult)(nil),        // 0: tekton.TaskRunResult
+	(*CreateTaskRunRequest)(nil), // 1: tekton.CreateTaskRunRequest
+	(*DeleteTaskRunRequest)(nil), // 2: tekton.DeleteTaskRunRequest
+	(*UpdateTaskRunRequest)(nil), // 3: tekton.UpdateTaskRunRequest
+	(*GetTaskRunRequest)(nil),    // 4: tekton.GetTaskRunRequest
+	(*ListTaskRunsRequest)(nil),  // 5: tekton.ListTaskRunsRequest
+	(*ListTaskRunsResponse)(nil), // 6: tekton.ListTaskRunsResponse
+	(*TaskRun)(nil),              // 7: tekton.TaskRun
+	(*empty.Empty)(nil),          // 8: google.protobuf.Empty
 }
 var file_api_proto_depIdxs = []int32{
-	6, // 0: tekton.CreateTaskRunRequest.task_run:type_name -> tekton.TaskRun
-	6, // 1: tekton.UpdateTaskRunRequest.task_run:type_name -> tekton.TaskRun
-	6, // 2: tekton.ListTaskRunsResponse.items:type_name -> tekton.TaskRun
-	0, // 3: tekton.Results.CreateTaskRun:input_type -> tekton.CreateTaskRunRequest
-	2, // 4: tekton.Results.UpdateTaskRun:input_type -> tekton.UpdateTaskRunRequest
-	3, // 5: tekton.Results.GetTaskRun:input_type -> tekton.GetTaskRunRequest
-	1, // 6: tekton.Results.DeleteTaskRun:input_type -> tekton.DeleteTaskRunRequest
-	4, // 7: tekton.Results.ListTaskRuns:input_type -> tekton.ListTaskRunsRequest
-	6, // 8: tekton.Results.CreateTaskRun:output_type -> tekton.TaskRun
-	6, // 9: tekton.Results.UpdateTaskRun:output_type -> tekton.TaskRun
-	6, // 10: tekton.Results.GetTaskRun:output_type -> tekton.TaskRun
-	7, // 11: tekton.Results.DeleteTaskRun:output_type -> google.protobuf.Empty
-	5, // 12: tekton.Results.ListTaskRuns:output_type -> tekton.ListTaskRunsResponse
-	8, // [8:13] is the sub-list for method output_type
-	3, // [3:8] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	7, // 0: tekton.TaskRunResult.task_run:type_name -> tekton.TaskRun
+	7, // 1: tekton.CreateTaskRunRequest.task_run:type_name -> tekton.TaskRun
+	7, // 2: tekton.UpdateTaskRunRequest.task_run:type_name -> tekton.TaskRun
+	7, // 3: tekton.ListTaskRunsResponse.items:type_name -> tekton.TaskRun
+	1, // 4: tekton.Results.CreateTaskRunResult:input_type -> tekton.CreateTaskRunRequest
+	3, // 5: tekton.Results.UpdateTaskRunResult:input_type -> tekton.UpdateTaskRunRequest
+	4, // 6: tekton.Results.GetTaskRunResultResult:input_type -> tekton.GetTaskRunRequest
+	2, // 7: tekton.Results.DeleteTaskRunResult:input_type -> tekton.DeleteTaskRunRequest
+	5, // 8: tekton.Results.ListTaskRuns:input_type -> tekton.ListTaskRunsRequest
+	0, // 9: tekton.Results.CreateTaskRunResult:output_type -> tekton.TaskRunResult
+	0, // 10: tekton.Results.UpdateTaskRunResult:output_type -> tekton.TaskRunResult
+	0, // 11: tekton.Results.GetTaskRunResultResult:output_type -> tekton.TaskRunResult
+	8, // 12: tekton.Results.DeleteTaskRunResult:output_type -> google.protobuf.Empty
+	6, // 13: tekton.Results.ListTaskRuns:output_type -> tekton.ListTaskRunsResponse
+	9, // [9:14] is the sub-list for method output_type
+	4, // [4:9] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_api_proto_init() }
@@ -418,7 +495,7 @@ func file_api_proto_init() {
 	file_taskrun_proto_init()
 	if !protoimpl.UnsafeEnabled {
 		file_api_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*CreateTaskRunRequest); i {
+			switch v := v.(*TaskRunResult); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -430,7 +507,7 @@ func file_api_proto_init() {
 			}
 		}
 		file_api_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*DeleteTaskRunRequest); i {
+			switch v := v.(*CreateTaskRunRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -442,7 +519,7 @@ func file_api_proto_init() {
 			}
 		}
 		file_api_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*UpdateTaskRunRequest); i {
+			switch v := v.(*DeleteTaskRunRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -454,7 +531,7 @@ func file_api_proto_init() {
 			}
 		}
 		file_api_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GetTaskRunRequest); i {
+			switch v := v.(*UpdateTaskRunRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -466,7 +543,7 @@ func file_api_proto_init() {
 			}
 		}
 		file_api_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ListTaskRunsRequest); i {
+			switch v := v.(*GetTaskRunRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -478,6 +555,18 @@ func file_api_proto_init() {
 			}
 		}
 		file_api_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ListTaskRunsRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_api_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ListTaskRunsResponse); i {
 			case 0:
 				return &v.state
@@ -496,7 +585,7 @@ func file_api_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_api_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
@@ -522,10 +611,10 @@ const _ = grpc.SupportPackageIsVersion6
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type ResultsClient interface {
-	CreateTaskRun(ctx context.Context, in *CreateTaskRunRequest, opts ...grpc.CallOption) (*TaskRun, error)
-	UpdateTaskRun(ctx context.Context, in *UpdateTaskRunRequest, opts ...grpc.CallOption) (*TaskRun, error)
-	GetTaskRun(ctx context.Context, in *GetTaskRunRequest, opts ...grpc.CallOption) (*TaskRun, error)
-	DeleteTaskRun(ctx context.Context, in *DeleteTaskRunRequest, opts ...grpc.CallOption) (*empty.Empty, error)
+	CreateTaskRunResult(ctx context.Context, in *CreateTaskRunRequest, opts ...grpc.CallOption) (*TaskRunResult, error)
+	UpdateTaskRunResult(ctx context.Context, in *UpdateTaskRunRequest, opts ...grpc.CallOption) (*TaskRunResult, error)
+	GetTaskRunResultResult(ctx context.Context, in *GetTaskRunRequest, opts ...grpc.CallOption) (*TaskRunResult, error)
+	DeleteTaskRunResult(ctx context.Context, in *DeleteTaskRunRequest, opts ...grpc.CallOption) (*empty.Empty, error)
 	ListTaskRuns(ctx context.Context, in *ListTaskRunsRequest, opts ...grpc.CallOption) (*ListTaskRunsResponse, error)
 }
 
@@ -537,36 +626,36 @@ func NewResultsClient(cc grpc.ClientConnInterface) ResultsClient {
 	return &resultsClient{cc}
 }
 
-func (c *resultsClient) CreateTaskRun(ctx context.Context, in *CreateTaskRunRequest, opts ...grpc.CallOption) (*TaskRun, error) {
-	out := new(TaskRun)
-	err := c.cc.Invoke(ctx, "/tekton.Results/CreateTaskRun", in, out, opts...)
+func (c *resultsClient) CreateTaskRunResult(ctx context.Context, in *CreateTaskRunRequest, opts ...grpc.CallOption) (*TaskRunResult, error) {
+	out := new(TaskRunResult)
+	err := c.cc.Invoke(ctx, "/tekton.Results/CreateTaskRunResult", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *resultsClient) UpdateTaskRun(ctx context.Context, in *UpdateTaskRunRequest, opts ...grpc.CallOption) (*TaskRun, error) {
-	out := new(TaskRun)
-	err := c.cc.Invoke(ctx, "/tekton.Results/UpdateTaskRun", in, out, opts...)
+func (c *resultsClient) UpdateTaskRunResult(ctx context.Context, in *UpdateTaskRunRequest, opts ...grpc.CallOption) (*TaskRunResult, error) {
+	out := new(TaskRunResult)
+	err := c.cc.Invoke(ctx, "/tekton.Results/UpdateTaskRunResult", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *resultsClient) GetTaskRun(ctx context.Context, in *GetTaskRunRequest, opts ...grpc.CallOption) (*TaskRun, error) {
-	out := new(TaskRun)
-	err := c.cc.Invoke(ctx, "/tekton.Results/GetTaskRun", in, out, opts...)
+func (c *resultsClient) GetTaskRunResultResult(ctx context.Context, in *GetTaskRunRequest, opts ...grpc.CallOption) (*TaskRunResult, error) {
+	out := new(TaskRunResult)
+	err := c.cc.Invoke(ctx, "/tekton.Results/GetTaskRunResultResult", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *resultsClient) DeleteTaskRun(ctx context.Context, in *DeleteTaskRunRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
+func (c *resultsClient) DeleteTaskRunResult(ctx context.Context, in *DeleteTaskRunRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
 	out := new(empty.Empty)
-	err := c.cc.Invoke(ctx, "/tekton.Results/DeleteTaskRun", in, out, opts...)
+	err := c.cc.Invoke(ctx, "/tekton.Results/DeleteTaskRunResult", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -584,10 +673,10 @@ func (c *resultsClient) ListTaskRuns(ctx context.Context, in *ListTaskRunsReques
 
 // ResultsServer is the server API for Results service.
 type ResultsServer interface {
-	CreateTaskRun(context.Context, *CreateTaskRunRequest) (*TaskRun, error)
-	UpdateTaskRun(context.Context, *UpdateTaskRunRequest) (*TaskRun, error)
-	GetTaskRun(context.Context, *GetTaskRunRequest) (*TaskRun, error)
-	DeleteTaskRun(context.Context, *DeleteTaskRunRequest) (*empty.Empty, error)
+	CreateTaskRunResult(context.Context, *CreateTaskRunRequest) (*TaskRunResult, error)
+	UpdateTaskRunResult(context.Context, *UpdateTaskRunRequest) (*TaskRunResult, error)
+	GetTaskRunResultResult(context.Context, *GetTaskRunRequest) (*TaskRunResult, error)
+	DeleteTaskRunResult(context.Context, *DeleteTaskRunRequest) (*empty.Empty, error)
 	ListTaskRuns(context.Context, *ListTaskRunsRequest) (*ListTaskRunsResponse, error)
 }
 
@@ -595,17 +684,17 @@ type ResultsServer interface {
 type UnimplementedResultsServer struct {
 }
 
-func (*UnimplementedResultsServer) CreateTaskRun(context.Context, *CreateTaskRunRequest) (*TaskRun, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method CreateTaskRun not implemented")
+func (*UnimplementedResultsServer) CreateTaskRunResult(context.Context, *CreateTaskRunRequest) (*TaskRunResult, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateTaskRunResult not implemented")
 }
-func (*UnimplementedResultsServer) UpdateTaskRun(context.Context, *UpdateTaskRunRequest) (*TaskRun, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method UpdateTaskRun not implemented")
+func (*UnimplementedResultsServer) UpdateTaskRunResult(context.Context, *UpdateTaskRunRequest) (*TaskRunResult, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateTaskRunResult not implemented")
 }
-func (*UnimplementedResultsServer) GetTaskRun(context.Context, *GetTaskRunRequest) (*TaskRun, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method GetTaskRun not implemented")
+func (*UnimplementedResultsServer) GetTaskRunResultResult(context.Context, *GetTaskRunRequest) (*TaskRunResult, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTaskRunResultResult not implemented")
 }
-func (*UnimplementedResultsServer) DeleteTaskRun(context.Context, *DeleteTaskRunRequest) (*empty.Empty, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method DeleteTaskRun not implemented")
+func (*UnimplementedResultsServer) DeleteTaskRunResult(context.Context, *DeleteTaskRunRequest) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteTaskRunResult not implemented")
 }
 func (*UnimplementedResultsServer) ListTaskRuns(context.Context, *ListTaskRunsRequest) (*ListTaskRunsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListTaskRuns not implemented")
@@ -615,74 +704,74 @@ func RegisterResultsServer(s *grpc.Server, srv ResultsServer) {
 	s.RegisterService(&_Results_serviceDesc, srv)
 }
 
-func _Results_CreateTaskRun_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _Results_CreateTaskRunResult_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(CreateTaskRunRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ResultsServer).CreateTaskRun(ctx, in)
+		return srv.(ResultsServer).CreateTaskRunResult(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/tekton.Results/CreateTaskRun",
+		FullMethod: "/tekton.Results/CreateTaskRunResult",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ResultsServer).CreateTaskRun(ctx, req.(*CreateTaskRunRequest))
+		return srv.(ResultsServer).CreateTaskRunResult(ctx, req.(*CreateTaskRunRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Results_UpdateTaskRun_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _Results_UpdateTaskRunResult_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(UpdateTaskRunRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ResultsServer).UpdateTaskRun(ctx, in)
+		return srv.(ResultsServer).UpdateTaskRunResult(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/tekton.Results/UpdateTaskRun",
+		FullMethod: "/tekton.Results/UpdateTaskRunResult",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ResultsServer).UpdateTaskRun(ctx, req.(*UpdateTaskRunRequest))
+		return srv.(ResultsServer).UpdateTaskRunResult(ctx, req.(*UpdateTaskRunRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Results_GetTaskRun_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _Results_GetTaskRunResultResult_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetTaskRunRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ResultsServer).GetTaskRun(ctx, in)
+		return srv.(ResultsServer).GetTaskRunResultResult(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/tekton.Results/GetTaskRun",
+		FullMethod: "/tekton.Results/GetTaskRunResultResult",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ResultsServer).GetTaskRun(ctx, req.(*GetTaskRunRequest))
+		return srv.(ResultsServer).GetTaskRunResultResult(ctx, req.(*GetTaskRunRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Results_DeleteTaskRun_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _Results_DeleteTaskRunResult_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(DeleteTaskRunRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ResultsServer).DeleteTaskRun(ctx, in)
+		return srv.(ResultsServer).DeleteTaskRunResult(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/tekton.Results/DeleteTaskRun",
+		FullMethod: "/tekton.Results/DeleteTaskRunResult",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ResultsServer).DeleteTaskRun(ctx, req.(*DeleteTaskRunRequest))
+		return srv.(ResultsServer).DeleteTaskRunResult(ctx, req.(*DeleteTaskRunRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -710,20 +799,20 @@ var _Results_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*ResultsServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "CreateTaskRun",
-			Handler:    _Results_CreateTaskRun_Handler,
+			MethodName: "CreateTaskRunResult",
+			Handler:    _Results_CreateTaskRunResult_Handler,
 		},
 		{
-			MethodName: "UpdateTaskRun",
-			Handler:    _Results_UpdateTaskRun_Handler,
+			MethodName: "UpdateTaskRunResult",
+			Handler:    _Results_UpdateTaskRunResult_Handler,
 		},
 		{
-			MethodName: "GetTaskRun",
-			Handler:    _Results_GetTaskRun_Handler,
+			MethodName: "GetTaskRunResultResult",
+			Handler:    _Results_GetTaskRunResultResult_Handler,
 		},
 		{
-			MethodName: "DeleteTaskRun",
-			Handler:    _Results_DeleteTaskRun_Handler,
+			MethodName: "DeleteTaskRunResult",
+			Handler:    _Results_DeleteTaskRunResult_Handler,
 		},
 		{
 			MethodName: "ListTaskRuns",


### PR DESCRIPTION
Added a new message TaskRunResult to combine TaskRun and results_id
Modified CRUD to make them now query based on results_id
Generate a random unique results_id inside CreateTaskRunResult
Modified tests to be compatible with new function interfaces

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
