### PR TITLE
[results] Implement v1alpha2 Create/GetResult.

### DIFF
--- a/results/go.mod
+++ b/results/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/go-cmp v0.5.2
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.1.2
-	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
+	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/smartystreets/assertions v1.1.1 // indirect
 	github.com/tektoncd/pipeline v0.17.1

--- a/results/pkg/api/server/db/errors.go
+++ b/results/pkg/api/server/db/errors.go
@@ -1,0 +1,64 @@
+package db
+
+import (
+	"errors"
+
+	"github.com/mattn/go-sqlite3"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+// WrapError converts database error codes into their corresponding gRPC status
+// codes.
+func WrapError(err error) error {
+	if err == nil {
+		return err
+	}
+
+	// Check for gorm provided errors first - these are more likely to be
+	// supported across drivers.
+	if code, ok := gormCode(err); ok {
+		return status.Error(code, err.Error())
+	}
+
+	// Fallback to implementation specific codes.
+	switch e := err.(type) {
+	case sqlite3.Error:
+		return status.Error(sqlite(e), err.Error())
+	}
+
+	return err
+}
+
+// gormCode returns gRPC status codes corresponding to gorm errors. This is not
+// an exhaustive list.
+// See https://pkg.go.dev/gorm.io/gorm@v1.20.7#pkg-variables for list of
+// errors.
+func gormCode(err error) (codes.Code, bool) {
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return codes.NotFound, true
+	}
+	return codes.Unknown, false
+}
+
+// sqlite converts sqlite3 error codes to gRPC status codes. This is not an
+// exhaustive list.
+// See https://pkg.go.dev/github.com/mattn/go-sqlite3#pkg-variables for list of
+// error codes.
+func sqlite(err sqlite3.Error) codes.Code {
+	switch err.Code {
+	case sqlite3.ErrConstraint:
+		switch err.ExtendedCode {
+		case sqlite3.ErrConstraintUnique:
+			return codes.AlreadyExists
+		}
+		return codes.InvalidArgument
+	case sqlite3.ErrNotFound:
+		return codes.NotFound
+	}
+	return status.Code(err)
+}
+
+// TODO: MySQL codes

--- a/results/pkg/api/server/test/db.go
+++ b/results/pkg/api/server/test/db.go
@@ -1,0 +1,56 @@
+package test
+
+import (
+	"database/sql"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// NewDB set up a temporary database for testing
+func NewDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	// Create a temporary file
+	tmpfile, err := ioutil.TempFile("", "testdb")
+	if err != nil {
+		t.Fatalf("failed to create temp file for db: %v", err)
+	}
+	t.Log("test database: ", tmpfile.Name())
+	t.Cleanup(func() {
+		tmpfile.Close()
+		os.Remove(tmpfile.Name())
+	})
+
+	// Connect to sqlite DB manually to load in schema.
+	db, err := sql.Open("sqlite3", tmpfile.Name())
+	if err != nil {
+		t.Fatalf("failed to open the results.db: %v", err)
+	}
+	defer db.Close()
+
+	_, b, _, _ := runtime.Caller(0)
+	basepath := filepath.Dir(b)
+	schema, err := ioutil.ReadFile(path.Join(basepath, "../../../../schema/results.sql"))
+	if err != nil {
+		t.Fatalf("failed to read schema file: %v", err)
+	}
+	// Create result table using the checked in scheme to ensure compatibility.
+	if _, err := db.Exec(string(schema)); err != nil {
+		t.Fatalf("failed to execute the result table creation statement statement: %v", err)
+	}
+
+	// Reopen DB using gorm to use all the nice gorm tools.
+	gdb, err := gorm.Open(sqlite.Open(tmpfile.Name()), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open the results.db: %v", err)
+	}
+
+	return gdb
+}

