### PR TITLE
Fix resource modified time

### DIFF
--- a/hub/api/pkg/db/model/20200731_add_modifiedat_to_resource_version.go
+++ b/hub/api/pkg/db/model/20200731_add_modifiedat_to_resource_version.go
@@ -1,0 +1,17 @@
+package model
+
+import (
+	"github.com/jinzhu/gorm"
+	"go.uber.org/zap"
+	"gopkg.in/gormigrate.v1"
+)
+
+func addModifiedAtToResourceVersion(log *zap.SugaredLogger) *gormigrate.Migration {
+
+	return &gormigrate.Migration{
+		ID: "20200731_addmodified_at_to_resourceversion",
+		Migrate: func(db *gorm.DB) error {
+			return db.AutoMigrate(&ResourceVersion{}).Error
+		},
+	}
+}

--- a/hub/api/pkg/db/model/migration.go
+++ b/hub/api/pkg/db/model/migration.go
@@ -11,7 +11,7 @@ func Migrate(db *gorm.DB, log *zap.SugaredLogger) error {
 
 	// NOTE: If writing a migration for a new table then add the same in InitSchema
 	migration := gormigrate.New(db, gormigrate.DefaultOptions, []*gormigrate.Migration{
-		// NOTE: Add Migration Here
+		addModifiedAtToResourceVersion(log),
 	})
 
 	migration.InitSchema(func(db *gorm.DB) error {

--- a/hub/api/pkg/db/model/models.go
+++ b/hub/api/pkg/db/model/models.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"time"
+
 	"github.com/jinzhu/gorm"
 )
 
@@ -56,6 +58,7 @@ type (
 		URL         string
 		Resource    Resource
 		ResourceID  uint
+		ModifiedAt  time.Time
 	}
 
 	// ResourceTag represent struct for resource_tag, needed for creating foreign key

--- a/hub/api/pkg/git/git.go
+++ b/hub/api/pkg/git/git.go
@@ -78,10 +78,7 @@ func (c *Client) Fetch(spec FetchSpec) (Repo, error) {
 		return Repo{}, err
 	}
 
-	fetchArgs := []string{
-		"fetch", "--recurse-submodules=yes", "--depth=1",
-		"origin", spec.Revision,
-	}
+	fetchArgs := []string{"fetch", "--recurse-submodules=yes", "origin", spec.Revision}
 
 	if _, err := git(log, "", fetchArgs...); err != nil {
 		// Fetch can fail if an old commitid was used so try git pull, performing regardless of error

--- a/hub/api/pkg/service/resource.go
+++ b/hub/api/pkg/service/resource.go
@@ -78,7 +78,7 @@ func (d *ResourceDetail) Init(r *model.Resource) {
 	d.DisplayName = latestVersion.DisplayName
 	d.LatestVersion = latestVersion.Version
 	d.Description = latestVersion.Description
-	d.LastUpdatedAt = latestVersion.UpdatedAt
+	d.LastUpdatedAt = latestVersion.ModifiedAt
 }
 
 // All Resources


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Previously, API sync service used to use update_at time to infer the
date a resource was last modified. The sync service also used to parse
the entire catalog if requested even if it was already parsed and
updated in DB.

This patch fixes it by exiting early if the SHA/HEAD of the catalog last
scanned is the same. It also adds a modified_at field to compute and
store the last modified time of the resource instead of relying on the
updated_at so that even if the catalog gets updated, the modified_at
still remains the same.

Signed-off-by: Sunil Thaha <sthaha@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [🙅  ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
