### PR TITLE
Using CronJobs to automatically clean up completed Runs

### DIFF
--- a/pipeline/cleanup/README.md
+++ b/pipeline/cleanup/README.md
@@ -1,0 +1,25 @@
+# Cleanup old TaskRuns and PipelineRuns
+
+Here is how users can clean up old TaskRuns and PipelineRuns.
+
+The general method is to use a CronJob to trigger a Task that deletes all but the `n` most recent PipelineRuns and `2*n` most recent TaskRuns.
+
+## Prerequisites
+
+* A Kubernetes cluster with Tekton Pipelines installed
+* Several old TaskRuns and/or PipelineRuns you wish to delete
+
+## Scheduling the cleanup job
+
+You'll need to install all the files in this directory to run the cleanup task.
+
+* [serviceaccount.yaml](serviceaccount.yaml): this creates the service account needed to run the job, along with the associated ClusterRole and Rolebinding.
+
+* [cleanup-template.yaml](cleanup-template.yaml): this creates the TriggerTemplate that spawns the TaskRun that does the deleting. It uses the `tkn` CLI to do the deleting. 
+
+* [binding.yaml](binding.yaml): this creates the TriggerBinding that is used to pass parameters to the TaskRun.
+
+* [eventlistener.yaml](eventlistener.yaml): this creates the sink that receives the incoming event that triggers the creation of the cleanup job.
+
+* [cronjob.yaml](cronjob.yaml): this is used to run the cleanup job on a schedule. There are two environmental variables that need to be set in the job: `NAMESPACE` for the namespace you wish to clean up, and `CLEANUP_KEEP` for the number of PipelineRuns to keep (the job will keep twice as many TaskRuns as this number). The schedule for the job running can be set in the `.spec.schedule` field using [crontab format](https://crontab.guru/)
+

--- a/pipeline/cleanup/binding.yaml
+++ b/pipeline/cleanup/binding.yaml
@@ -1,0 +1,10 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: cleanup-details
+spec:
+  params:
+  - name: keep
+    value: $(body.params.cleanup.keep) 
+  - name: namespace
+    value: $(body.params.target.namespace)

--- a/pipeline/cleanup/cleanup-template.yaml
+++ b/pipeline/cleanup/cleanup-template.yaml
@@ -1,0 +1,45 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: cleanup-runs
+spec:
+  params:
+  - name: namespace
+    description: Namespace to cleanup to in the target cluster
+  - name: clusterResource
+    description: Name of the cluster resource that points to the target cluster
+  - name: keep
+    description: Amount of old resources to keep
+    default: "200"
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    metadata:
+      name: cleanup-runs-$(tt.params.namespace)-$(uid)
+    spec:
+      serviceAccountName: tekton-cleaner
+      taskSpec:
+        params:
+        - name: keep
+        - name: namespace
+        steps:
+        - name: cleanup-pr-tr
+          image: gcr.io/tekton-releases/dogfooding/tkn
+          script: |
+            #!/bin/sh
+            set -ex
+            # A safety check, to avoid deleting too much!
+            if [[ $(params.keep) -eq 0 || $(params.keep) == "" ]]; then
+              echo "This task cannot be used to delete *all* resources from a cluster" >&2
+              echo "Please specifcy a value for keep > 0"
+              exit 1
+            fi
+            # Cleanup pipelineruns first, as this will delete tasksruns too
+            tkn pr delete -n $(params.namespace) --keep $(params.keep)
+            # Keep double the amount of tr, for standalone trs
+            tkn tr delete -n $(params.namespace) --keep $(( $(params.keep) * 2 ))
+      params:
+      - name: keep
+        value: $(tt.params.keep)
+      - name: namespace
+        value: $(tt.params.namespace)

--- a/pipeline/cleanup/cronjob.yaml
+++ b/pipeline/cleanup/cronjob.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cleanup-trigger
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+          - name: workspace
+            emptyDir: {}
+          containers:
+          - name: trigger
+            image: curlimages/curl
+            command:
+              - /bin/sh
+            args:
+              - -ce
+              - |
+                cat <<EOF > /workspace/post-body.json
+                {
+                  "trigger-template": "cleanup",
+                  "params": {
+                    "target": {
+                      "namespace": "$NAMESPACE"
+                    },
+                    "cleanup": {
+                        "keep": "$CLEANUP_KEEP"
+                    }
+                  }
+                }
+                EOF
+                curl -d @/workspace/post-body.json $SINK_URL
+            volumeMounts:
+            - mountPath: /workspace
+              name: workspace
+            env:
+              - name: SINK_URL
+                value: "http://el-tekton-cd.default.svc.cluster.local:8080"
+              - name: NAMESPACE
+                value: "default"
+              - name: CLEANUP_KEEP
+                value: "1"
+          restartPolicy: Never

--- a/pipeline/cleanup/eventlistener.yaml
+++ b/pipeline/cleanup/eventlistener.yaml
@@ -1,0 +1,17 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: tekton-cd
+spec:
+  serviceAccountName: tekton-cleaner
+  triggers:
+    - name: cleanup
+      interceptors:
+        - cel:
+            filter: >-
+              'trigger-template' in body &&
+              body['trigger-template'] == 'cleanup'
+      bindings:
+        - ref: cleanup-details
+      template:
+        name: cleanup-runs

--- a/pipeline/cleanup/serviceaccount.yaml
+++ b/pipeline/cleanup/serviceaccount.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-cleaner
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-cleaner
+rules:
+- apiGroups: [""]
+  resources: ["namespaces", "configmaps"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["tekton.dev"]
+  resources: ["pipelineruns", "taskruns", "pipelineresources"]
+  verbs: ["get", "list", "delete", "create"]
+- apiGroups: ["triggers.tekton.dev"]
+  resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tektoncd-cleaner-delete-pr-tr-default
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: tekton-cleaner
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-cleaner


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR fixes #479 by providing documentation on how to use a CronJob to clean up old TaskRuns / PipelineRuns. It is based on what @afrittoli implemented in [tektoncd/plumbing#442](https://github.com/tektoncd/plumbing/pull/442).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
