### PR TITLE
Adding cluster resource to cleanup job

### DIFF
--- a/pipeline/cleanup/README.md
+++ b/pipeline/cleanup/README.md
@@ -13,13 +13,15 @@ The general method is to use a CronJob to trigger a Task that deletes all but th
 
 You'll need to install all the files in this directory to run the cleanup task.
 
-* [serviceaccount.yaml](serviceaccount.yaml): this creates the service account needed to run the job, along with the associated ClusterRole and Rolebinding.
+* [serviceaccount.yaml](serviceaccount.yaml): this creates the service account needed to run the job, along with the associated ClusterRole and Rolebinding
 
-* [cleanup-template.yaml](cleanup-template.yaml): this creates the TriggerTemplate that spawns the TaskRun that does the deleting. It uses the `tkn` CLI to do the deleting. 
+* [cleanup-template.yaml](cleanup-template.yaml): this creates the TriggerTemplate that spawns the TaskRun that does the deleting. It uses the `tkn` CLI to do the deleting
 
-* [binding.yaml](binding.yaml): this creates the TriggerBinding that is used to pass parameters to the TaskRun.
+* [binding.yaml](binding.yaml): this creates the TriggerBinding that is used to pass parameters to the TaskRun
 
-* [eventlistener.yaml](eventlistener.yaml): this creates the sink that receives the incoming event that triggers the creation of the cleanup job.
+* [eventlistener.yaml](eventlistener.yaml): this creates the sink that receives the incoming event that triggers the creation of the cleanup job
 
-* [cronjob.yaml](cronjob.yaml): this is used to run the cleanup job on a schedule. There are two environmental variables that need to be set in the job: `NAMESPACE` for the namespace you wish to clean up, and `CLEANUP_KEEP` for the number of PipelineRuns to keep (the job will keep twice as many TaskRuns as this number). The schedule for the job running can be set in the `.spec.schedule` field using [crontab format](https://crontab.guru/)
+* [pvc.yaml](pvc.yaml): this creates a PersistentVolumeClaim to store the Kubernetes credentials
+
+* [cronjob.yaml](cronjob.yaml): this is used to run the cleanup job on a schedule 
 

--- a/pipeline/cleanup/binding.yaml
+++ b/pipeline/cleanup/binding.yaml
@@ -4,7 +4,21 @@ metadata:
   name: cleanup-details
 spec:
   params:
-  - name: keep
-    value: $(body.params.cleanup.keep) 
   - name: namespace
     value: $(body.params.target.namespace)
+  - name: keep
+    value: $(body.params.cleanup.keep)
+  - name: filename
+    value: $(body.params.auth.filename)
+  - name: name
+    value: $(body.params.auth.name)
+  - name: url
+    value: $(body.params.auth.url)
+  - name: username
+    value: $(body.params.auth.username)
+  - name: cadata
+    value: $(body.params.auth.cadata)
+  - name: clientKeyData
+    value: $(body.params.auth.clientkeydata)
+  - name: clientCertificateData
+    value: $(body.params.auth.clientcertdata)

--- a/pipeline/cleanup/cleanup-template.yaml
+++ b/pipeline/cleanup/cleanup-template.yaml
@@ -6,40 +6,102 @@ spec:
   params:
   - name: namespace
     description: Namespace to cleanup to in the target cluster
-  - name: clusterResource
-    description: Name of the cluster resource that points to the target cluster
   - name: keep
     description: Amount of old resources to keep
     default: "200"
+  - name: filename
+    description: Filename for the kubeconfig file
+    default: "kubeconfig"
+  - name: name
+    description: Name of the cluster
+  - name: url
+    description: Address of the target cluster
+  - name: username
+    description: Username for basic authentication to the cluster
+  - name: cadata
+    description: Contains PEM-encoded certificate authority certificates
+    default: ""
+  - name: clientKeyData
+    description: Contains PEM-encoded data from a client key file for TLS
+    default: ""
+  - name: clientCertificateData
+    description: Contains PEM-encoded data from a client cert file for TLS
+    default: ""
   resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
-    kind: TaskRun
+    kind: PipelineRun
     metadata:
       name: cleanup-runs-$(tt.params.namespace)-$(uid)
     spec:
       serviceAccountName: tekton-cleaner
-      taskSpec:
-        params:
-        - name: keep
-        - name: namespace
-        steps:
-        - name: cleanup-pr-tr
-          image: gcr.io/tekton-releases/dogfooding/tkn
-          script: |
-            #!/bin/sh
-            set -ex
-            # A safety check, to avoid deleting too much!
-            if [[ $(params.keep) -eq 0 || $(params.keep) == "" ]]; then
-              echo "This task cannot be used to delete *all* resources from a cluster" >&2
-              echo "Please specifcy a value for keep > 0"
-              exit 1
-            fi
-            # Cleanup pipelineruns first, as this will delete tasksruns too
-            tkn pr delete -n $(params.namespace) --keep $(params.keep)
-            # Keep double the amount of tr, for standalone trs
-            tkn tr delete -n $(params.namespace) --keep $(( $(params.keep) * 2 ))
+      pipelineSpec:
+        workspaces:
+          - name: shared-workspace
+        tasks:
+          - name: kubeconfig-creator
+            taskRef: kubeconfig-creator
+            workspaces:
+              - name: output
+                workspace: shared-workspace
+            params:
+              - name: name
+              - name: username
+              - name: url
+              - name: cadata
+              - name: clientKeyData
+              - name: clientCertificateData
+          - name: cleanup-pr-tr
+            taskSpec:
+              params:
+              - name: filename
+              - name: keep
+              - name: namespace
+              steps:
+              - name: cleanup-pr-tr
+                image: gcr.io/tekton-releases/dogfooding/tkn
+                script: |
+                  #!/bin/sh
+                  set -ex
+                  # connect to the proper cluster
+                  export KUBECONFIG="$(workspaces.input.path)/$(inputs.params.filename)"
+                  # A safety check, to avoid deleting too much!
+                  if [[ $(params.keep) -eq 0 || $(params.keep) == "" ]]; then
+                    echo "This task cannot be used to delete *all* resources from a cluster" >&2
+                    echo "Please specifcy a value for keep > 0"
+                    exit 1
+                  fi
+                  # Cleanup pipelineruns first, as this will delete tasksruns too
+                  tkn pr delete -n $(params.namespace) --keep $(params.keep)
+                  # Keep double the amount of tr, for standalone trs
+                  tkn tr delete -n $(params.namespace) --keep $(( $(params.keep) * 2 ))
+            workspaces:
+              - name: input
+                workspace: shared-workspace
+            params:
+              - name: filename
+                value: kubeconfig
+            runAfter:
+              - kubeconfig-creator
       params:
-      - name: keep
-        value: $(tt.params.keep)
-      - name: namespace
-        value: $(tt.params.namespace)
+        - name: keep
+          value: $(tt.params.keep)
+        - name: namespace
+          value: $(tt.params.namespace)
+        - name: filename
+          value: $(tt.params.filename)
+        - name: name
+          value: $(tt.params.name)
+        - name: url
+          value: $(tt.params.url)
+        - name: username
+          value: $(tt.params.username)
+        - name: cadata
+          value: $(tt.params.cadata)
+        - name: clientKeyData
+          value: $(tt.params.clientKeyData)
+        - name: clientCertificateData
+          value: $(tt.params.clientCertificateData)
+      workspaces:
+        - name: shared-workspace
+          persistentvolumeclaim:
+            claimName: kubeconfig-pvc

--- a/pipeline/cleanup/cronjob.yaml
+++ b/pipeline/cleanup/cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: cleanup-trigger
 spec:
-  schedule: "*/1 * * * *"
+  schedule: "0 12 * * *"
   jobTemplate:
     spec:
       template:
@@ -27,7 +27,15 @@ spec:
                       "namespace": "$NAMESPACE"
                     },
                     "cleanup": {
-                        "keep": "$CLEANUP_KEEP"
+                      "keep": "$CLEANUP_KEEP"
+                    }, 
+                    "auth": {
+                      "filename:" $FILENAME
+                      "name": "$NAME",
+                      "url": "$URL",
+                      "cadata": "$CA_DATA",
+                      "clientKeyData": "$CLIENT_KEY_DATA",
+                      "clientCertificateData: "$CLIENT_CERTIFICATE_DATA"
                     }
                   }
                 }
