### PR TITLE
[task-loops] Fix nightly release

### DIFF
--- a/task-loops/tekton/publish.yaml
+++ b/task-loops/tekton/publish.yaml
@@ -12,6 +12,11 @@ spec:
     description: The vX.Y.Z version that the artifacts should be tagged with (including `v`)
   - name: imageRegistry
     description: The target image registry
+  - name: imageRegistryPath
+    description: The path (project) in the image registry
+  - name: imageRegistryRegions
+    description: The target image registry regions
+    default: "us eu asia"
   - name: releaseAsLatest
     description: Whether to tag and publish this release as Pipelines' latest
   - name: platforms
@@ -32,10 +37,12 @@ spec:
         value: "/workspace/go/src/$(params.package)"
       - name: "PROJECT_ROOT"
         value: "/workspace/go/src/$(params.package)/$(params.subfolder)"
+      - name: CONTAINER_REGISTRY
+        value: "$(params.imageRegistry)/$(params.imageRegistryPath)"
       - name: CONTAINER_REGISTY_CREDENTIALS
         value: "$(workspaces.release-secret.path)/$(params.serviceAccountPath)"
       - name: REGIONS
-        value: "us eu asia"
+        value: "$(params.imageRegistryRegions)"
   steps:
 
   - name: create-ko-yaml
@@ -60,15 +67,15 @@ spec:
       #!/busybox/sh
       set -ex
 
-      # Login to gcr.io
+      # Login to $(params.imageRegistry)
       DOCKER_CONFIG=$(cat ${CONTAINER_REGISTY_CREDENTIALS} | \
-        crane auth login -u _json_key --password-stdin gcr.io 2>&1 | \
+        crane auth login -u _json_key --password-stdin (params.imageRegistry) 2>&1 | \
         sed 's,^.*logged in via \(.*\)$,\1,g')
 
       # Auth with account credentials for all regions.
       for region in ${REGIONS}
       do
-        HOSTNAME=${region}.gcr.io
+        HOSTNAME=${region}.$(params.imageRegistry)
         cat ${CONTAINER_REGISTY_CREDENTIALS} | crane auth login -u _json_key --password-stdin ${HOSTNAME}
       done
       cp ${DOCKER_CONFIG} /workspace/docker-config.json
@@ -77,7 +84,7 @@ spec:
     image: gcr.io/tekton-releases/dogfooding/ko:latest
     env:
     - name: KO_DOCKER_REPO
-      value: $(params.imageRegistry)
+      value: $(params.imageRegistry)/$(params.imageRegistryPath)
     - name: GOPATH
       value: /workspace/go
     - name: GO111MODULE
@@ -129,7 +136,7 @@ spec:
     script: |
       set -ex
 
-      IMAGES_PATH=$(params.imageRegistry)/$(params.package)
+      IMAGES_PATH=${CONTAINER_REGISTRY}/$(params.package)
       if [ "$(params.subfolder)" != "" ]; then
         IMAGES_PATH=${IMAGES_PATH}/$(params.subfolder)
       fi

--- a/task-loops/tekton/release-pipeline.yaml
+++ b/task-loops/tekton/release-pipeline.yaml
@@ -14,7 +14,9 @@ spec:
   - name: gitRevision
     description: the git revision to release
   - name: imageRegistry
-    default: gcr.io/tekton-nightly
+    default: gcr.io
+  - name: imageRegistryPath
+    description: The path (project) in the image registry
   - name: versionTag
     description: The X.Y.Z version that the artifacts should be tagged with
   - name: releaseBucket
@@ -97,6 +99,8 @@ spec:
           value: $(params.versionTag)
         - name: imageRegistry
           value: $(params.imageRegistry)
+        - name: imageRegistryPath
+          value: $(params.imageRegistryPath)
         - name: releaseAsLatest
           value: $(params.releaseAsLatest)
         - name: platforms


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The image registry params has been split on imageRegistry +
imageRegistryPath. That allows for using imageRegistry in
the auth part and to align with pipeline builds.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
