### PR TITLE
Hub: use sha256 instead of tags

### DIFF
--- a/hub/api/config/12-db-deployment.yaml
+++ b/hub/api/config/12-db-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: db
-          image: postgres:13
+          image: postgres:13@sha256:260a98d976574b439712c35914fdcb840755233f79f3e27ea632543f78b7a21e
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5432


### PR DESCRIPTION
Previously Hub db image used postgres:13 which used to get updated
frequently and caused db to fail with the following error

```
PostgreSQL Database directory appears to contain a database; Skipping initialization

[1] FATAL:   database files are incompatible with server
[1] DETAIL:  The database cluster was initialized with CATALOG_VERSION_NO 202005171, but the server was compiled with CATALOG_VERSION_NO 202007201.
[1] HINT:    It looks like you need to initdb.
[1] LOG:     database system is shut down

```
This used to happen because the docker image used to get updated
frequently and overwrote the same tag.

Hopefully pinning down the image using its SHA should fix this 🤞.

Signed-off-by: Sunil Thaha <sthaha@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