@@ -37,10 +45,20 @@ spec:
             - mountPath: /workspace
               name: workspace
             env:
-              - name: SINK_URL
-                value: "http://el-tekton-cd.default.svc.cluster.local:8080"
+              - name: URL
+                value: https://api.ci-ln-...
               - name: NAMESPACE
-                value: "default"
+                value: default
+              - name: FILENAME
+                value: kubeconfig
               - name: CLEANUP_KEEP
-                value: "1"
+                value: "5"
+              - name: NAME 
+                value: cluster-bot
+              - name: CA_DATA
+                value: LS0tLS... 
+              - name: CLIENT_KEY_DATA
+                value: LS0tLS...
+              - name: CLIENT_CERTIFICATE_DATA
+                value: LS0tLS...
           restartPolicy: Never

--- a/pipeline/cleanup/pvc.yaml
+++ b/pipeline/cleanup/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cleanup-pvc
+spec:
+  resources:
+    requests:
+      storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce

--- a/pipeline/cleanup/serviceaccount.yaml
+++ b/pipeline/cleanup/serviceaccount.yaml
@@ -22,11 +22,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tektoncd-cleaner-delete-pr-tr-default
-  namespace: default
 subjects:
 - kind: ServiceAccount
   name: tekton-cleaner
-  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

As per a [comment](https://github.com/tektoncd/experimental/pull/626#pullrequestreview-517810540) in #626 , adding the ability to select the cluster that the cleanup job runs on. It uses the [kubeconfig create task](https://github.com/tektoncd/catalog/tree/master/task/kubeconfig-creator/0.1) to select the cluster, then the existing cleanup task to do the cleanup.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