--- a/results/pkg/api/server/v1alpha1/server_test.go
+++ b/results/pkg/api/server/v1alpha1/server_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/experimental/results/pkg/api/server/test"
 	ppb "github.com/tektoncd/experimental/results/proto/pipeline/v1beta1/pipeline_go_proto"
 	pb "github.com/tektoncd/experimental/results/proto/v1alpha1/results_go_proto"
 	"google.golang.org/genproto/protobuf/field_mask"
@@ -19,7 +20,7 @@ import (
 // Test functionality of Server code
 func TestCreateResult(t *testing.T) {
 	// Create a temporay database
-	srv, err := SetupTestDB(t)
+	srv, err := New(test.NewDB(t))
 	if err != nil {
 		t.Fatalf("failed to create temp file for db: %v", err)
 	}
@@ -41,7 +42,7 @@ func TestCreateResult(t *testing.T) {
 
 func TestGetResult(t *testing.T) {
 	// Create a temporary database
-	srv, err := SetupTestDB(t)
+	srv, err := New(test.NewDB(t))
 	if err != nil {
 		t.Fatalf("failed to setup db: %v", err)
 	}
@@ -73,7 +74,7 @@ func TestGetResult(t *testing.T) {
 
 func TestUpdateResult(t *testing.T) {
 	// Create a temporary database
-	srv, err := SetupTestDB(t)
+	srv, err := New(test.NewDB(t))
 	if err != nil {
 		t.Fatalf("failed to create temp file for db: %v", err)
 	}
@@ -219,7 +220,7 @@ func TestUpdateResult(t *testing.T) {
 
 func TestDeleteResult(t *testing.T) {
 	// Create a temporay database
-	srv, err := SetupTestDB(t)
+	srv, err := New(test.NewDB(t))
 	if err != nil {
 		t.Fatalf("failed to create temp file for db: %v", err)
 	}
@@ -257,7 +258,7 @@ func TestDeleteResult(t *testing.T) {
 
 func TestListResults(t *testing.T) {
 	// Create a temporary database
-	srv, err := SetupTestDB(t)
+	srv, err := New(test.NewDB(t))
 	if err != nil {
 		t.Fatalf("failed to setup db: %v", err)
 	}

--- a/results/pkg/api/server/v1alpha2/result/result.go
+++ b/results/pkg/api/server/v1alpha2/result/result.go
@@ -1,0 +1,48 @@
+// Package result provides utilities for manipulating and validating Results.
+package result
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/tektoncd/experimental/results/pkg/api/server/db"
+	pb "github.com/tektoncd/experimental/results/proto/v1alpha2/results_go_proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	// NameRegex matches valid name specs for a Result.
+	NameRegex = regexp.MustCompile("(^[a-z0-9_-]{1,63})/results/([a-z0-9_-]{1,63}$)")
+)
+
+// ParseName splits a full Result name into its individual (parent, name)
+// components.
+func ParseName(raw string) (parent, name string, err error) {
+	s := NameRegex.FindStringSubmatch(raw)
+	if len(s) != 3 {
+		return "", "", status.Errorf(codes.InvalidArgument, "name must match %s", NameRegex.String())
+	}
+	return s[1], s[2], nil
+}
+
+// ToStorage converts an API Result into its corresponding database storage
+// equivalent.
+// parent,name should be the name parts (e.g. not containing "/results/").
+func ToStorage(parent, name string, r *pb.Result) (*db.Result, error) {
+	result := &db.Result{
+		Parent: parent,
+		ID:     r.GetId(),
+		Name:   name,
+	}
+	return result, nil
+}
+
+// ToAPI converts a database storage Result into its corresponding API
+// equivalent.
+func ToAPI(r *db.Result) *pb.Result {
+	return &pb.Result{
+		Name: fmt.Sprintf("%s/results/%s", r.Parent, r.Name),
+		Id:   r.ID,
+	}
+}

--- a/results/pkg/api/server/v1alpha2/result/result_test.go
+++ b/results/pkg/api/server/v1alpha2/result/result_test.go
@@ -1,0 +1,116 @@
+package result
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/experimental/results/pkg/api/server/db"
+	pb "github.com/tektoncd/experimental/results/proto/v1alpha2/results_go_proto"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestParseName(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		// if want is nil, assume error
+		want []string
+	}{
+		{
+			name: "simple",
+			in:   "a/results/b",
+			want: []string{"a", "b"},
+		},
+		{
+			name: "resource name reuse",
+			in:   "results/results/results",
+			want: []string{"results", "results"},
+		},
+		{
+			name: "missing name",
+			in:   "a/results/",
+		},
+		{
+			name: "missing name, no slash",
+			in:   "a/results",
+		},
+		{
+			name: "missing parent",
+			in:   "/results/b",
+		},
+		{
+			name: "missing parent, no slash",
+			in:   "results/b",
+		},
+		{
+			name: "wrong resource",
+			in:   "a/record/b",
+		},
+		{
+			name: "invalid parent",
+			in:   "a/b/results/c",
+		},
+		{
+			name: "invalid name",
+			in:   "a/results/b/c",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parent, name, err := ParseName(tc.in)
+			if err != nil {
+				if tc.want == nil {
+					// error was expected, continue
+					return
+				}
+				t.Fatal(err)
+			}
+			if tc.want == nil {
+				t.Fatalf("expected error, got: [%s, %s]", parent, name)
+			}
+
+			if parent != tc.want[0] && name != tc.want[1] {
+				t.Errorf("want: %v, got: [%s, %s]", tc.want, parent, name)
+			}
+		})
+	}
+}
+
+func TestToStorage(t *testing.T) {
+	got, err := ToStorage("foo", "bar", &pb.Result{
+		Name: "foo/results/bar",
+		Id:   "a",
+
+		// These fields are ignored for now.
+		CreatedTime: timestamppb.Now(),
+		Annotations: map[string]string{"a": "b"},
+		Etag:        "tacocat",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &db.Result{
+		Parent: "foo",
+		Name:   "bar",
+		ID:     "a",
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("-want,+got: %s", diff)
+	}
+}
+
+func TestToAPI(t *testing.T) {
+	got := ToAPI(&db.Result{
+		Parent: "foo",
+		Name:   "bar",
+		ID:     "a",
+	})
+	want := &pb.Result{
+		Name: "foo/results/bar",
+		Id:   "a",
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("-want,+got: %s", diff)
+	}
+}

--- a/results/pkg/api/server/v1alpha2/results.go
+++ b/results/pkg/api/server/v1alpha2/results.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"context"
+
+	"github.com/tektoncd/experimental/results/pkg/api/server/db"
+	"github.com/tektoncd/experimental/results/pkg/api/server/v1alpha2/result"
+	pb "github.com/tektoncd/experimental/results/proto/v1alpha2/results_go_proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// CreateResult creates a new result in the database.
+func (s *Server) CreateResult(ctx context.Context, req *pb.CreateResultRequest) (*pb.Result, error) {
+	r := req.GetResult()
+
+	// Validate the incoming request
+	parent, name, err := result.ParseName(r.GetName())
+	if err != nil {
+		return nil, err
+	}
+	if req.GetParent() != parent {
+		return nil, status.Error(codes.InvalidArgument, "requested parent does not match resource name")
+	}
+
+	// Populate Result with server provided fields.
+	r.Id = uid()
+
+	store, err := result.ToStorage(parent, name, req.GetResult())
+	if err != nil {
+		return nil, err
+	}
+	if err := db.WrapError(s.db.WithContext(ctx).Create(store).Error); err != nil {
+		return nil, err
+	}
+
+	return result.ToAPI(store), nil
+}
+
+// GetResult returns a single Result.
+func (s *Server) GetResult(ctx context.Context, req *pb.GetResultRequest) (*pb.Result, error) {
+	parent, name, err := result.ParseName(req.GetName())
+	if err != nil {
+		return nil, err
+	}
+	store := &db.Result{}
+	q := s.db.WithContext(ctx).
+		Where(&db.Result{Parent: parent, Name: name}).
+		First(store)
+	if err := db.WrapError(q.Error); err != nil {
+		return nil, err
+	}
+	return result.ToAPI(store), nil
+}

--- a/results/pkg/api/server/v1alpha2/results_test.go
+++ b/results/pkg/api/server/v1alpha2/results_test.go
@@ -1,0 +1,142 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/experimental/results/pkg/api/server/test"
+	pb "github.com/tektoncd/experimental/results/proto/v1alpha2/results_go_proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+var (
+	// Used for deterministically increasing UUID generation.
+	lastID = uint32(0)
+)
+
+func TestMain(m *testing.M) {
+	uid = func() string {
+		return fmt.Sprint(atomic.AddUint32(&lastID, 1))
+	}
+	os.Exit(m.Run())
+}
+
+func TestCreateResult(t *testing.T) {
+	srv, err := New(test.NewDB(t))
+	if err != nil {
+		t.Fatalf("failed to create temp file for db: %v", err)
+	}
+
+	ctx := context.Background()
+	req := &pb.CreateResultRequest{
+		Parent: "foo",
+		Result: &pb.Result{
+			Name: "foo/results/bar",
+		},
+	}
+	t.Run("success", func(t *testing.T) {
+		got, err := srv.CreateResult(ctx, req)
+		if err != nil {
+			t.Fatalf("could not create result: %v", err)
+		}
+		want := proto.Clone(req.GetResult()).(*pb.Result)
+		want.Id = fmt.Sprint(lastID)
+		if diff := cmp.Diff(got, want, protocmp.Transform()); diff != "" {
+			t.Errorf("-want, +got: %s", diff)
+		}
+	})
+
+	// Errors
+	for _, tc := range []struct {
+		name string
+		req  *pb.CreateResultRequest
+		want codes.Code
+	}{
+		{
+			name: "mismatched parent",
+			req: &pb.CreateResultRequest{
+				Parent: "foo",
+				Result: &pb.Result{
+					Name: "baz/results/bar",
+				},
+			},
+			want: codes.InvalidArgument,
+		},
+		{
+			name: "missing name",
+			req: &pb.CreateResultRequest{
+				Parent: "foo",
+				Result: &pb.Result{},
+			},
+			want: codes.InvalidArgument,
+		},
+		{
+			name: "already exists",
+			req:  req,
+			want: codes.AlreadyExists,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := srv.CreateResult(ctx, tc.req); status.Code(err) != tc.want {
+				t.Fatalf("want: %v, got: %v - %+v", tc.want, status.Code(err), err)
+			}
+		})
+	}
+}
+
+func TestGetResult(t *testing.T) {
+	srv, err := New(test.NewDB(t))
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+
+	ctx := context.Background()
+	create, err := srv.CreateResult(ctx, &pb.CreateResultRequest{
+		Parent: "foo",
+		Result: &pb.Result{
+			Name: "foo/results/bar",
+		},
+	})
+	if err != nil {
+		t.Fatalf("could not create result: %v", err)
+	}
+
+	get, err := srv.GetResult(ctx, &pb.GetResultRequest{Name: create.GetName()})
+	if err != nil {
+		t.Fatalf("could not get result: %v", err)
+	}
+	if diff := cmp.Diff(create, get, protocmp.Transform()); diff != "" {
+		t.Errorf("-want, +got: %s", diff)
+	}
+
+	// Errors
+	for _, tc := range []struct {
+		name string
+		req  *pb.GetResultRequest
+		want codes.Code
+	}{
+		{
+			name: "no name",
+			req:  &pb.GetResultRequest{},
+			want: codes.InvalidArgument,
+		},
+		{
+			name: "not found",
+			req:  &pb.GetResultRequest{Name: "a/results/doesnotexist"},
+			want: codes.NotFound,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := srv.GetResult(ctx, tc.req); status.Code(err) != tc.want {
+				t.Fatalf("want: %v, got: %v - %+v", tc.want, status.Code(err), err)
+			}
+		})
+	}
+}

--- a/results/pkg/api/server/v1alpha2/server.go
+++ b/results/pkg/api/server/v1alpha2/server.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+	"github.com/google/uuid"
+	pb "github.com/tektoncd/experimental/results/proto/v1alpha2/results_go_proto"
+	"gorm.io/gorm"
+)
+
+var (
+	uid = func() string {
+		return uuid.New().String()
+	}
+)
+
+// Server with implementation of API server
+type Server struct {
+	pb.UnimplementedResultsServer
+	db *gorm.DB
+}
+
+// New set up environment for the api server
+func New(db *gorm.DB) (*Server, error) {
+	srv := &Server{
+		db: db,
+	}
+	return srv, nil
+}

--- a/results/pkg/watcher/reconciler/internal/test/clients.go
+++ b/results/pkg/watcher/reconciler/internal/test/clients.go
@@ -5,10 +5,11 @@ import (
 	"net"
 	"testing"
 
+	"github.com/tektoncd/experimental/results/pkg/api/server/test"
 	server "github.com/tektoncd/experimental/results/pkg/api/server/v1alpha1"
 	pb "github.com/tektoncd/experimental/results/proto/v1alpha1/results_go_proto"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
-	"github.com/tektoncd/pipeline/test"
+	pipelinetest "github.com/tektoncd/pipeline/test"
 	"google.golang.org/grpc"
 	"knative.dev/pkg/configmap"
 )
@@ -18,7 +19,7 @@ const (
 )
 
 func NewResultsClient(t *testing.T) pb.ResultsClient {
-	srv, err := server.SetupTestDB(t)
+	srv, err := server.New(test.NewDB(t))
 	if err != nil {
 		t.Fatalf("Failed to create fake server: %v", err)
 	}
@@ -41,10 +42,10 @@ func NewResultsClient(t *testing.T) pb.ResultsClient {
 	return pb.NewResultsClient(conn)
 }
 
-func GetFakeClients(t *testing.T, d test.Data, client pb.ResultsClient) (context.Context, test.Clients, *configmap.InformedWatcher) {
+func GetFakeClients(t *testing.T, d pipelinetest.Data, client pb.ResultsClient) (context.Context, pipelinetest.Clients, *configmap.InformedWatcher) {
 	t.Helper()
 	ctx, _ := ttesting.SetupFakeContext(t)
-	clients, _ := test.SeedTestData(t, ctx, d)
+	clients, _ := pipelinetest.SeedTestData(t, ctx, d)
 	cmw := configmap.NewInformedWatcher(clients.Kube, "")
 	return ctx, clients, cmw
 }

--- a/results/schema/results.sql
+++ b/results/schema/results.sql
@@ -8,7 +8,7 @@ CREATE TABLE results (
 
 	PRIMARY KEY(parent, id)
 );
-CREATE UNIQUE INDEX resultsByName ON results(parent, name);
+CREATE UNIQUE INDEX results_by_name ON results(parent, name);
 
 CREATE TABLE records (
 	parent varchar(64),
@@ -21,4 +21,4 @@ CREATE TABLE records (
 
 	PRIMARY KEY(parent, result_id, id)
 );
-CREATE UNIQUE INDEX recordsByName ON records(parent, result_name, name);
+CREATE UNIQUE INDEX records_by_name ON records(parent, result_name, name);


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Implements the CreateResult and GetResult methods of the v1alpha2
interface.

Includes request validation, and some basic error handling.
Unfortunately since SQL error codes are somewhat impl specific, we will
need to do some additional work to fill out error handling (particularly
for MySQL). For now, focus on gorm/sqlite errors for unit testing.


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
