### PR TITLE
[results] Implements the ETAG to solve the race condition problem

### DIFF
--- a/results/pkg/watcher/reconciler/pipelinerun/pipelinerun_test.go
+++ b/results/pkg/watcher/reconciler/pipelinerun/pipelinerun_test.go
@@ -119,6 +119,7 @@ func (tt *PipelineRunTest) testUpdatePipelineRun(t *testing.T) {
 		Executions: []*pb.Execution{{
 			Execution: &pb.Execution_PipelineRun{p},
 		}},
+		Etag: res.Etag,
 	}
 	if diff := cmp.Diff(want, res, protocmp.Transform()); diff != "" {
 		t.Fatalf("Expected completed PipelineRun should be upated in api server: %v", diff)

--- a/results/pkg/watcher/reconciler/reconciler_test.go
+++ b/results/pkg/watcher/reconciler/reconciler_test.go
@@ -119,6 +119,7 @@ func testUpdatePipelineRunToTheExistedResult(t *testing.T) {
 	}
 
 	want := trResult
+	want.Etag = prResult.Etag
 	want.Executions = append(want.Executions, &pb.Execution{Execution: &pb.Execution_PipelineRun{prProto}})
 	if diff := cmp.Diff(want, prResult, protocmp.Transform()); diff != "" {
 		t.Fatalf("Expected completed PipelineRun should be upated in api server: %v", diff)
@@ -166,6 +167,7 @@ func testUpdateTaskRunToTheExistedResult(t *testing.T) {
 	}
 
 	want := prResult
+	want.Etag = trResult.Etag
 	want.Executions = append(want.Executions, &pb.Execution{Execution: &pb.Execution_TaskRun{trProto}})
 	if diff := cmp.Diff(want, trResult, protocmp.Transform()); diff != "" {
 		t.Fatalf("Expected completed TaskRun should be upated in api server: %v", diff)

--- a/results/pkg/watcher/reconciler/taskrun/taskrun_test.go
+++ b/results/pkg/watcher/reconciler/taskrun/taskrun_test.go
@@ -119,6 +119,7 @@ func (tt *TaskRunTest) testUpdateTaskRun(t *testing.T) {
 		Executions: []*pb.Execution{{
 			Execution: &pb.Execution_TaskRun{p},
 		}},
+		Etag: res.Etag,
 	}
 	if diff := cmp.Diff(want, res, protocmp.Transform()); diff != "" {
 		t.Fatalf("Expected completed TaskRun should be upated in api server: %v", diff)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
There might be multiple update requests for one result in the same period, which could lead to the race condition problem.

To avoid that, we need to make sure the result in our update request untouched before being updated to the database.  We achieve this by the `etag`. A valid update request must carry the ETag of the result that to be updated. We encode the serialized result to a string as its etag.

The etag is like a summary of a result's content. Once the content changed, the etag would be different. Check [here](https://developers.google.com/gdata/docs/2.0/reference#ResourceVersioning) for more information.

Closes #616 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
