### PR TITLE
Hub: Add support for pipeline in sync service

### DIFF
--- a/hub/api/pkg/git/repo.go
+++ b/hub/api/pkg/git/repo.go
@@ -58,7 +58,16 @@ func (r Repo) ParseTektonResources() ([]TektonResource, error) {
 	// TODO(sthaha): may be in parallel
 	// TODO(sthaha): replace it by channels and stream and write?
 	// TODO(sthaha): get task kind from scheme ?
-	return r.findResourcesByKind("Task")
+	kinds := []string{"Task", "Pipeline"}
+	resources := []TektonResource{}
+	for _, k := range kinds {
+		ret, err := r.findResourcesByKind(k)
+		if err != nil {
+			return []TektonResource{}, err
+		}
+		resources = append(resources, ret...)
+	}
+	return resources, nil
 }
 
 func ignoreNotExists(err error) error {


### PR DESCRIPTION
Previously, sync service used to read-only tasks from catalog.
Now, it will read the task and pipeline from the catalog and add to DB.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
