### PR TITLE
Support configurable secret names.

### DIFF
--- a/commit-status-tracker/README.md
+++ b/commit-status-tracker/README.md
@@ -109,7 +109,6 @@ It looks for a single `PipelineResource` of type `git` and pulls the *url* and *
 If no suitable `PipelineResource` is found, then this will be logged as an
 error, and _not_ retried.
 
-
 ## Private Git repository hosts
 
 You'll need to configure the deployment:
@@ -130,7 +129,6 @@ env:
     value: "gl.example.com=gitlab"
 ```
 
-
 If you are running with an untrusted SSL certificate, then you'll need to
 slightly tweak the command:
 
@@ -144,6 +142,11 @@ containers:
 
 This `--insecure` is the same as curl's `-k/--insecure` in that it disables TLS
 certificate verification, do not use this if you don't need to.
+
+# Customizing the secret used to authenticate requests
+
+It's possible to provide an environment variable `STATUS_TRACKER_SECRET` to
+override the default secret name which is `commit-status-tracker-git-secret`.
 
 ## Prerequisites
 

--- a/commit-status-tracker/pkg/controller/pipelinerun/pipelinerun_controller_test.go
+++ b/commit-status-tracker/pkg/controller/pipelinerun/pipelinerun_controller_test.go
@@ -58,7 +58,7 @@ func TestPipelineRunControllerPendingState(t *testing.T) {
 
 	objs := []runtime.Object{
 		pipelineRun,
-		makeSecret(map[string][]byte{"token": []byte(testToken)}),
+		makeSecret(defaultSecretName, map[string][]byte{"token": []byte(testToken)}),
 	}
 	r, data := makeReconciler(t, testRepoURL, pipelineRun, objs...)
 
@@ -95,7 +95,7 @@ func TestPipelineRunReconcileWithPreviousPending(t *testing.T) {
 			apis.Condition{Type: apis.ConditionSucceeded, Status: corev1.ConditionUnknown})))
 	objs := []runtime.Object{
 		pipelineRun,
-		makeSecret(map[string][]byte{"token": []byte(testToken)}),
+		makeSecret(defaultSecretName, map[string][]byte{"token": []byte(testToken)}),
 	}
 	r, data := makeReconciler(t, testRepoURL, pipelineRun, objs...)
 
@@ -140,7 +140,7 @@ func TestPipelineRunControllerSuccessState(t *testing.T) {
 			apis.Condition{Type: apis.ConditionSucceeded, Status: corev1.ConditionTrue})))
 	objs := []runtime.Object{
 		pipelineRun,
-		makeSecret(map[string][]byte{"token": []byte(testToken)}),
+		makeSecret(defaultSecretName, map[string][]byte{"token": []byte(testToken)}),
 	}
 	r, data := makeReconciler(t, testRepoURL, pipelineRun, objs...)
 
@@ -177,7 +177,7 @@ func TestPipelineRunControllerFailedState(t *testing.T) {
 			apis.Condition{Type: apis.ConditionSucceeded, Status: corev1.ConditionFalse})))
 	objs := []runtime.Object{
 		pipelineRun,
-		makeSecret(map[string][]byte{"token": []byte(testToken)}),
+		makeSecret(defaultSecretName, map[string][]byte{"token": []byte(testToken)}),
 	}
 	r, data := makeReconciler(t, testRepoURL, pipelineRun, objs...)
 
@@ -211,7 +211,7 @@ func TestPipelineRunReconcileNonNotifiable(t *testing.T) {
 			apis.Condition{Type: apis.ConditionSucceeded, Status: corev1.ConditionUnknown})))
 	objs := []runtime.Object{
 		pipelineRun,
-		makeSecret(map[string][]byte{"token": []byte(testToken)}),
+		makeSecret(defaultSecretName, map[string][]byte{"token": []byte(testToken)}),
 	}
 	r, data := makeReconciler(t, testRepoURL, pipelineRun, objs...)
 
@@ -243,7 +243,7 @@ func TestPipelineRunReconcileWithNoGitRepository(t *testing.T) {
 			apis.Condition{Type: apis.ConditionSucceeded, Status: corev1.ConditionUnknown})))
 	objs := []runtime.Object{
 		pipelineRun,
-		makeSecret(map[string][]byte{"token": []byte(testToken)}),
+		makeSecret(defaultSecretName, map[string][]byte{"token": []byte(testToken)}),
 	}
 	r, data := makeReconciler(t, "", pipelineRun, objs...)
 
@@ -277,7 +277,7 @@ func TestPipelineRunReconcileWithGitRepositories(t *testing.T) {
 			apis.Condition{Type: apis.ConditionSucceeded, Status: corev1.ConditionUnknown})))
 	objs := []runtime.Object{
 		pipelineRun,
-		makeSecret(map[string][]byte{"token": []byte(testToken)}),
+		makeSecret(defaultSecretName, map[string][]byte{"token": []byte(testToken)}),
 	}
 	r, data := makeReconciler(t, "", pipelineRun, objs...)
 


### PR DESCRIPTION
# Changes

Support configurable secret names.
    
This allows configuring the name of the secret to use to authenticate requests.
    
By providing an environment variable `STATUS_TRACKER_SECRET` with the name of a secret, you can override the
default `commit-status-tracker-git-secret` value with a secret name of your choice.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
