### PR TITLE
Concurrency support for task looping

### DIFF
--- a/task-loops/README.md
+++ b/task-loops/README.md
@@ -14,6 +14,8 @@ This is an **_experimental feature_**.  The purpose is to explore potential use 
 
 ## Install
 
+The Task Loop Extension does not have any published releases.  You can build and deploy it using [`ko`](https://github.com/google/ko).
+
 ## Usage
 
 Two resources are required to run a Task in a loop:
@@ -35,6 +37,7 @@ A `TaskLoop` definition supports the following fields:
 - Optional:
   - [`timeout`](#specifying-a-timeout) - Specifies a timeout for the execution of a `Task`.
   - [`retries`](#specifying-retries) - Specifies the number of times to retry the execution of a `Task` after a failure.
+  - [`concurrency`](#specifying-concurrency) - Specifies the number of `TaskRuns` that are allowed to run concurrently.
 
 The example below shows a basic `TaskLoop`:
 
@@ -160,8 +163,13 @@ for more information about how `TaskRun` processes the timeout.
 
 #### Specifying retries
 
-You can specify the number of times to retry the execution of a `Task` when it fails.
+You can use the `retries` field to specify the number of times to retry the execution of a `Task` when it fails.
 If you don't explicitly specify a value, no retry is performed.
+
+#### Specifying concurrency
+
+You can use the `concurrency` field to specify the number of `TaskRuns` that are allowed to run concurrently.
+The default is 1.  If you specify 0 or a negative value, then the `TaskRuns` for all iterations are allowed to run concurrently.
 
 ### Configuring a `Run`
 
@@ -262,8 +270,6 @@ These limitations may be addressed in future issues based on community feedback.
 
 * The value of only one `Task` parameter can be varied between `TaskRun` executions.
 
-* Each `TaskRun` is executed sequentially.  The second `TaskRun` is created only after the first `TaskRun` completes, and so on.
-
 * If a `TaskRun` fails, the execution of the `TaskLoop` stops.  `TaskRun`s for remaining iteration values are not created.
 
 * `Task` results are not collected into `Run` results (`run.status.results`).
@@ -274,6 +280,8 @@ These limitations may be addressed in future issues based on community feedback.
 * There are no metrics specific to `Run`.
 
 ## Uninstall
+
+Use the command `kubectl delete -f config\` to delete the Kubernetes resources for this project.
 
 ## Want to get involved?
 

--- a/task-loops/pkg/apis/taskloop/v1alpha1/taskloop_types.go
+++ b/task-loops/pkg/apis/taskloop/v1alpha1/taskloop_types.go
@@ -57,6 +57,10 @@ type TaskLoopSpec struct {
 	// Retries represents how many times a task should be retried in case of task failure.
 	// +optional
 	Retries int `json:"retries,omitempty"`
+
+	// Concurrency represents how many tasks can be running at the same time.
+	// +optional
+	Concurrency *int `json:"concurrency,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/task-loops/pkg/apis/taskloop/v1alpha1/zz_generated.deepcopy.go
+++ b/task-loops/pkg/apis/taskloop/v1alpha1/zz_generated.deepcopy.go
@@ -140,6 +140,11 @@ func (in *TaskLoopSpec) DeepCopyInto(out *TaskLoopSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.Concurrency != nil {
+		in, out := &in.Concurrency, &out.Concurrency
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Add support for TaskRuns to run in parallel.

# Changes

A new field called concurrency is added to the TaskLoop CRD. It allows you to control the number of TaskRuns that can run in parallel. The default is 1.  If you specify 0 or a negative value, then the TaskRuns for all iterations are allowed to run concurrently.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
