### PR TITLE
[results] Add e2e tests.

### DIFF
--- a/results/README.md
+++ b/results/README.md
@@ -18,18 +18,16 @@ implementation of the in-cluster watcher will live in `./cmd/watcher`.
 
 ### Configure your database.
 
-The API Server requires a SQL database to connect to for result storage.
-database schema can be found under [schema/results.sql](schema/results.sql). We
-provide a MySQL server as default. To deploy the default MySQL server in Tekton,
-you need to first set the environment variable `MYSQL_ROOT_PASSWORD`, then run:
+The reference implementation of the API Server requires a SQL database for
+result storage. The database schema can be found under
+[schema/results.sql](schema/results.sql). 
 
-```
-ko apply -f config/100-mysql-pv.yaml && ko apply -f config/101-mysql-deployment.yaml
-```
+Initial one-time setup is required to configure the password and initial config:
 
-Connection parameters are
-[configured via environment variables](cmd/api/README.md). Configure these in
-the API deployment config in [config/api.yaml](config/api.yaml).
+```sh
+kubectl create secret generic tekton-results-mysql --namespace="tekton-pipelines" --from-literal=user=root --from-literal=password=$(openssl rand -base64 20)
+kubectl create configmap mysql-initdb-config --from-file="schema/results.sql" --namespace="tekton-pipelines"
+```
 
 ### Deploying
 
@@ -67,10 +65,4 @@ $ go get -u github.com/golang/protobuf/protoc-gen-go
 
 ```
 $ go generate ./proto/
-```
-
-4. Install the sqlite3
-
-```
-$ apt-get install sqlite3
 ```

--- a/results/cmd/watcher/main.go
+++ b/results/cmd/watcher/main.go
@@ -80,7 +80,8 @@ func main() {
 	defer conn.Close()
 	log.Println("connected!")
 
-	sharedmain.MainWithContext(injection.WithNamespaceScope(signals.NewContext(), ""), "watcher", func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	ctx := sharedmain.WithHADisabled(injection.WithNamespaceScope(signals.NewContext(), ""))
+	sharedmain.MainWithContext(ctx, "watcher", func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		client := pb.NewResultsClient(conn)
 		return reconciler.NewController(ctx, cmw, client)
 	})

--- a/results/config/101-mysql-deployment.yaml
+++ b/results/config/101-mysql-deployment.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     app: tekton-results-mysql
 ---
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tekton-results-mysql
@@ -29,19 +29,25 @@ spec:
       - image: mysql:5.6
         name: mysql
         env:
-          # Use secret in real usage
+        - name: MYSQL_DATABASE
+          value: results
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: <fill this in>
-              key: <fill this in>
+              name: tekton-results-mysql
+              key: password
         ports:
         - containerPort: 3306
           name: mysql
         volumeMounts:
         - name: mysql-persistent-storage
           mountPath: /var/lib/mysql
+        - name: mysql-initdb
+          mountPath: /docker-entrypoint-initdb.d
       volumes:
       - name: mysql-persistent-storage
         persistentVolumeClaim:
           claimName: results-mysql-pv-claim
+      - name: mysql-initdb
+        configMap:
+          name: mysql-initdb-config

--- a/results/config/api.yaml
+++ b/results/config/api.yaml
@@ -31,18 +31,21 @@ spec:
         env:
           # See cmd/api/README.md for documentation of these vars.
           - name: DB_USER
-            value: <fill this in>
+            valueFrom:
+              secretKeyRef:
+                name: tekton-results-mysql
+                key: user
           - name: DB_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: <fill this in>
-                key: <fill this in>
+                name: tekton-results-mysql
+                key: password
           - name: DB_PROTOCOL
-            value: <fill this in> 
+            value: tcp
           - name: DB_ADDR
-            value: <fill this in> 
+            value: tekton-results-mysql.tekton-pipelines.svc.cluster.local
           - name: DB_NAME
-            value: <fill this in> 
+            value: results
 
 ---
 

--- a/results/test/e2e/README.md
+++ b/results/test/e2e/README.md
@@ -1,0 +1,51 @@
+# Results E2E tests
+
+## Quickstart
+
+```sh
+$ ./setup.sh
+$ ./install.sh
+$ ./test.sh
+```
+
+## Dependencies
+
+- git
+- kubectl
+- ko (>= v0.6.2)
+- kind
+- jq
+
+## Scripts
+
+This folder contains several scripts, useful for testing e2e workflows:
+
+### `setup.sh`
+
+Sets up a local kind cluster, and configures your local kubectl context to use
+this environment.
+
+| Environment variable | Description              | Default               |
+| -------------------- | ------------------------ | --------------------- |
+| KIND_CLUSTER_NAME    | KIND cluster name to use | tekton-results        |
+| KIND_IMAGE           | KIND node image to use   | kindest/node:v1.17.11 |
+
+### `install.sh`
+
+Installs Tekton Pipelines and Results components. Results is always installed
+from the local repo.
+
+All components are installed to the current kubectl context
+(`kubectl config current-context`).
+
+This can safely be ran multiple times, and should be ran anytime a change is
+made to Results components.
+
+| Environment variable   | Description                                                             | Default                                                                     |
+| ---------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| KO_DOCKER_REPO         | Docker repository to use for ko                                         | kind.local                                                                  |
+| TEKTON_PIPELINE_CONFIG | Tekton Pipelines config source (anything `kubectl apply -f` compatible) | https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml |
+
+### `test.sh`
+
+Runs the test against the current kubectl context.

--- a/results/test/e2e/install.sh
+++ b/results/test/e2e/install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+export KO_DOCKER_REPO=${KO_DOCKER_REPO:-"kind.local"}
+
+ROOT="$(git rev-parse --show-toplevel)/results"
+
+echo "Installing Tekton Pipelines..."
+TEKTON_PIPELINE_CONFIG=${TEKTON_PIPELINE_CONFIG:-"https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml"}
+kubectl apply --filename ${TEKTON_PIPELINE_CONFIG}
+
+echo "Generating DB secret..."
+# Don't fail if the secret isn't created - this can happen if the secret already exists.
+kubectl create secret generic tekton-results-mysql --namespace="tekton-pipelines" --from-literal=user=root --from-literal=password=$(openssl rand -base64 20) || true
+
+echo "Generating DB init config..."
+kubectl create configmap mysql-initdb-config --from-file="${ROOT}/schema/results.sql" --namespace="tekton-pipelines" || true
+
+echo "Installing Tekton Results..."
+ko apply --filename="${ROOT}/config/"
+
+echo "Waiting for deployments to be ready..."
+kubectl wait deployment "tekton-results-mysql" --namespace="tekton-pipelines" --for="condition=available" --timeout="60s"
+kubectl wait deployment "tekton-results-api" --namespace="tekton-pipelines" --for="condition=available" --timeout="60s"
+kubectl wait deployment "tekton-results-watcher" --namespace="tekton-pipelines" --for="condition=available" --timeout="60s"

--- a/results/test/e2e/setup.sh
+++ b/results/test/e2e/setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-"tekton-results"}
+KIND_IMAGE="${KIND_IMAGE:-kindest/node:v1.17.11}"
+
+kind create cluster --name="${KIND_CLUSTER_NAME}" --image="${KIND_IMAGE}" --wait=60s
+kubectl cluster-info --context "kind-${KIND_CLUSTER_NAME}"

