### PR TITLE
[results] Wire up e2e tests.

### DIFF
--- a/results/test/e2e/cleanup.sh
+++ b/results/test/e2e/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export DOCKER_IN_DOCKER_ENABLED="true"
+export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-"tekton-results"}
+kind delete cluster --name=tekton-results

--- a/results/test/e2e/setup.sh
+++ b/results/test/e2e/setup.sh
@@ -15,8 +15,9 @@
 
 set -e
 
+export DOCKER_IN_DOCKER_ENABLED="true"
 export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-"tekton-results"}
 KIND_IMAGE="${KIND_IMAGE:-kindest/node:v1.17.11}"
 
-kind create cluster --name="${KIND_CLUSTER_NAME}" --image="${KIND_IMAGE}" --wait=60s
+kind create cluster --name="${KIND_CLUSTER_NAME}" --image="${KIND_IMAGE}" --wait=60s || echo "continuing anyway..."
 kubectl cluster-info --context "kind-${KIND_CLUSTER_NAME}"

--- a/results/test/e2e/test.sh
+++ b/results/test/e2e/test.sh
@@ -16,9 +16,9 @@
 set -e
 
 ROOT="$(git rev-parse --show-toplevel)/results"
-TASKRUN="${DIR}/test/e2e/taskrun.yaml"
+TASKRUN="${ROOT}/test/e2e/taskrun.yaml"
 
-kubectl delete -f "${TASKRUN}" || true
+kubectl delete -f "${TASKRUN}" || echo "continuing anyway..."
 kubectl apply -f "${TASKRUN}"
 echo "Waiting for TaskRun to complete..."
 kubectl wait -f "${TASKRUN}" --for=condition=Succeeded

--- a/results/test/presubmit-tests.sh
+++ b/results/test/presubmit-tests.sh
@@ -33,24 +33,12 @@ function pre_build_tests() {
     pushd ${TEST_FOLDER}
 }
 
+function post_build_tests() {
+    golangci-lint run
+}
+
 function pre_unit_tests() {
     pushd ${TEST_FOLDER}
-}
-
-function pre_integration_tests() {
-    pushd ${TEST_FOLDER}
-}
-
-function post_build_tests() {
-    popd
-}
-
-function post_unit_tests() {
-    popd
-}
-
-function post_integration_tests() {
-    popd
 }
 
 # June 28th 2019: work around https://github.com/tektoncd/plumbing/issues/44
@@ -60,6 +48,23 @@ function unit_tests() {
   go test -v -race ./... || failed=1
   echo "unit_tests returning $@"
   return ${failed}
+}
+
+function post_unit_tests() {
+    popd
+}
+
+function pre_integration_tests() {
+    ${TEST_FOLDER}/test/e2e/setup.sh
+    ${TEST_FOLDER}/test/e2e/install.sh
+}
+
+function integration_tests() {
+    ${TEST_FOLDER}/test/e2e/test.sh
+}
+
+function post_integration_tests() {
+    ${TEST_FOLDER}/test/e2e/cleanup.sh
 }
 
 # We use the default build, unit and integration test runners.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This enables e2e testing using kind for presubmits.

NOTE: this might fail in the real CI environment due to missing
dependencies, but we won't know for sure until it's actually ran.

Depends on fixes in #672.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
