### PR TITLE
Hub: fixes scroll position

### DIFF
--- a/hub/ui-new/src/components/main/App.tsx
+++ b/hub/ui-new/src/components/main/App.tsx
@@ -130,7 +130,7 @@ const App: React.FC<mainProps> = () => {
       <Page header={Header}>
         <Route exact path="/" component={BackgroundImageHeader} />
         <PageSection >
-          <Grid gutter='sm' sm={6} md={4} lg={4} xl2={1}>
+          <Grid>
             <GridItem span={12}>
               <Route exact path="/detail/:taskId"
                 component={BasicDetailParent} />

--- a/hub/ui/src/components/main/App.tsx
+++ b/hub/ui/src/components/main/App.tsx
@@ -142,7 +142,7 @@ const App: React.FC<mainProps> = () => {
       <Page header={Header}>
         <Route exact path="/" component={BackgroundImageHeader} />
         <PageSection >
-          <Grid gutter='sm' sm={6} md={4} lg={4} xl2={1}>
+          <Grid>
             <GridItem span={12}>
               <Route exact path="/detail/:taskId"
                 component={BasicDetailParent} />


### PR DESCRIPTION
Previously,on clicking resource card it's detail page
was open with scroll position at bottom and showed no content.
Now,detail page opens with scroll position at top.

Signed-off-by: Shiv Verma <shverma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
