### PR TITLE
[cloudevents] use cde events for taskrun/pipelinerun start,finish

### DIFF
--- a/cloudevents/go.mod
+++ b/cloudevents/go.mod
@@ -3,9 +3,12 @@ module github.com/tektoncd/experimental/cloudevents
 go 1.15
 
 require (
-	github.com/cloudevents/sdk-go/v2 v2.1.0
+	github.com/cdfoundation/sig-events v0.0.0-20210615132203-8e93cb616045 // indirect
+	github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210615132203-8e93cb616045
+	github.com/cloudevents/sdk-go/v2 v2.3.1
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-containerregistry v0.5.1 // indirect
+	github.com/google/uuid v1.2.0
 	github.com/tektoncd/pipeline v0.24.3
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2

--- a/cloudevents/go.mod
+++ b/cloudevents/go.mod
@@ -3,7 +3,6 @@ module github.com/tektoncd/experimental/cloudevents
 go 1.15
 
 require (
-	github.com/cdfoundation/sig-events v0.0.0-20210615132203-8e93cb616045 // indirect
 	github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210615132203-8e93cb616045
 	github.com/cloudevents/sdk-go/v2 v2.3.1
 	github.com/google/go-cmp v0.5.5

--- a/cloudevents/go.sum
+++ b/cloudevents/go.sum
@@ -24,6 +24,7 @@ cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4g
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
+cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
@@ -130,6 +131,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
@@ -139,6 +141,10 @@ github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/c2h5oh/datasize v0.0.0-20171227191756-4eba002a5eae/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
+github.com/cdfoundation/sig-events v0.0.0-20210615132203-8e93cb616045 h1:2wbEGnNRUEz0OTZHGOr25pviWBGz9trQRrG8yx2wgmk=
+github.com/cdfoundation/sig-events v0.0.0-20210615132203-8e93cb616045/go.mod h1:tEGEsD1OcV+voUc0zdDfaR1JonqgphtYSPVlCkcCa8M=
+github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210615132203-8e93cb616045 h1:7OxBfPTKazzqkATM4vnqXC8CBdzsDuIKial39YilRjw=
+github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210615132203-8e93cb616045/go.mod h1:xghRV+aIAccdyXaxtjeIxY/JhE8jrnEzBI6Ut+ZVS2Y=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0 h1:t/LhUZLVitR1Ow2YOnduCsavhwFUklBMoGVYUCqmCqk=
@@ -155,6 +161,8 @@ github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudevents/sdk-go/v2 v2.1.0 h1:bmgrU8k+K2ppZ+G/q5xEQx/Xk9HRtJmkrEO3qtDO2k0=
 github.com/cloudevents/sdk-go/v2 v2.1.0/go.mod h1:3CTrpB4+u7Iaj6fd7E2Xvm5IxMdRoaAhqaRVnOr2rCU=
+github.com/cloudevents/sdk-go/v2 v2.3.1 h1:QRTu0yRA4FbznjRSds0/4Hy6cVYpWV2wInlNJSHWAtw=
+github.com/cloudevents/sdk-go/v2 v2.3.1/go.mod h1:4fO2UjPMYYR1/7KPJQCwTPb0lFA8zYuitkUpAZFSY1Q=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
@@ -165,6 +173,7 @@ github.com/containerd/stargz-snapshotter/estargz v0.4.1 h1:5e7heayhB7CcgdTkqfZqr
 github.com/containerd/stargz-snapshotter/estargz v0.4.1/go.mod h1:x7Q9dg9QYb4+ELgxmo4gBUeJB0tl5dqH1Sdz0nJU1QM=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -429,7 +438,9 @@ github.com/grpc-ecosystem/grpc-gateway v1.14.6/go.mod h1:zdiPV4Yse/1gnckTHtghG4G
 github.com/grpc-ecosystem/grpc-gateway v1.14.8 h1:hXClj+iFpmLM8i3lkO6i4Psli4P2qObQuQReiII26U8=
 github.com/grpc-ecosystem/grpc-gateway v1.14.8/go.mod h1:NZE8t6vs6TnwLL/ITkaK8W3ecMLGAbh2jXTclvpiwYo=
 github.com/h2non/gock v1.0.9/go.mod h1:CZMcB0Lg5IWnr9bF79pPMg9WeV6WumxQiUJ1UvdO1iE=
+github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
+github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -451,6 +462,7 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
@@ -463,6 +475,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/tdigest v0.0.0-20180711151920-a7d76c6f093a/go.mod h1:9GkyshztGufsdPQWjH+ifgnIr3xNUL5syI70g2dzU1o=
@@ -513,6 +526,8 @@ github.com/lightstep/tracecontext.go v0.0.0-20181129014701-1757c391b1ac h1:+2b6i
 github.com/lightstep/tracecontext.go v0.0.0-20181129014701-1757c391b1ac/go.mod h1:Frd2bnT3w5FB5q49ENTfVlztJES+1k/7lyWX2+9gq/M=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
+github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -540,6 +555,7 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -612,6 +628,7 @@ github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIw
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
+github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -673,6 +690,7 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -692,11 +710,16 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
+github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v1.1.1 h1:KfztREH0tPxJJ+geloSLaAkaPkr4ki2Er5quFV1TDo4=
+github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
+github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -705,6 +728,9 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
+github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
+github.com/spf13/viper v1.7.1 h1:pM5oEahlgWv/WnHXpgbKz7iLIxRf65tye2Ci+XFK5sk=
+github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
@@ -720,6 +746,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
+github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tektoncd/pipeline v0.24.3 h1:hfMDwkAa5D4BMKUI0ojivXa1Vw5ls+N3KROtwK8sNd0=
 github.com/tektoncd/pipeline v0.24.3/go.mod h1:8yXwJvaRU+cDH6fjwJFvKFOnB/WYHrRUD66TTR7l1eg=
 github.com/tektoncd/plumbing v0.0.0-20210514044347-f8a9689d5bd5/go.mod h1:WTWwsg91xgm+jPOKoyKVK/yRYxnVDlUYeDlypB1lDdQ=
@@ -1018,6 +1046,7 @@ golang.org/x/tools v0.0.0-20191010075000-0337d82405ff/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191118222007-07fc4c7f2b98/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -1187,6 +1216,8 @@ gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=
+gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/cloudevents/go.sum
+++ b/cloudevents/go.sum
@@ -141,8 +141,6 @@ github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/c2h5oh/datasize v0.0.0-20171227191756-4eba002a5eae/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/cdfoundation/sig-events v0.0.0-20210615132203-8e93cb616045 h1:2wbEGnNRUEz0OTZHGOr25pviWBGz9trQRrG8yx2wgmk=
-github.com/cdfoundation/sig-events v0.0.0-20210615132203-8e93cb616045/go.mod h1:tEGEsD1OcV+voUc0zdDfaR1JonqgphtYSPVlCkcCa8M=
 github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210615132203-8e93cb616045 h1:7OxBfPTKazzqkATM4vnqXC8CBdzsDuIKial39YilRjw=
 github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210615132203-8e93cb616045/go.mod h1:xghRV+aIAccdyXaxtjeIxY/JhE8jrnEzBI6Ut+ZVS2Y=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=

--- a/cloudevents/pkg/reconciler/events/cloudevent/cloudevent.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/cloudevent.go
@@ -1,0 +1,162 @@
+package cloudevent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	cdeevents "github.com/cdfoundation/sig-events/cde/sdk/go/pkg/cdf/events"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/uuid"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	"time"
+)
+
+// CEClient matches the `Client` interface from github.com/cloudevents/sdk-go/v2/cloudevents
+type CEClient cloudevents.Client
+
+// TektonCloudEventData type is used to marshal and unmarshal the payload of
+// a Tekton cloud event. It can include a TaskRun or a PipelineRun
+type TektonCloudEventData struct {
+	TaskRun     *v1beta1.TaskRun     `json:"taskRun,omitempty"`
+	PipelineRun *v1beta1.PipelineRun `json:"pipelineRun,omitempty"`
+}
+
+// newTektonCloudEventData returns a new instance of TektonCloudEventData
+func newTektonCloudEventData(runObject objectWithCondition) TektonCloudEventData {
+	tektonCloudEventData := TektonCloudEventData{}
+	switch v := runObject.(type) {
+	case *v1beta1.TaskRun:
+		tektonCloudEventData.TaskRun = v
+	case *v1beta1.PipelineRun:
+		tektonCloudEventData.PipelineRun = v
+	}
+	return tektonCloudEventData
+}
+
+func getEventType(runObject objectWithCondition) (*cdeevents.CDEventType, error) {
+	c := runObject.GetStatusCondition().GetCondition(apis.ConditionSucceeded)
+	if c == nil {
+		return nil, fmt.Errorf("no condition for ConditionSucceeded in %T", runObject)
+	}
+	var eventType cdeevents.CDEventType
+	switch {
+	// TODO : Update TaskRun/PipelineRun events from finished to success/fa
+	case c.IsUnknown():
+		switch runObject.(type) {
+		case *v1beta1.TaskRun:
+			switch c.Reason {
+			case v1beta1.TaskRunReasonStarted.String():
+				eventType = cdeevents.TaskRunStartedEventV1
+				//case v1beta1.TaskRunReasonRunning.String():
+				//	eventType = TaskRunRunningEventV1
+				//default:
+				//	eventType = TaskRunUnknownEventV1
+			}
+		case *v1beta1.PipelineRun:
+			switch c.Reason {
+			case v1beta1.PipelineRunReasonStarted.String():
+				eventType = cdeevents.PipelineRunStartedEventV1
+				//case v1beta1.PipelineRunReasonRunning.String():
+				//	eventType = PipelineRunRunningEventV1
+				//default:
+				//	eventType = PipelineRunUnknownEventV1
+			}
+		}
+	case c.IsFalse():
+		switch runObject.(type) {
+		case *v1beta1.TaskRun:
+			eventType = cdeevents.TaskRunFinishedEventV1 //TaskRunFailedEventV1
+		case *v1beta1.PipelineRun:
+			eventType = cdeevents.PipelineRunFinishedEventV1 //PipelineRunFailedEventV1
+		}
+	case c.IsTrue():
+		switch runObject.(type) {
+		case *v1beta1.TaskRun:
+			eventType = cdeevents.TaskRunFinishedEventV1 //TaskRunSuccessfulEventV1
+		case *v1beta1.PipelineRun:
+			eventType = cdeevents.PipelineRunFinishedEventV1 //PipelineRunSuccessfulEventV1
+		}
+	default:
+		return nil, fmt.Errorf("unknown condition for in %T.Status %s", runObject, c.Status)
+	}
+	return &eventType, nil
+}
+
+// eventForObjectWithCondition creates a new event based for a objectWithCondition,
+// or return an error if not possible.
+func eventForObjectWithCondition(runObject objectWithCondition) (*cloudevents.Event, error) {
+	event := cloudevents.NewEvent()
+	event.SetID(uuid.New().String())
+	event.SetSubject(runObject.GetObjectMeta().GetName())
+	// TODO: SelfLink is deprecated https://github.com/tektoncd/pipeline/issues/2676
+	source := runObject.GetObjectMeta().GetSelfLink()
+	if source == "" {
+		gvk := runObject.GetObjectKind().GroupVersionKind()
+		source = fmt.Sprintf("/apis/%s/%s/namespaces/%s/%s/%s",
+			gvk.Group,
+			gvk.Version,
+			runObject.GetObjectMeta().GetNamespace(),
+			gvk.Kind,
+			runObject.GetObjectMeta().GetName())
+	}
+	event.SetSource(source)
+	eventType, err := getEventType(runObject)
+	if err != nil {
+		return nil, err
+	}
+	if eventType == nil {
+		return nil, errors.New("No matching event type found")
+	}
+	event.SetType(eventType.String())
+
+	if err := event.SetData(cloudevents.ApplicationJSON, newTektonCloudEventData(runObject)); err != nil {
+		return nil, err
+	}
+	return &event, nil
+}
+
+// SendCloudEventWithRetries sends a cloud event for the specified resource.
+// It does not block and it perform retries with backoff using the cloudevents
+// sdk-go capabilities.
+// It accepts a runtime.Object to avoid making objectWithCondition public since
+// it's only used within the events/cloudevents packages.
+func SendCloudEventWithRetries(ctx context.Context, object runtime.Object) error {
+	var (
+		o  objectWithCondition
+		ok bool
+	)
+	if o, ok = object.(objectWithCondition); !ok {
+		return errors.New("Input object does not satisfy objectWithCondition")
+	}
+	logger := logging.FromContext(ctx)
+	ceClient := cloudevent.Get(ctx)
+	if ceClient == nil {
+		return errors.New("No cloud events client found in the context")
+	}
+	event, err := eventForObjectWithCondition(o)
+	if err != nil {
+		return err
+	}
+
+	wasIn := make(chan error)
+	go func() {
+		wasIn <- nil
+		logger.Debugf("Sending cloudevent of type %q", event.Type())
+		if result := ceClient.Send(cloudevents.ContextWithRetriesExponentialBackoff(ctx, 10*time.Millisecond, 10), *event); !cloudevents.IsACK(result) {
+			logger.Warnf("Failed to send cloudevent: %s", result.Error())
+			recorder := controller.GetEventRecorder(ctx)
+			if recorder == nil {
+				logger.Warnf("No recorder in context, cannot emit error event")
+			}
+			recorder.Event(object, corev1.EventTypeWarning, "Cloud Event Failure", result.Error())
+		}
+	}()
+
+	return <-wasIn
+}

--- a/cloudevents/pkg/reconciler/events/cloudevent/cloudevent.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/cloudevent.go
@@ -23,9 +23,9 @@ import (
 type EventStatus string
 
 const (
-	StatusRunning EventStatus = "Running"
+	StatusRunning  EventStatus = "Running"
 	StatusFinished EventStatus = "Finished"
-	StatusError EventStatus = "Error"
+	StatusError    EventStatus = "Error"
 )
 
 // CEClient matches the `Client` interface from github.com/cloudevents/sdk-go/v2/cloudevents
@@ -73,6 +73,11 @@ func getEventType(runObject objectWithCondition) (*EventType, error) {
 			switch c.Reason {
 			case v1beta1.TaskRunReasonStarted.String():
 				eventType.Type = cdeevents.TaskRunStartedEventV1
+			case v1beta1.TaskRunReasonRunning.String():
+				eventType.Type = cdeevents.TaskRunStartedEventV1
+			// Unknown status, unknown reason -> no event type
+			default:
+				return nil, fmt.Errorf("unknown status with unknown reason %s", c.Reason)
 			}
 		case *v1beta1.PipelineRun:
 			switch c.Reason {
@@ -80,6 +85,9 @@ func getEventType(runObject objectWithCondition) (*EventType, error) {
 				eventType.Type = cdeevents.PipelineRunQueuedEventV1
 			case v1beta1.PipelineRunReasonRunning.String():
 				eventType.Type = cdeevents.PipelineRunStartedEventV1
+			// Unknown status, unknown reason -> no event type
+			default:
+				return nil, fmt.Errorf("unknown status with unknown reason %s", c.Reason)
 			}
 		}
 	case c.IsTrue():

--- a/cloudevents/pkg/reconciler/events/cloudevent/cloudevent.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/cloudevent.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/json"
+	"time"
+
 	cdeevents "github.com/cdfoundation/sig-events/cde/sdk/go/pkg/cdf/events"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/google/uuid"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	corev1 "k8s.io/api/core/v1"
@@ -14,73 +16,87 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
-	"time"
+)
+
+// TODO(afrittoli) The valid statuses should be encoded in the SDK
+// EvenStatus encodes valid statuses defined in https://github.com/cdfoundation/sig-events/blob/main/vocabulary-draft/core.md#continuous-delivery-core-events
+type EventStatus string
+
+const (
+	StatusRunning EventStatus = "Running"
+	StatusFinished EventStatus = "Finished"
+	StatusError EventStatus = "Error"
 )
 
 // CEClient matches the `Client` interface from github.com/cloudevents/sdk-go/v2/cloudevents
 type CEClient cloudevents.Client
 
-// TektonCloudEventData type is used to marshal and unmarshal the payload of
-// a Tekton cloud event. It can include a TaskRun or a PipelineRun
-type TektonCloudEventData struct {
-	TaskRun     *v1beta1.TaskRun     `json:"taskRun,omitempty"`
-	PipelineRun *v1beta1.PipelineRun `json:"pipelineRun,omitempty"`
-}
+type CDECloudEventData map[string]string
 
-// newTektonCloudEventData returns a new instance of TektonCloudEventData
-func newTektonCloudEventData(runObject objectWithCondition) TektonCloudEventData {
-	tektonCloudEventData := TektonCloudEventData{}
+// getEventData returns a new instance of CDECloudEventData
+func getEventData(runObject objectWithCondition) (CDECloudEventData, error) {
+	cdeCloudEventData := map[string]string{}
 	switch v := runObject.(type) {
 	case *v1beta1.TaskRun:
-		tektonCloudEventData.TaskRun = v
+		data, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		cdeCloudEventData["taskrun"] = string(data)
 	case *v1beta1.PipelineRun:
-		tektonCloudEventData.PipelineRun = v
+		data, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		cdeCloudEventData["pipelinerun"] = string(data)
 	}
-	return tektonCloudEventData
+	return cdeCloudEventData, nil
 }
 
-func getEventType(runObject objectWithCondition) (*cdeevents.CDEventType, error) {
+type EventType struct {
+	Type   cdeevents.CDEventType
+	Status EventStatus
+}
+
+// getEventType returns the event type and status
+func getEventType(runObject objectWithCondition) (*EventType, error) {
 	c := runObject.GetStatusCondition().GetCondition(apis.ConditionSucceeded)
 	if c == nil {
 		return nil, fmt.Errorf("no condition for ConditionSucceeded in %T", runObject)
 	}
-	var eventType cdeevents.CDEventType
+	eventType := EventType{}
 	switch {
-	// TODO : Update TaskRun/PipelineRun events from finished to success/fa
 	case c.IsUnknown():
+		eventType.Status = StatusRunning
 		switch runObject.(type) {
 		case *v1beta1.TaskRun:
 			switch c.Reason {
 			case v1beta1.TaskRunReasonStarted.String():
-				eventType = cdeevents.TaskRunStartedEventV1
-				//case v1beta1.TaskRunReasonRunning.String():
-				//	eventType = TaskRunRunningEventV1
-				//default:
-				//	eventType = TaskRunUnknownEventV1
+				eventType.Type = cdeevents.TaskRunStartedEventV1
 			}
 		case *v1beta1.PipelineRun:
 			switch c.Reason {
 			case v1beta1.PipelineRunReasonStarted.String():
-				eventType = cdeevents.PipelineRunStartedEventV1
-				//case v1beta1.PipelineRunReasonRunning.String():
-				//	eventType = PipelineRunRunningEventV1
-				//default:
-				//	eventType = PipelineRunUnknownEventV1
+				eventType.Type = cdeevents.PipelineRunQueuedEventV1
+			case v1beta1.PipelineRunReasonRunning.String():
+				eventType.Type = cdeevents.PipelineRunStartedEventV1
 			}
 		}
-	case c.IsFalse():
-		switch runObject.(type) {
-		case *v1beta1.TaskRun:
-			eventType = cdeevents.TaskRunFinishedEventV1 //TaskRunFailedEventV1
-		case *v1beta1.PipelineRun:
-			eventType = cdeevents.PipelineRunFinishedEventV1 //PipelineRunFailedEventV1
-		}
 	case c.IsTrue():
+		eventType.Status = StatusFinished
 		switch runObject.(type) {
 		case *v1beta1.TaskRun:
-			eventType = cdeevents.TaskRunFinishedEventV1 //TaskRunSuccessfulEventV1
+			eventType.Type = cdeevents.TaskRunFinishedEventV1 //TaskRunFailedEventV1
 		case *v1beta1.PipelineRun:
-			eventType = cdeevents.PipelineRunFinishedEventV1 //PipelineRunSuccessfulEventV1
+			eventType.Type = cdeevents.PipelineRunFinishedEventV1 //PipelineRunFailedEventV1
+		}
+	case c.IsFalse():
+		eventType.Status = StatusError
+		switch runObject.(type) {
+		case *v1beta1.TaskRun:
+			eventType.Type = cdeevents.TaskRunFinishedEventV1 //TaskRunFailedEventV1
+		case *v1beta1.PipelineRun:
+			eventType.Type = cdeevents.PipelineRunFinishedEventV1 //PipelineRunFailedEventV1
 		}
 	default:
 		return nil, fmt.Errorf("unknown condition for in %T.Status %s", runObject, c.Status)
@@ -91,33 +107,42 @@ func getEventType(runObject objectWithCondition) (*cdeevents.CDEventType, error)
 // eventForObjectWithCondition creates a new event based for a objectWithCondition,
 // or return an error if not possible.
 func eventForObjectWithCondition(runObject objectWithCondition) (*cloudevents.Event, error) {
-	event := cloudevents.NewEvent()
-	event.SetID(uuid.New().String())
+	var event cloudevents.Event
+	var err error
+	meta := runObject.GetObjectMeta()
+	data, err := getEventData(runObject)
+	if err != nil {
+		return nil, err
+	}
+	etype, err := getEventType(runObject)
+	if err != nil {
+		return nil, err
+	}
+	switch runObject.(type) {
+	case *v1beta1.TaskRun:
+		event, err = cdeevents.CreateTaskRunEvent(etype.Type, string(meta.GetUID()), meta.GetName(), "", data)
+		if err != nil {
+			return nil, err
+		}
+	case *v1beta1.PipelineRun:
+		event, err = cdeevents.CreatePipelineRunEvent(etype.Type, string(meta.GetUID()), meta.GetName(), string(etype.Status), "", "", data)
+		if err != nil {
+			return nil, err
+		}
+	}
 	event.SetSubject(runObject.GetObjectMeta().GetName())
-	// TODO: SelfLink is deprecated https://github.com/tektoncd/pipeline/issues/2676
 	source := runObject.GetObjectMeta().GetSelfLink()
 	if source == "" {
 		gvk := runObject.GetObjectKind().GroupVersionKind()
 		source = fmt.Sprintf("/apis/%s/%s/namespaces/%s/%s/%s",
 			gvk.Group,
 			gvk.Version,
-			runObject.GetObjectMeta().GetNamespace(),
+			meta.GetNamespace(),
 			gvk.Kind,
-			runObject.GetObjectMeta().GetName())
+			meta.GetName())
 	}
 	event.SetSource(source)
-	eventType, err := getEventType(runObject)
-	if err != nil {
-		return nil, err
-	}
-	if eventType == nil {
-		return nil, errors.New("No matching event type found")
-	}
-	event.SetType(eventType.String())
 
-	if err := event.SetData(cloudevents.ApplicationJSON, newTektonCloudEventData(runObject)); err != nil {
-		return nil, err
-	}
 	return &event, nil
 }
 
@@ -132,12 +157,12 @@ func SendCloudEventWithRetries(ctx context.Context, object runtime.Object) error
 		ok bool
 	)
 	if o, ok = object.(objectWithCondition); !ok {
-		return errors.New("Input object does not satisfy objectWithCondition")
+		return errors.New("input object does not satisfy objectWithCondition")
 	}
 	logger := logging.FromContext(ctx)
 	ceClient := cloudevent.Get(ctx)
 	if ceClient == nil {
-		return errors.New("No cloud events client found in the context")
+		return errors.New("no cloud events client found in the context")
 	}
 	event, err := eventForObjectWithCondition(o)
 	if err != nil {
@@ -153,8 +178,9 @@ func SendCloudEventWithRetries(ctx context.Context, object runtime.Object) error
 			recorder := controller.GetEventRecorder(ctx)
 			if recorder == nil {
 				logger.Warnf("No recorder in context, cannot emit error event")
+			} else {
+				recorder.Event(object, corev1.EventTypeWarning, "Cloud Event Failure", result.Error())
 			}
-			recorder.Event(object, corev1.EventTypeWarning, "Cloud Event Failure", result.Error())
 		}
 	}()
 

--- a/cloudevents/pkg/reconciler/events/cloudevent/cloudevent_test.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/cloudevent_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevent
+
+import (
+	"testing"
+
+	cdeevents "github.com/cdfoundation/sig-events/cde/sdk/go/pkg/cdf/events"
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test/diff"
+	"github.com/tektoncd/pipeline/test/names"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+)
+
+const (
+	taskRunName     = "faketaskrunname"
+	pipelineRunName = "fakepipelinerunname"
+)
+
+func getTaskRunByCondition(status corev1.ConditionStatus, reason string) *v1beta1.TaskRun {
+	return &v1beta1.TaskRun{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "TaskRun",
+			APIVersion: "v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      taskRunName,
+			Namespace: "marshmallow",
+		},
+		Spec: v1beta1.TaskRunSpec{},
+		Status: v1beta1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: status,
+					Reason: reason,
+				}},
+			},
+		},
+	}
+}
+
+func getPipelineRunByCondition(status corev1.ConditionStatus, reason string) *v1beta1.PipelineRun {
+	return &v1beta1.PipelineRun{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PipelineRun",
+			APIVersion: "v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pipelineRunName,
+			Namespace: "marshmallow",
+		},
+		Spec: v1beta1.PipelineRunSpec{},
+		Status: v1beta1.PipelineRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: status,
+					Reason: reason,
+				}},
+			},
+		},
+	}
+}
+
+func TestEventForTaskRun(t *testing.T) {
+	taskRunTests := []struct {
+		desc          string
+		taskRun       *v1beta1.TaskRun
+		wantEventType cdeevents.CDEventType
+	}{{
+		desc:          "send a cloud event when a taskrun starts",
+		taskRun:       getTaskRunByCondition(corev1.ConditionUnknown, v1beta1.TaskRunReasonStarted.String()),
+		wantEventType: cdeevents.TaskRunStartedEventV1,
+	}, {
+		desc:          "send a cloud event when a taskrun starts running",
+		taskRun:       getTaskRunByCondition(corev1.ConditionUnknown, v1beta1.TaskRunReasonRunning.String()),
+		wantEventType: cdeevents.TaskRunStartedEventV1,
+	}, {
+		desc:    "send a cloud event with unknown status taskrun",
+		taskRun: getTaskRunByCondition(corev1.ConditionUnknown, "doesn't matter"),
+	}, {
+		desc:          "send a cloud event with failed status taskrun",
+		taskRun:       getTaskRunByCondition(corev1.ConditionFalse, "meh"),
+		wantEventType: cdeevents.TaskRunFinishedEventV1,
+	}, {
+		desc:          "send a cloud event with successful status taskrun",
+		taskRun:       getTaskRunByCondition(corev1.ConditionTrue, "yay"),
+		wantEventType: cdeevents.TaskRunFinishedEventV1,
+	}, {
+		desc: "send a cloud event with successful status taskrun, empty selflink",
+		taskRun: func() *v1beta1.TaskRun {
+			tr := getTaskRunByCondition(corev1.ConditionTrue, "yay")
+			// v1.20 does not set selfLink in controller
+			tr.ObjectMeta.SelfLink = ""
+			return tr
+		}(),
+		wantEventType: cdeevents.TaskRunFinishedEventV1,
+	}}
+
+	for _, c := range taskRunTests {
+		t.Run(c.desc, func(t *testing.T) {
+			names.TestingSeed()
+
+			got, err := eventForObjectWithCondition(c.taskRun)
+			if err != nil {
+				// If not event type was set, don't expect an event
+				if c.wantEventType != "" {
+					t.Fatalf("I did not expect an error but I got %s", err)
+				}
+			} else {
+				wantSubject := taskRunName
+				if d := cmp.Diff(wantSubject, got.Subject()); d != "" {
+					t.Errorf("Wrong Event ID %s", diff.PrintWantGot(d))
+				}
+				if d := cmp.Diff(string(c.wantEventType), got.Type()); d != "" {
+					t.Errorf("Wrong Event Type %s", diff.PrintWantGot(d))
+				}
+				wantData, _ := getEventData(c.taskRun)
+				gotData := CDECloudEventData{}
+				if err := got.DataAs(&gotData); err != nil {
+					t.Errorf("Unexpected error from DataAsl; %s", err)
+				}
+				if d := cmp.Diff(wantData, gotData); d != "" {
+					t.Errorf("Wrong Event data %s", diff.PrintWantGot(d))
+				}
+
+				if err := got.Validate(); err != nil {
+					t.Errorf("Expected event to be valid; %s", err)
+				}
+			}
+		})
+	}
+}
+
+func TestEventForPipelineRun(t *testing.T) {
+	pipelineRunTests := []struct {
+		desc          string
+		pipelineRun   *v1beta1.PipelineRun
+		wantEventType cdeevents.CDEventType
+		wantStatus    EventStatus
+	}{{
+		desc:          "send a cloud event with unknown status pipelinerun, just started",
+		pipelineRun:   getPipelineRunByCondition(corev1.ConditionUnknown, v1beta1.PipelineRunReasonStarted.String()),
+		wantEventType: cdeevents.PipelineRunQueuedEventV1,
+		wantStatus:    StatusRunning,
+	}, {
+		desc:          "send a cloud event with unknown status pipelinerun, just started running",
+		pipelineRun:   getPipelineRunByCondition(corev1.ConditionUnknown, v1beta1.PipelineRunReasonRunning.String()),
+		wantEventType: cdeevents.PipelineRunStartedEventV1,
+		wantStatus:    StatusRunning,
+	}, {
+		desc:        "send a cloud event with unknown status pipelinerun",
+		pipelineRun: getPipelineRunByCondition(corev1.ConditionUnknown, "doesn't matter"),
+	}, {
+		desc:          "send a cloud event with successful status pipelinerun",
+		pipelineRun:   getPipelineRunByCondition(corev1.ConditionTrue, "yay"),
+		wantEventType: cdeevents.PipelineRunFinishedEventV1,
+		wantStatus:    StatusFinished,
+	}, {
+		desc:          "send a cloud event with unknown status pipelinerun",
+		pipelineRun:   getPipelineRunByCondition(corev1.ConditionFalse, "meh"),
+		wantEventType: cdeevents.PipelineRunFinishedEventV1,
+		wantStatus:    StatusError,
+	}}
+
+	for _, c := range pipelineRunTests {
+		t.Run(c.desc, func(t *testing.T) {
+			names.TestingSeed()
+
+			got, err := eventForObjectWithCondition(c.pipelineRun)
+			if err != nil {
+				// If not event type was set, don't expect an event
+				if c.wantEventType != "" {
+					t.Fatalf("I did not expect an error but I got %s", err)
+				}
+			} else {
+				wantSubject := pipelineRunName
+				if d := cmp.Diff(wantSubject, got.Subject()); d != "" {
+					t.Errorf("Wrong Event ID %s", diff.PrintWantGot(d))
+				}
+				if d := cmp.Diff(string(c.wantEventType), got.Type()); d != "" {
+					t.Errorf("Wrong Event Type %s", diff.PrintWantGot(d))
+				}
+				if d := cmp.Diff(string(c.wantStatus), got.Extensions()["pipelinerunstatus"]); d != "" {
+					t.Errorf("Wrong Event Type %s", diff.PrintWantGot(d))
+				}
+				wantData, _ := getEventData(c.pipelineRun)
+				gotData := CDECloudEventData{}
+				if err := got.DataAs(&gotData); err != nil {
+					t.Errorf("Unexpected error from DataAsl; %s", err)
+				}
+				if d := cmp.Diff(wantData, gotData); d != "" {
+					t.Errorf("Wrong Event data %s", diff.PrintWantGot(d))
+				}
+
+				if err := got.Validate(); err != nil {
+					t.Errorf("Expected event to be valid; %s", err)
+				}
+			}
+		})
+	}
+}

