### PR TITLE
Hub: replace default logger in gorm with suggared logger

### DIFF
--- a/hub/api/pkg/app/app.go
+++ b/hub/api/pkg/app/app.go
@@ -112,6 +112,15 @@ func (e *ApiConfig) Addr() string {
 	return ":5000"
 }
 
+// adaptor for gorm logger interface
+type gormLogger struct {
+	*zap.SugaredLogger
+}
+
+func (l *gormLogger) Print(v ...interface{}) {
+	l.Info(v...)
+}
+
 func BaseConfigFromEnv() (*BaseConfig, error) {
 	// load from .env file but skip if not found
 	if err := godotenv.Load(); err != nil {
@@ -139,6 +148,8 @@ func BaseConfigFromEnv() (*BaseConfig, error) {
 		log.Error(err, "failed to establish database connection")
 		return nil, err
 	}
+
+	bc.db.SetLogger(&gormLogger{log})
 
 	log.Infof("Successfully connected to db %s", bc.dbConf)
 


### PR DESCRIPTION
This adds a sugared logger for gorm log which would be easy to filter
and monitor hub API usage.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
