### PR TITLE
[cel] install from nightly release

### DIFF
--- a/cel/README.md
+++ b/cel/README.md
@@ -29,6 +29,12 @@ NAME                              READY   STATUS    RESTARTS   AGE
 cel-controller-654bdc4cc8-7bvvn   1/1     Running   0          3m4s
 ```
 
+Alternatively, install it from the nightly release using:
+
+```commandline
+kubectl apply --filename https://storage.cloud.google.com/tekton-releases-nightly/cel/latest/release.yaml
+```
+
 ## Usage
 
 To evaluate a CEL expressions using `Custom Tasks`, we need to define a [`Run`](https://github.com/tektoncd/pipeline/blob/master/docs/runs.md)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Users have been installing `ko` and using it to build and install the
controller on their clusters

We now have a Cron Job that builds a nightly release
https://github.com/tektoncd/plumbing/tree/main/tekton/cronjobs/dogfooding/releases/cel-nightly

This change adds documentation for installing from the nightly release

/kind documentation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
