### PR TITLE
[cel][pip][wait][loop] Fix the cp command in the release publish task

### DIFF
--- a/cel/tekton/publish.yaml
+++ b/cel/tekton/publish.yaml
@@ -96,7 +96,7 @@ spec:
       # Setup docker-auth
       DOCKER_CONFIG=~/.docker
       mkdir -p ${DOCKER_CONFIG}
-      cp /workspace/docker-config.json ${DOCKER_CONFIG}/
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
 
       # Change to directory with our .ko.yaml
       cd ${PROJECT_ROOT}
@@ -156,7 +156,7 @@ spec:
       # Setup docker-auth
       DOCKER_CONFIG=~/.docker
       mkdir -p ${DOCKER_CONFIG}
-      cp /workspace/docker-config.json ${DOCKER_CONFIG}/
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
 
       # Tag the images in all regions
       for IMAGE in $(cat /workspace/built_images)

--- a/pipelines-in-pipelines/tekton/publish.yaml
+++ b/pipelines-in-pipelines/tekton/publish.yaml
@@ -96,7 +96,7 @@ spec:
       # Setup docker-auth
       DOCKER_CONFIG=~/.docker
       mkdir -p ${DOCKER_CONFIG}
-      cp /workspace/docker-config.json ${DOCKER_CONFIG}/
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
 
       # Change to directory with our .ko.yaml
       cd ${PROJECT_ROOT}
@@ -156,7 +156,7 @@ spec:
       # Setup docker-auth
       DOCKER_CONFIG=~/.docker
       mkdir -p ${DOCKER_CONFIG}
-      cp /workspace/docker-config.json ${DOCKER_CONFIG}/
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
 
       # Tag the images in all regions
       for IMAGE in $(cat /workspace/built_images)

--- a/task-loops/tekton/publish.yaml
+++ b/task-loops/tekton/publish.yaml
@@ -98,7 +98,7 @@ spec:
       # Setup docker-auth
       DOCKER_CONFIG=~/.docker
       mkdir -p ${DOCKER_CONFIG}
-      cp /workspace/docker-config.json ${DOCKER_CONFIG}/
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
 
       # Change to directory with our .ko.yaml
       cd ${PROJECT_ROOT}
@@ -160,7 +160,7 @@ spec:
       # Setup docker-auth
       DOCKER_CONFIG=~/.docker
       mkdir -p ${DOCKER_CONFIG}
-      cp /workspace/docker-config.json ${DOCKER_CONFIG}/
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
 
       # Tag the images in all regions
       for IMAGE in $(cat /workspace/built_images)

--- a/wait-task/tekton/publish.yaml
+++ b/wait-task/tekton/publish.yaml
@@ -96,7 +96,7 @@ spec:
       # Setup docker-auth
       DOCKER_CONFIG=~/.docker
       mkdir -p ${DOCKER_CONFIG}
-      cp /workspace/docker-config.json ${DOCKER_CONFIG}/
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
 
       # Change to directory with our .ko.yaml
       cd ${PROJECT_ROOT}
@@ -153,7 +153,7 @@ spec:
       # Setup docker-auth
       DOCKER_CONFIG=~/.docker
       mkdir -p ${DOCKER_CONFIG}
-      cp /workspace/docker-config.json ${DOCKER_CONFIG}/
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
 
       # Tag the images in all regions
       for IMAGE in $(cat /workspace/built_images)


### PR DESCRIPTION
# Changes

Before Tekton Pipelines v0.24.x, $HOME and workDir were implicitly set,
which rendered the cp command redundant and hid the issue.

Partially fixes tektoncd/plumbing#856

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
