### PR TITLE
[pipelines-in-pipelines]: the new created pr should has ownerref as the Run

### DIFF
--- a/pipelines-in-pipelines/pkg/reconciler/pip/piprun.go
+++ b/pipelines-in-pipelines/pkg/reconciler/pip/piprun.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"time"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -36,8 +39,6 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
-	"reflect"
-	"time"
 )
 
 const (
@@ -195,7 +196,7 @@ func getObjectMeta(run *v1alpha1.Run) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Name:            run.Name,
 		Namespace:       run.Namespace,
-		OwnerReferences: run.OwnerReferences,
+		OwnerReferences: []metav1.OwnerReference{run.GetOwnerReference()},
 		Labels:          getPipelineRunLabels(run),
 		Annotations:     getPipelineRunAnnotations(run),
 	}

--- a/pipelines-in-pipelines/pkg/reconciler/pip/piprun_test.go
+++ b/pipelines-in-pipelines/pkg/reconciler/pip/piprun_test.go
@@ -19,6 +19,10 @@ package pip
 import (
 	"context"
 	"fmt"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/experimental/pipelines-in-pipelines/test"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -28,6 +32,7 @@ import (
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ktesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
@@ -36,9 +41,6 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
-	"strings"
-	"testing"
-	"time"
 )
 
 func getPipController(t *testing.T, d test.Data) (test.Assets, func()) {
@@ -187,6 +189,8 @@ var p = &v1beta1.Pipeline{
 	},
 }
 
+var blockOwnerDeletion = true
+var isController = true
 var pr = &v1beta1.PipelineRun{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "run-with-pipeline",
@@ -194,6 +198,15 @@ var pr = &v1beta1.PipelineRun{
 		Labels: map[string]string{
 			"tekton.dev/pipeline": "pipeline",
 			"tekton.dev/run":      "run-with-pipeline",
+		},
+		OwnerReferences: []v1.OwnerReference{
+			{
+				APIVersion:         "tekton.dev/v1alpha1",
+				Kind:               "Run",
+				Name:               "run-with-pipeline",
+				Controller:         &isController,
+				BlockOwnerDeletion: &blockOwnerDeletion,
+			},
 		},
 		Annotations: map[string]string{},
 	},


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
In current implements, when create the new `pr`, its `OwnerReferences` is set to the original `pr`.
https://github.com/tektoncd/experimental/blob/ff79df0f529c229e85df93ae9cb1120d31c8455c/pipelines-in-pipelines/pkg/reconciler/pip/piprun.go#L198

The `Run`'s ownerRef, which means the original PR who created the Run.

But the `controller` will trigger by `pipelinerun informer` and with `Run` as it's `OwnerReferences`, see:
https://github.com/tektoncd/experimental/blob/ff79df0f529c229e85df93ae9cb1120d31c8455c/pipelines-in-pipelines/pkg/reconciler/pip/controller.go#L68-L71

In my case, my new created `pr` cost about 5m to complete, then the `Run`'s state keep as `unkonw` and original `pr` keep running forever. 


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
