### PR TITLE
Add apply and delete sub-commands to generators cli

### DIFF
--- a/generators/cmd/cli/cmd/apply.go
+++ b/generators/cmd/cli/cmd/apply.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"generators/pkg/manager"
+	"generators/pkg/writer"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	configFile string
+	applyCmd   = &cobra.Command{
+		Use:   "apply",
+		Short: "Apply generated configuration to Kubernetes Cluster",
+		RunE:  apply,
+	}
+)
+
+func init() {
+	applyCmd.Flags().StringVarP(&configFile, "filename", "f", "", "spec file")
+	rootCmd.AddCommand(applyCmd)
+}
+
+func apply(cmd *cobra.Command, args []string) error {
+	if len(configFile) == 0 {
+		return errors.New("No input file specified")
+	}
+
+	client, err := manager.GetKubeClient(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("fail to create a Kubernetes client: %w", err)
+	}
+
+	buf := new(bytes.Buffer)
+	if err := writer.WriteToDisk(configFile, buf); err != nil {
+		return fmt.Errorf("fail to get the generated config from %s: %w", configFile, err)
+	}
+	return manager.CreateResource(context.Background(), client, buf)
+}

--- a/generators/cmd/cli/cmd/delete.go
+++ b/generators/cmd/cli/cmd/delete.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"generators/pkg/manager"
+	"generators/pkg/writer"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	deleteFile string
+	deleteCmd  = &cobra.Command{
+		Use:   "delete",
+		Short: "Delete generated configuration from Kubernetes Cluster",
+		RunE:  delete,
+	}
+)
+
+func init() {
+	deleteCmd.Flags().StringVarP(&deleteFile, "filename", "f", "", "spec file")
+	rootCmd.AddCommand(deleteCmd)
+}
+
+func delete(cmd *cobra.Command, args []string) error {
+	if len(deleteFile) == 0 {
+		return errors.New("No input file specified")
+	}
+
+	client, err := manager.GetKubeClient(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("fail to create a Kubernetes client: %w", err)
+	}
+
+	buf := new(bytes.Buffer)
+	if err := writer.WriteToDisk(deleteFile, buf); err != nil {
+		return fmt.Errorf("fail to get the generated config from %s: %w", deleteFile, err)
+	}
+	return manager.DeleteResource(context.Background(), client, buf)
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This PR aims to add support for [Tekton Generators](https://github.com/tektoncd/pipeline/issues/2590) cli.

The changes include:

1. Add the sub-command `apply` to apply the generated resources on the cluster.
2. Add the sub-command `delete` to delete the generated resources on the cluster.



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