--- a/cloudevents/pkg/reconciler/events/cloudevent/interface.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/interface.go
@@ -17,5 +17,4 @@ type objectWithCondition interface {
 
 	// GetStatusCondition returns a ConditionAccessor for the status of the RunsToCompletion
 	GetStatusCondition() apis.ConditionAccessor
-
 }

--- a/cloudevents/pkg/reconciler/events/cloudevent/interface.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/interface.go
@@ -1,0 +1,20 @@
+package cloudevent
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
+)
+
+// objectWithCondition is implemented by TaskRun and PipelineRun
+type objectWithCondition interface {
+
+	// Object requires GetObjectKind() and DeepCopyObject()
+	runtime.Object
+
+	// ObjectMetaAccessor requires a GetObjectMeta that returns the ObjectMeta
+	metav1.ObjectMetaAccessor
+
+	// GetStatusCondition returns a ConditionAccessor for the status of the RunsToCompletion
+	GetStatusCondition() apis.ConditionAccessor
+}

--- a/cloudevents/pkg/reconciler/events/cloudevent/interface.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/interface.go
@@ -17,4 +17,5 @@ type objectWithCondition interface {
 
 	// GetStatusCondition returns a ConditionAccessor for the status of the RunsToCompletion
 	GetStatusCondition() apis.ConditionAccessor
+
 }

