### PR TITLE
Hub: adds tooltip for badges and font for resource name

### DIFF
--- a/hub/ui-new/.eslintrc
+++ b/hub/ui-new/.eslintrc
@@ -1,0 +1,42 @@
+{
+    "env": {
+        "browser": true,
+        "es6": true,
+        "node": true
+    },
+    "extends": [
+        "google",
+        "plugin:react/recommended"
+    ],
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true
+        },
+        "ecmaVersion": 2018,
+        "sourceType": "module"
+    },
+    "plugins": [
+        "react",
+        "@typescript-eslint"
+    ],
+    "rules": {
+        "require-jsdoc": 0,
+        // "indent": [
+        //     "error",
+        //     2
+        // ],
+        "indent": [
+            2,
+            2,
+            {
+                "SwitchCase": 1
+            }
+        ],
+        "no-multi-spaces": "error"
+    }
+}

--- a/hub/ui-new/src/components/basic-detail/BasicDetail.tsx
+++ b/hub/ui-new/src/components/basic-detail/BasicDetail.tsx
@@ -102,22 +102,20 @@ const BasicDetail: React.FC<BasicDetailProp> = (props: any) => {
   const [versions, setVersion] =
     useState(props.task.latestVersion.version + ' (latest) ');
   const [taskLink, setTaskLink] =
-    useState(`kubectl apply -f ${ props.task.latestVersion.rawURL }`);
+    useState(`kubectl apply -f ${props.task.latestVersion.rawURL}`);
 
   const [href, setHref] = useState(`${
     props.task.latestVersion.webURL.substring(0,
-      props.task.latestVersion.webURL.lastIndexOf('/') + 1) }`);
+      props.task.latestVersion.webURL.lastIndexOf('/') + 1)}`);
 
-  // Display Name for resource
-  let displayName = '';
-  if (props.task.latestVersion.displayName === '') {
-    displayName = props.task.name;
-  } else {
-    displayName = props.task.latestVersion.displayName.replace(
-      /(^\w|\s+\w){1}/g, ((str) => {
-        return str.toUpperCase();
-      })) + ' (' + (props.task.name) + ')';
-  }
+  //  Resource name
+  let resourceName = props.task.latestVersion.displayName === '' ?
+    <span style={{fontFamily: 'courier, monospace'}}>
+      {props.task.name}</span> :
+    <p >{props.task.latestVersion.displayName}
+      {<span style={{fontFamily: 'courier, monospace'}}>
+        {`(${props.task.name})`}</span>}
+    </p>;
 
   // Dropdown menu to show versions
   const [isOpen, set] = useState(false);
@@ -129,13 +127,13 @@ const BasicDetail: React.FC<BasicDetailProp> = (props: any) => {
     tempTaskData.forEach((item: any, index: any) => {
       if (props.task.latestVersion.version === item.version) {
         dropdownItems.push(<DropdownItem
-          key={`res-${ item.version }`} name={item.id.toString()}
+          key={`res-${item.version}`} name={item.id.toString()}
           onClick={getVersionDetail} >
           {item.version + ' (latest) '}
         </DropdownItem>);
       } else {
         dropdownItems.push(<DropdownItem
-          key={`res-${ item.version }`} name={item.id.toString()}
+          key={`res-${item.version}`} name={item.id.toString()}
           onClick={getVersionDetail} >
           {item.version}
         </DropdownItem>);
@@ -145,15 +143,15 @@ const BasicDetail: React.FC<BasicDetailProp> = (props: any) => {
 
   // versions details of a perticular version
   function getVersionDetail(event: any) {
-    fetch(`${ API_URL }/resource/version/${ event.target.name }`)
+    fetch(`${API_URL}/resource/version/${event.target.name}`)
       .then((response) => response.json())
       .then((data) => {
         props.fetchTaskDescription(data.rawURL);
 
-        setHref(`${ data.webURL.substring(0,
-          data.webURL.lastIndexOf('/') + 1) }`);
+        setHref(`${data.webURL.substring(0,
+          data.webURL.lastIndexOf('/') + 1)}`);
 
-        setTaskLink(`kubectl apply -f ${ data.rawURL }`);
+        setTaskLink(`kubectl apply -f ${data.rawURL}`);
 
         setSummary(data.description.substring(0,
           data.description.indexOf('\n')) ||
@@ -166,10 +164,13 @@ const BasicDetail: React.FC<BasicDetailProp> = (props: any) => {
               1).trim() : ' ',
         );
 
-        displayName = data.dsiplayName === ' ' ? data.resource.name :
-          displayName.replace(/(^\w|\s+\w){1}/g, ((str) => {
-            return str.toUpperCase();
-          }));
+        resourceName = data.displayName === '' ?
+          <span style={{fontFamily: 'courier, monospace'}}>
+            {data.resource.name}</span> :
+          <p >{data.displayName}
+            {<span style={{fontFamily: 'courier, monospace'}}>
+              {`(${data.resource.name})`}</span>}
+          </p>;
       });
     setVersion(event.target.text);
   }
@@ -239,7 +240,7 @@ const BasicDetail: React.FC<BasicDetailProp> = (props: any) => {
                 <Text style={{fontSize: '2em'}}>
                   {/* {props.task.name.charAt(0).toUpperCase() +
                     props.task.name.slice(1)} */}
-                  {displayName}
+                  {resourceName}
                 </Text>
               </FlexItem>
 

--- a/hub/ui-new/src/components/filter/Filter.tsx
+++ b/hub/ui-new/src/components/filter/Filter.tsx
@@ -63,7 +63,7 @@ const Filter: React.FC = (props: any) => {
     categoryData.map((categoryName: string, index: number) =>
       filterItem.push(
         {
-          id: `${ categoryName['id'] }`,
+          id: `${categoryName['id']}`,
           value: categoryName['name'], isChecked: false,
         },
       ));
@@ -93,19 +93,19 @@ const Filter: React.FC = (props: any) => {
     switch (idx) {
       case 0:
         return <BuildIcon size="sm" color="black"
-          style={{marginLeft: '-0.5em'}} />;
+          style={{marginLeft: '-0.5em', verticalAlign: '-0.15em'}} />;
       case 1:
         return <DomainIcon size="sm" color="black"
-          style={{marginLeft: '-0.5em'}} />;
+          style={{marginLeft: '-0.5em', verticalAlign: '-0.15em'}} />;
       case 2:
         return <CatIcon size="sm" color="#484848"
-          style={{marginLeft: '-0.5em'}} />;
+          style={{marginLeft: '-0.5em', verticalAlign: '-0.15em'}} />;
       case 3:
         return <CertificateIcon size="sm" color="#484848"
-          style={{marginLeft: '-0.5em'}} />;
+          style={{marginLeft: '-0.5em', verticalAlign: '-0.15em'}} />;
       case 4:
         return <UserIcon size="sm" color="#484848"
-          style={{marginLeft: '-0.5em'}} />;
+          style={{marginLeft: '-0.5em', verticalAlign: '-0.15em'}} />;
       default:
         return;
     }
@@ -312,7 +312,7 @@ const Filter: React.FC = (props: any) => {
   if (status !== undefined && checkBoxStatus !== undefined) {
     const verifiedtask = status.checklist.slice(2, 5);
     showverifiedtask = verifiedtask.map((it: any, idx: number) => (
-      <div key={`task-${ idx }`} style={{marginBottom: '0.5em'}}>
+      <div key={`task-${idx}`} style={{marginBottom: '0.5em'}}>
         <Checkbox
           onClick={filterApi}
           isChecked={checkBoxStatus[it.value]}

--- a/hub/ui-new/src/components/task/Task.tsx
+++ b/hub/ui-new/src/components/task/Task.tsx
@@ -21,6 +21,7 @@ import {
   FlexItem,
   Flex,
   FlexModifiers,
+  Tooltip,
 } from '@patternfly/react-core';
 import {
   StarIcon,
@@ -89,20 +90,28 @@ const Task: React.FC<TaskProp> = (props: any) => {
   let verifiedStatus: any;
   if (props.task) {
     if (props.task.catalog.type.toLowerCase() === 'official') {
-      verifiedStatus = <div className="vtask" >
-        <CatIcon size="md" color='#484848'
-          style={{width: '2em', height: '2em'}} />
-      </div>;
+      verifiedStatus = <Tooltip content={<b>Official</b>}>
+        <div className="vtask" >
+          <CatIcon size="md" color='#484848'
+            style={{width: '2em', height: '2em'}} />
+        </div>
+      </Tooltip>;
     }
     if (props.task.catalog.type.toLowerCase() === 'verified') {
-      verifiedStatus = <div className="vtask" >
-        <CertificateIcon size="md" color='#484848' />
-      </div>;
+      verifiedStatus = <Tooltip content={<b>Verified</b>}>
+        <div className="vtask" >
+          <CertificateIcon size="md" color='#484848'
+            style={{width: '2em', height: '2em'}} />
+        </div>
+      </Tooltip>;
     }
     if (props.task.catalog.type.toLowerCase() === 'community') {
-      verifiedStatus = <div className="vtask" >
-        <UserIcon size="md" color='#484848' />
-      </div>;
+      verifiedStatus = <Tooltip content={<b>Community</b>}>
+        <div className="vtask" >
+          <UserIcon size="md" color='#484848'
+            style={{width: '2em', height: '2em'}} />
+        </div>
+      </Tooltip>;
     }
   }
 
@@ -110,31 +119,28 @@ const Task: React.FC<TaskProp> = (props: any) => {
   // for adding icon to task and pipeline
   let resourceIcon: React.ReactNode;
   if (props.task.type.toLowerCase() === 'task') {
-    resourceIcon = <BuildIcon
-      style={{
-        width: '2em', height: '2em',
-        verticalAlign: '-0.2em',
-      }} color="#484848" />;
+    resourceIcon = <Tooltip content={<b>Task</b>}>
+      <BuildIcon
+        style={{width: '2em', height: '2em', verticalAlign: '-0.2em'}}
+        color="#484848"
+      />
+    </Tooltip>;
   } else {
-    resourceIcon = <DomainIcon
-      style={{
-        width: '2em',
-        height: '2em', verticalAlign: '-0.2em',
-      }}
-      color="#484848"
-    />;
+    resourceIcon = <Tooltip content={<b>Pipeline</b>}>
+      <DomainIcon
+        style={{width: '2em', height: '2em', verticalAlign: '-0.2em'}}
+        color="#484848"
+      />
+    </Tooltip>;
   };
 
 
   // Display name
-  let displayName = '';
-  if (props.task.latestVersion.displayName === '') {
-    displayName = props.task.name;
-  } else {
-    displayName = props.task.latestVersion.displayName.replace(/(^\w|\s+\w){1}/g, ((str) => {
-      return str.toUpperCase();
-    }));
-  }
+
+  const resourceName = props.task.latestVersion.displayName === '' ?
+    <span style={{fontFamily: 'courier, monospace'}}>
+      {props.task.name}</span> : <span>
+      {props.task.latestVersion.displayName}</span>;
 
   return (
     <GalleryItem>
@@ -170,7 +176,7 @@ const Task: React.FC<TaskProp> = (props: any) => {
             <Flex>
               <FlexItem>
                 <span className="task-heading">
-                  {displayName}
+                  {resourceName}
                   {/* {props.task.name[0].toUpperCase() + props.task.name.slice(1)} */}
                 </span>
               </FlexItem>
@@ -186,9 +192,9 @@ const Task: React.FC<TaskProp> = (props: any) => {
           <CardBody className="catalog-tile-pf-body">
             <div className="catalog-tile-pf-description">
               <span>
-                {`${ props.task.latestVersion.description.substring(0,
-                  props.task.latestVersion.description.indexOf('\n')) }` ||
-                  `${ props.task.latestVersion.description }`}
+                {`${props.task.latestVersion.description.substring(0,
+                  props.task.latestVersion.description.indexOf('\n'))}` ||
+                  `${props.task.latestVersion.description}`}
               </span>
             </div>
 
@@ -197,19 +203,24 @@ const Task: React.FC<TaskProp> = (props: any) => {
 
 
             <TextContent className="text"
-              style={{marginBottom: '1em', marginLeft: '0.2em'}}>
+              style={{
+                marginBottom: '0.5em', marginTop:
+                  '-1em', marginLeft: '0em',
+              }}>
               Updated {diffDays}
             </TextContent>
 
             <div style={{height: '2em'}}>
               {
-                tempArr.map((tag: any) => {
-                  return (
-                    <Badge style={{
-                      marginLeft: '0.2em',
-                      marginBottom: '1em',
-                    }} key={`badge-${tag}`} className="badge">{tag}</Badge>
-                  );
+                tempArr.map((tag: any, index: number) => {
+                  if (index < 3) {
+                    return (
+                      <Badge style={{
+                        marginRight: '0.3em',
+                        marginBottom: '0.5em',
+                      }} key={`badge-${tag}`} className="badge">{tag}</Badge>
+                    );
+                  }
                 })
               }
             </div>

--- a/hub/ui/src/components/basic-detail/BasicDetail.tsx
+++ b/hub/ui/src/components/basic-detail/BasicDetail.tsx
@@ -84,15 +84,14 @@ const BasicDetail: React.FC<BasicDetailProp> = (props: any) => {
   const [href, setHref] = useState(`${props.version.webUrl.substring(0,
     props.version.webUrl.lastIndexOf('/') + 1)}`);
 
-  // Display Name
-  let displayName = '';
-  if (props.task.displayName === '') {
-    displayName = props.task.name;
-  } else {
-    displayName = props.task.displayName.replace(/(^\w|\s+\w){1}/g, ((str) => {
-      return str.toUpperCase();
-    })) + ' (' + (props.task.name) + ')';
-  }
+  // resource name
+  let resourceName = props.task.displayName === '' ?
+    <span style={{fontFamily: 'courier, monospace'}}>
+      {props.task.name}</span> :
+    <p >{props.task.displayName}
+      {<span style={{fontFamily: 'courier, monospace'}}>
+        {`(${props.task.name})`}</span>}
+    </p>;
 
   // Dropdown menu to show versions
   const [isOpen, set] = useState(false);
@@ -128,13 +127,12 @@ const BasicDetail: React.FC<BasicDetailProp> = (props: any) => {
       if (event.target.name === item.version) {
         props.fetchTaskDescription(item.rawUrl);
 
-        if (props.task.displayName === '') {
-          displayName = item.name;
-        } else {
-          displayName = item.displayName.replace(/(^\w|\s+\w){1}/g, ((str) => {
-            return str.toUpperCase();
-          }));
-        }
+        resourceName = props.task.displayName === '' ?
+          <span style={{fontFamily: 'courier, monospace'}}>{item.name}</span> :
+          <p >{item.displayName}
+            {<span style={{fontFamily: 'courier, monospace'}}>
+              {`(${item.name})`}</span>}
+          </p>;
 
         setHref(`${item.webUrl.substring(0,
           item.webUrl.lastIndexOf('/') + 1)}`);
@@ -214,9 +212,7 @@ const BasicDetail: React.FC<BasicDetailProp> = (props: any) => {
 
               <FlexItem>
                 <Text style={{fontSize: '2em'}}>
-                  {/* {props.task.name.charAt(0).toUpperCase() +
-                    props.task.name.slice(1)} */}
-                  {displayName}
+                  {resourceName}
                 </Text>
               </FlexItem>
 

--- a/hub/ui/src/components/filter/Filter.tsx
+++ b/hub/ui/src/components/filter/Filter.tsx
@@ -93,19 +93,19 @@ const Filter: React.FC = (props: any) => {
     switch (idx) {
       case 0:
         return <BuildIcon size="sm" color="black"
-          style={{marginLeft: '-0.5em'}} />;
+          style={{marginLeft: '-0.5em', verticalAlign: '-0.15em'}} />;
       case 1:
         return <DomainIcon size="sm" color="black"
-          style={{marginLeft: '-0.5em'}} />;
+          style={{marginLeft: '-0.5em', verticalAlign: '-0.15em'}} />;
       case 2:
         return <CatIcon size="sm" color="#484848"
-          style={{marginLeft: '-0.5em'}} />;
+          style={{marginLeft: '-0.5em', verticalAlign: '-0.15em'}} />;
       case 3:
         return <CertificateIcon size="sm" color="#484848"
-          style={{marginLeft: '-0.5em'}} />;
+          style={{marginLeft: '-0.5em', verticalAlign: '-0.15em'}} />;
       case 4:
         return <UserIcon size="sm" color="#484848"
-          style={{marginLeft: '-0.5em'}} />;
+          style={{marginLeft: '-0.5em', verticalAlign: '-0.15em'}} />;
       default:
         return;
     }

--- a/hub/ui/src/components/task/Task.tsx
+++ b/hub/ui/src/components/task/Task.tsx
@@ -22,6 +22,7 @@ import {
   Flex,
   Grid,
   GridItem,
+  Tooltip,
 } from '@patternfly/react-core';
 import {
   StarIcon,
@@ -73,22 +74,28 @@ const Task: React.FC<TaskProp> = (props: any) => {
   let verifiedStatus: any;
   if (props.task) {
     if (props.task.catalog.type.toLowerCase() === 'official') {
-      verifiedStatus = <div className="vtask" >
-        <CatIcon size="md" color='#484848'
-          style={{width: '2em', height: '2em'}} />
-      </div>;
+      verifiedStatus = <Tooltip content={<b>Official</b>}>
+        <div className="vtask" >
+          <CatIcon size="md" color='#484848'
+            style={{width: '2em', height: '2em'}} />
+        </div>
+      </Tooltip>;
     }
     if (props.task.catalog.type.toLowerCase() === 'verified') {
-      verifiedStatus = <div className="vtask" >
-        <CertificateIcon size="md" color='#484848'
-          style={{width: '2em', height: '2em'}} />
-      </div>;
+      verifiedStatus = <Tooltip content={<b>Verified</b>}>
+        <div className="vtask" >
+          <CertificateIcon size="md" color='#484848'
+            style={{width: '2em', height: '2em'}} />
+        </div>
+      </Tooltip>;
     }
     if (props.task.catalog.type.toLowerCase() === 'community') {
-      verifiedStatus = <div className="vtask" >
-        <UserIcon size="md" color='#484848'
-          style={{width: '2em', height: '2em'}} />
-      </div>;
+      verifiedStatus = <Tooltip content={<b>Community</b>}>
+        <div className="vtask" >
+          <UserIcon size="md" color='#484848'
+            style={{width: '2em', height: '2em'}} />
+        </div>
+      </Tooltip>;
     }
   }
 
@@ -96,31 +103,28 @@ const Task: React.FC<TaskProp> = (props: any) => {
   // for adding icon to task and pipeline
   let resourceIcon: React.ReactNode;
   if (props.task.type.toLowerCase() === 'task') {
-    resourceIcon = <BuildIcon
-      style={{
-        width: '2em', height: '2em',
-        verticalAlign: '-0.2em',
-      }} color="#484848" />;
+    resourceIcon = <Tooltip content={<b>Task</b>}>
+      <BuildIcon
+        style={{width: '2em', height: '2em', verticalAlign: '-0.2em'}}
+        color="#484848"
+      />
+    </Tooltip>;
   } else {
-    resourceIcon = <DomainIcon
-      style={{
-        width: '2em',
-        height: '2em', verticalAlign: '-0.2em',
-      }}
-      color="#484848"
-    />;
+    resourceIcon = <Tooltip content={<b>Pipeline</b>}>
+      <DomainIcon
+        style={{width: '2em', height: '2em', verticalAlign: '-0.2em'}}
+        color="#484848"
+      />
+    </Tooltip>;
   };
 
+  // resource name
+  const resourceName = props.task.displayName === '' ?
+    <span style={{fontFamily: 'courier, monospace'}}>
+      {props.task.name}</span> : <span>
+      {props.task.displayName}</span>;
 
-  // Display name
-  let displayName = '';
-  if (props.task.displayName === '') {
-    displayName = props.task.name;
-  } else {
-    displayName = props.task.displayName.replace(/(^\w|\s+\w){1}/g, ((str) => {
-      return str.toUpperCase();
-    }));
-  }
+
   // resource summary
   let resourceSummary = '';
   if (props.task.description.length > 120) {
@@ -130,7 +134,7 @@ const Task: React.FC<TaskProp> = (props: any) => {
         props.task.description.indexOf('\n') !== -1 ?
           props.task.description.indexOf('\n') : 120);
     if (props.task.description.indexOf('\n') > 120 ||
-     props.task.description.indexOf('\n') === -1) {
+      props.task.description.indexOf('\n') === -1) {
       resourceSummary += '...';
     }
   } else {
@@ -173,14 +177,14 @@ const Task: React.FC<TaskProp> = (props: any) => {
             <Grid>
               <GridItem span={9}>
                 <span className="task-heading">
-                  {displayName}
+                  {resourceName}
                   {/* {props.task.name[0].toUpperCase() + props.task.name.slice(1)} */}
                 </span>
               </GridItem>
               <GridItem span={1}>
 
               </GridItem>
-              <GridItem span={2}>
+              <GridItem span={2} style={{marginTop: '0.25em'}}>
                 <span style={{marginLeft: '0.4em'}}>
                   v{props.task.latestVersion}
                 </span>
@@ -199,19 +203,21 @@ const Task: React.FC<TaskProp> = (props: any) => {
 
 
             <TextContent className="text"
-              style={{marginBottom: '1em', marginLeft: '0.2em'}}>
+              style={{marginBottom: '0.5em', marginTop: '-1em', marginLeft: '0em'}}>
               Updated {diffDays}
             </TextContent>
 
             <div style={{height: '2em'}}>
               {
-                tempArr.map((tag: any) => {
-                  return (
-                    <Badge style={{
-                      marginLeft: '0.2em',
-                      marginBottom: '1em',
-                    }} key={`badge-${tag}`} className="badge">{tag}</Badge>
-                  );
+                tempArr.map((tag: any, index: number) => {
+                  if (index < 3) {
+                    return (
+                      <Badge style={{
+                        marginRight: '0.3em',
+                        marginBottom: '0.5em',
+                      }} key={`badge-${tag}`} className="badge">{tag}</Badge>
+                    );
+                  }
                 })
               }
             </div>


### PR DESCRIPTION
this patch includes

- tooltip for resource type and support tier badge in resource card.
- `courier` and `monospace` font for resource name.
- limits on number of tags in resource card.

Signed-off-by: Shiv Verma <shverma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
