### PR TITLE
Pipelines in Pipelines: Propagate Results

### DIFF
--- a/pipelines-in-pipelines/examples/run-with-pipeline-with-results.yaml
+++ b/pipelines-in-pipelines/examples/run-with-pipeline-with-results.yaml
@@ -1,0 +1,28 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: hello-world
+spec:
+  results:
+    - name: message
+      value: $(tasks.generate-hello-world.results.message)
+  tasks:
+    - name: generate-hello-world
+      taskSpec:
+        results:
+          - name: message
+        steps:
+          - name: generate-message
+            image: alpine
+            script: |
+              echo -n "Hello World!" > $(results.message.path)
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Run
+metadata:
+  generateName: piprun-
+spec:
+  ref:
+    apiVersion: tekton.dev/v1beta1
+    kind: Pipeline
+    name: hello-world


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This project provides `Custom Task` / `Runs` that execute `PipelineRuns`,
which enables users to configure `Pipelines` in `Pipelines`

This change propagates `PipelineResults` from the `PipelineRun` to the
`Run` that created it - it maps `PipelineResults` to `RunResult`

Propagating `Results` ensures that they can be reused in the `Run` and
in subsequent `Tasks` if configured as a `Pipeline` in a `Pipeline`

Closes https://github.com/tektoncd/experimental/issues/732

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