--- a/cloudevents/pkg/reconciler/events/events.go
+++ b/cloudevents/pkg/reconciler/events/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2021 The Tekton Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package events
 
 import (
@@ -21,7 +22,7 @@ import (
 	"github.com/tektoncd/experimental/cloudevents/pkg/apis/config"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
+	"github.com/tektoncd/experimental/cloudevents/pkg/reconciler/events/cloudevent"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/logging"
 )

--- a/cloudevents/pkg/reconciler/events/events_test.go
+++ b/cloudevents/pkg/reconciler/events/events_test.go
@@ -55,7 +55,7 @@ func TestEmit(t *testing.T) {
 		name:           "with sink",
 		data:           map[string]string{"default-cloud-events-sink": "http://mysink"},
 		wantEvent:      "Normal Started",
-		wantCloudEvent: `(?s)dev.tekton.event.pipelinerun.started.v1.*test1`,
+		wantCloudEvent: `(?s)cd.pipelinerun.queued.v1.*test1`,
 	}}
 
 	for _, tc := range testcases {

--- a/cloudevents/pkg/reconciler/pipelinerun/reconciler_test.go
+++ b/cloudevents/pkg/reconciler/pipelinerun/reconciler_test.go
@@ -223,7 +223,7 @@ func TestReconcile_CloudEvents(t *testing.T) {
 	}{{
 		name:            "Pipeline with no condition",
 		condition:       nil,
-		wantCloudEvents: []string{`(?s)dev.tekton.event.pipelinerun.started.v1.*test-pipelinerun`},
+		wantCloudEvents: []string{`(?s)cd.pipelinerun.queued.v1.*test-pipelinerun`},
 		startTime:       false,
 	}, {
 		name: "Pipeline with running condition",
@@ -233,7 +233,7 @@ func TestReconcile_CloudEvents(t *testing.T) {
 			Reason: v1beta1.PipelineRunReasonRunning.String(),
 		},
 		startTime:       true,
-		wantCloudEvents: []string{`(?s)dev.tekton.event.pipelinerun.running.v1.*test-pipelinerun`},
+		wantCloudEvents: []string{`(?s)cd.pipelinerun.started.v1.*test-pipelinerun`},
 	}, {
 		name: "Pipeline with finished true condition",
 		condition: &apis.Condition{
@@ -242,7 +242,7 @@ func TestReconcile_CloudEvents(t *testing.T) {
 			Reason: v1beta1.PipelineRunReasonSuccessful.String(),
 		},
 		startTime:       true,
-		wantCloudEvents: []string{`(?s)dev.tekton.event.pipelinerun.successful.v1.*test-pipelinerun`},
+		wantCloudEvents: []string{`(?s)cd.pipelinerun.finished.v1.*test-pipelinerun`},
 	}, {
 		name: "Pipeline with finished false condition",
 		condition: &apis.Condition{
@@ -251,7 +251,7 @@ func TestReconcile_CloudEvents(t *testing.T) {
 			Reason: v1beta1.PipelineRunReasonCancelled.String(),
 		},
 		startTime:       true,
-		wantCloudEvents: []string{`(?s)dev.tekton.event.pipelinerun.failed.v1.*test-pipelinerun`},
+		wantCloudEvents: []string{`(?s)cd.pipelinerun.finished.v1.*test-pipelinerun`},
 	}}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- extract reconciler/events/cloudevent library from tektoncd/pipeline to amke changes in the datatype which is being used in sending cloudevents
- replace existing TektonEventType based events with CDEEventType events
- Update TaskRun and PipelineRun to use Started and Finished events
- TaskRun and PipelineRun success/failure events don't exist yet so these have been replaced with cde "finished" events for time being

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
