### PR TITLE
[OCI] Drop the vendor mode in the OCI tool makefile

### DIFF
--- a/oci/Makefile
+++ b/oci/Makefile
@@ -19,26 +19,26 @@ cross: amd64 386 arm arm64 ## build cross platform binaries
 
 .PHONY: amd64
 amd64:
-	GOOS=linux GOARCH=amd64 go build -mod=vendor $(LDFLAGS) -o bin/oci-linux-amd64 ./cmd/oci
-	GOOS=windows GOARCH=amd64 go build -mod=vendor $(LDFLAGS) -o bin/oci-windows-amd64 ./cmd/oci
-	GOOS=darwin GOARCH=amd64 go build -mod=vendor $(LDFLAGS) -o bin/oci-darwin-amd64 ./cmd/oci
+	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o bin/oci-linux-amd64 ./cmd/oci
+	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o bin/oci-windows-amd64 ./cmd/oci
+	GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o bin/oci-darwin-amd64 ./cmd/oci
 
 .PHONY: 386
 386:
-	GOOS=linux GOARCH=386 go build -mod=vendor $(LDFLAGS) -o bin/oci-linux-386 ./cmd/oci
-	GOOS=windows GOARCH=386 go build -mod=vendor $(LDFLAGS) -o bin/oci-windows-386 ./cmd/oci
-	GOOS=darwin GOARCH=386 go build -mod=vendor $(LDFLAGS) -o bin/oci-darwin-386 ./cmd/oci
+	GOOS=linux GOARCH=386 go build $(LDFLAGS) -o bin/oci-linux-386 ./cmd/oci
+	GOOS=windows GOARCH=386 go build $(LDFLAGS) -o bin/oci-windows-386 ./cmd/oci
+	GOOS=darwin GOARCH=386 go build $(LDFLAGS) -o bin/oci-darwin-386 ./cmd/oci
 
 .PHONY: arm
 arm:
-	GOOS=linux GOARCH=arm go build -mod=vendor $(LDFLAGS) -o bin/oci-linux-arm ./cmd/oci
+	GOOS=linux GOARCH=arm go build $(LDFLAGS) -o bin/oci-linux-arm ./cmd/oci
 
 .PHONY: arm64
 arm64:
-	GOOS=linux GOARCH=arm64 go build -mod=vendor $(LDFLAGS) -o bin/oci-linux-arm64 ./cmd/oci
+	GOOS=linux GOARCH=arm64 go build $(LDFLAGS) -o bin/oci-linux-arm64 ./cmd/oci
 
 bin/%: cmd/% vendor FORCE
-	go build -mod=vendor $(LDFLAGS) -v -o $@ ./$<
+	go build $(LDFLAGS) -v -o $@ ./$<
 
 check: lint test
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The OCI tool makefile attempts to use the vendor folder for the
build, but there is not vendor folder, so removing that.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