--- a/results/test/e2e/taskrun.yaml
+++ b/results/test/e2e/taskrun.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: hello
+spec:
+  serviceAccountName: default
+  taskSpec:
+    steps:
+      - name: hello
+        image: alpine
+        command: ["echo", "hello"]

--- a/results/test/e2e/test.sh
+++ b/results/test/e2e/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+ROOT="$(git rev-parse --show-toplevel)/results"
+TASKRUN="${DIR}/test/e2e/taskrun.yaml"
+
+kubectl delete -f "${TASKRUN}" || true
+kubectl apply -f "${TASKRUN}"
+echo "Waiting for TaskRun to complete..."
+kubectl wait -f "${TASKRUN}" --for=condition=Succeeded
+
+result_id=$(kubectl get -f "${TASKRUN}" -o json | jq -r '.metadata.annotations."results.tekton.dev/id"')
+if [[ -z "${result_id}" ]]; then
+    echo "Could not find 'results.tekton.dev/id' for ${TASKRUN}"
+    exit 1
+fi
+echo "Found result ${result_id}"
+echo "Success!"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This adds e2e tests that test basic k8s deployment and resource
annotation. Tests use kind as the execution mechanism, but could also
theoretically be ran against any k8s cluster.

Also required the following changes for the e2e tests to pass:
- Disables Knative leader election.
- Sets real values in `config/` so that services can easily be brought
  up.
- Configures mysql deployment to automatically create tables on startup.

This does not add the tests to the repo automation yet. When I tried to
run the presubmit_test.sh locally, the test hanged on the build tests.
This will require further investigation, so holding off for now.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._

/cc @dibyom 