### PR TITLE
Hub: Fix console error for rating API

### DIFF
--- a/hub/ui/src/components/rating/Rating.tsx
+++ b/hub/ui/src/components/rating/Rating.tsx
@@ -41,17 +41,18 @@ const Rating: React.FC = (props: any) => {
   }
 
   // Display rating for particular user
-  if (count === 0) {
-    fetch(`${API_URL}/resource/${Number(taskId)}/rating`, {
-      method: 'GET',
-      headers: new Headers({
-        'Accept': 'application/json',
-        'Authorization': `Bearer ${localStorage.getItem('token')}`,
-      }),
-    }).then((res) => res.json()).then((response) => {
-      setStars(Number(response.rating));
-    });
-    setCount((count) => count + 1);
+  if (localStorage.getItem('token') !== null && count === 0) {
+      fetch(`${API_URL}/resource/${Number(taskId)}/rating`, {
+        method: 'GET',
+        headers: new Headers({
+          'Accept': 'application/json',
+          'Authorization': `Bearer ${localStorage.getItem('token')}`,
+        }),
+      }).then((res) => res.json()).then((response) => {
+        setStars(Number(response.rating));
+      });
+      setCount((count) => count + 1);
+    }
   }
   // for showing number of star given by user
   switch (stars) {


### PR DESCRIPTION
This fixes console error, api should be called only if the user is
authenticated, before this it was getting called every time details
page is visited.

Signed-off-by: Sunil Thaha <sthaha@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [🙅  ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
