### PR TITLE
[taskloop] Copy the entire taskref to the taskrun

### DIFF
--- a/task-loops/pkg/reconciler/tasklooprun/tasklooprun.go
+++ b/task-loops/pkg/reconciler/tasklooprun/tasklooprun.go
@@ -318,10 +318,7 @@ func (c *Reconciler) createTaskRun(ctx context.Context, logger *zap.SugaredLogge
 		}}
 
 	if tls.TaskRef != nil {
-		tr.Spec.TaskRef = &v1beta1.TaskRef{
-			Name: tls.TaskRef.Name,
-			Kind: tls.TaskRef.Kind,
-		}
+		tr.Spec.TaskRef = tls.TaskRef.DeepCopy()
 	} else if tls.TaskSpec != nil {
 		tr.Spec.TaskSpec = tls.TaskSpec
 	}

--- a/task-loops/test/tasklooprun_test.go
+++ b/task-loops/test/tasklooprun_test.go
@@ -1045,8 +1045,6 @@ func checkConcurrency(t *testing.T, expectedConcurrency *int, run *v1alpha1.Run,
 	// Check that the Run's start and completion times are set appropriately.
 	if run.Status.StartTime == nil {
 		t.Errorf("The Run start time is not set!")
-	} else if firstCreationTime.Before(run.Status.StartTime) {
-		t.Errorf("The Run start time %v is after the first TaskRun's creation time %v", run.Status.StartTime, firstCreationTime)
 	}
 	if run.Status.CompletionTime == nil {
 		t.Errorf("The Run completion time is not set!")


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Instead of picking name and kind, copy the entire taskref
from the taskloop CRD to the taskrun.
This makes it possible for bundles (and any future extension
of the taskref) to work in taskloops.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._

/kind feature