### PR TITLE
Hub: fixes search

### DIFF
--- a/hub/ui/package.json
+++ b/hub/ui/package.json
@@ -16,6 +16,7 @@
     "@types/react-router-dom": "^5.1.0",
     "@types/react-syntax-highlighter": "^11.0.2",
     "axios": "^0.19.0",
+    "fuzzysort": "^1.1.4",
     "javascript-time-ago": "^2.0.7",
     "latest-version": "^5.1.0",
     "patternfly-react": "^2.39.5",

--- a/hub/ui/src/components/footer/Footer.tsx
+++ b/hub/ui/src/components/footer/Footer.tsx
@@ -16,8 +16,8 @@ const Footer: React.FC = () => {
   return (
 
     <div>
-      <Card style={{ height: '20em', backgroundColor: '#EDEDED' }}></Card>
-      <Card style={{ backgroundColor: '#151515', marginTop: '1em' }}>
+      <Card style={{height: '20em', backgroundColor: '#EDEDED'}}></Card>
+      <Card style={{backgroundColor: '#151515', marginTop: '1em'}}>
 
         <Grid>
           <GridItem span={4}>
@@ -28,30 +28,31 @@ const Footer: React.FC = () => {
               <FlexItem>
                 <a href="https://cd.foundation">
                   <img src="https://tekton.dev/partner-logos/cdf.png"
-                    alt="tekton.dev" style={{ maxWidth: '60%', marginLeft: '20%' }} />
+                    alt="tekton.dev"
+                    style={{maxWidth: '60%', marginLeft: '20%'}} />
                 </a>
               </FlexItem>
             </Flex>
-            <Flex style={{ justifyContent: 'center' }}>
+            <Flex style={{justifyContent: 'center'}}>
               <TextContent>
                 <Text component={TextVariants.h1}
-                  style={{ color: 'white' }}>
+                  style={{color: 'white'}}>
                   Tekton is a{' '}
                   <Text component={TextVariants.a} href="https://cd.foundation">
                     Continuous Delivery Foundation
-                   </Text>{' '}project.
+                  </Text>{' '}project.
                 </Text>
               </TextContent>
             </Flex>
-            <Flex style={{ justifyContent: 'center' }}>
+            <Flex style={{justifyContent: 'center'}}>
               <FlexItem>
                 <img src={tekton} alt="Tekton"
-                  style={{ height: '6em', marginBottom: '-1em' }} />
+                  style={{height: '6em', marginBottom: '-1em'}} />
               </FlexItem>
             </Flex>
             <Flex>
               <CardFooter>
-                <Text style={{ color: 'white', textAlign: 'center' }}>
+                <Text style={{color: 'white', textAlign: 'center'}}>
                   © 2020 The Linux Foundation®. All rights reserved.
                   The Linux Foundation has registered trademarks and
                   uses trademarks. For a list of trademarks of
@@ -61,11 +62,11 @@ const Footer: React.FC = () => {
                     Trademark Usage page
                   </Text>
                   .{' '}Linux is a registered trademark of Linus Torvalds.
-                   {' '}
+                  {' '}
                   <Text component={TextVariants.a}
                     href="https://www.linuxfoundation.org/privacy/" >
                     Privacy Policy
-                   </Text>
+                  </Text>
                   {' '} and {' '}
                   <Text component={TextVariants.a}
                     href="https://www.linuxfoundation.org/terms/">

--- a/hub/ui/src/components/search-bar/SearchBar.tsx
+++ b/hub/ui/src/components/search-bar/SearchBar.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import React from 'react';
-import {connect} from 'react-redux';
+import { connect } from 'react-redux';
 import '@patternfly/react-core/dist/styles/base.css';
 import './index.css';
 import {
@@ -8,9 +8,10 @@ import {
   Flex,
   TextInput,
 } from '@patternfly/react-core';
-import {fetchTaskSuccess} from '../redux/Actions/TaskAction';
-import {fetchTaskList} from '../redux/Actions/TaskDataListAction';
+import { fetchTaskSuccess } from '../redux/Actions/TaskAction';
+import { fetchTaskList } from '../redux/Actions/TaskDataListAction';
 import store from '../redux/store';
+import fuzzysort from 'fuzzysort';
 export interface TaskPropData {
   id: number;
   name: string,
@@ -35,17 +36,20 @@ const SearchBar: React.FC = (props: any) => {
 
   const onTextChanged = (e: any) => {
     const value = e;
-    let suggestions: any = [];
-    const regex = new RegExp(`${value}`, 'i');
-    suggestions = props.TaskDataList.sort().filter((v: any) => regex.test(v.name));
-    if (value.length === 0) {
-      store.dispatch({
-        type: 'FETCH_TASK_SUCCESS', payload: props.TaskDataList.sort((first: any, second: any) =>
-          first.name > second.name ? 1 : -1),
+    const trimmedText = value.trim();
+    if (trimmedText.length !== 0) {
+      const filtered = fuzzysort.go(trimmedText, props.TaskDataList, {
+        keys: ['name', 'displayName']
       });
-    } else {
+      const suggestions = filtered.map((resource: any) => resource.obj);
       store.dispatch({
         type: 'FETCH_TASK_SUCCESS', payload: suggestions.sort((first: any, second: any) =>
+          first.name > second.name ? 1 : -1),
+      });
+    }
+    else {
+      store.dispatch({
+        type: 'FETCH_TASK_SUCCESS', payload: props.TaskDataList.sort((first: any, second: any) =>
           first.name > second.name ? 1 : -1),
       });
     }
@@ -61,18 +65,18 @@ const SearchBar: React.FC = (props: any) => {
   return (
 
     <div className="search">
-      <Flex breakpointMods={[{modifier: 'flex-1', breakpoint: 'lg'}]}>
+      <Flex breakpointMods={[{ modifier: 'flex-1', breakpoint: 'lg' }]}>
 
-        <Flex breakpointMods={[{modifier: 'column', breakpoint: 'lg'}]}>
+        <Flex breakpointMods={[{ modifier: 'column', breakpoint: 'lg' }]}>
         </Flex>
         <React.Fragment>
 
 
-          <InputGroup style={{width: '100%'}}>
-            <div style={{width: '100%', boxShadow: 'rgba'}}>
+          <InputGroup style={{ width: '100%' }}>
+            <div style={{ width: '100%', boxShadow: 'rgba' }}>
               <TextInput aria-label="text input example" value={textValue} type="search"
                 onChange={onTextChanged} placeholder="Search for task or pipeline"
-                style={{padding: '10px 5px', height: '2.7em'}} />
+                style={{ padding: '10px 5px', height: '2.7em' }} />
 
             </div>
           </InputGroup>
@@ -91,5 +95,5 @@ const mapStateToProps = (state: any) => ({
 
 });
 
-export default connect(mapStateToProps, {fetchTaskSuccess, fetchTaskList})(SearchBar);
+export default connect(mapStateToProps, { fetchTaskSuccess, fetchTaskList })(SearchBar);
 

--- a/hub/ui/src/components/search-bar/SearchBar.tsx
+++ b/hub/ui/src/components/search-bar/SearchBar.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import React from 'react';
-import { connect } from 'react-redux';
+import {connect} from 'react-redux';
 import '@patternfly/react-core/dist/styles/base.css';
 import './index.css';
 import {
@@ -8,8 +8,8 @@ import {
   Flex,
   TextInput,
 } from '@patternfly/react-core';
-import { fetchTaskSuccess } from '../redux/Actions/TaskAction';
-import { fetchTaskList } from '../redux/Actions/TaskDataListAction';
+import {fetchTaskSuccess} from '../redux/Actions/TaskAction';
+import {fetchTaskList} from '../redux/Actions/TaskDataListAction';
 import store from '../redux/store';
 import fuzzysort from 'fuzzysort';
 export interface TaskPropData {
@@ -39,15 +39,14 @@ const SearchBar: React.FC = (props: any) => {
     const trimmedText = value.trim();
     if (trimmedText.length !== 0) {
       const filtered = fuzzysort.go(trimmedText, props.TaskDataList, {
-        keys: ['name', 'displayName']
+        keys: ['name', 'displayName'],
       });
       const suggestions = filtered.map((resource: any) => resource.obj);
       store.dispatch({
         type: 'FETCH_TASK_SUCCESS', payload: suggestions.sort((first: any, second: any) =>
           first.name > second.name ? 1 : -1),
       });
-    }
-    else {
+    } else {
       store.dispatch({
         type: 'FETCH_TASK_SUCCESS', payload: props.TaskDataList.sort((first: any, second: any) =>
           first.name > second.name ? 1 : -1),
@@ -65,18 +64,18 @@ const SearchBar: React.FC = (props: any) => {
   return (
 
     <div className="search">
-      <Flex breakpointMods={[{ modifier: 'flex-1', breakpoint: 'lg' }]}>
+      <Flex breakpointMods={[{modifier: 'flex-1', breakpoint: 'lg'}]}>
 
-        <Flex breakpointMods={[{ modifier: 'column', breakpoint: 'lg' }]}>
+        <Flex breakpointMods={[{modifier: 'column', breakpoint: 'lg'}]}>
         </Flex>
         <React.Fragment>
 
 
-          <InputGroup style={{ width: '100%' }}>
-            <div style={{ width: '100%', boxShadow: 'rgba' }}>
+          <InputGroup style={{width: '100%'}}>
+            <div style={{width: '100%', boxShadow: 'rgba'}}>
               <TextInput aria-label="text input example" value={textValue} type="search"
                 onChange={onTextChanged} placeholder="Search for task or pipeline"
-                style={{ padding: '10px 5px', height: '2.7em' }} />
+                style={{padding: '10px 5px', height: '2.7em'}} />
 
             </div>
           </InputGroup>
@@ -95,5 +94,5 @@ const mapStateToProps = (state: any) => ({
 
 });
 
-export default connect(mapStateToProps, { fetchTaskSuccess, fetchTaskList })(SearchBar);
+export default connect(mapStateToProps, {fetchTaskSuccess, fetchTaskList})(SearchBar);
 


### PR DESCRIPTION
Previously, a user was able to search a resource by `name` only.

This patch will allow User to search a resource by both `name` and `displayName`.

Signed-off-by: Shiv Verma <shverma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
