### PR TITLE
[cloudevents] Add support for handling artifact event types

### DIFF
--- a/cloudevents/go.mod
+++ b/cloudevents/go.mod
@@ -3,7 +3,7 @@ module github.com/tektoncd/experimental/cloudevents
 go 1.15
 
 require (
-	github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210615132203-8e93cb616045
+	github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210619194635-1b767876db95
 	github.com/cloudevents/sdk-go/v2 v2.3.1
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-containerregistry v0.5.1 // indirect

--- a/cloudevents/go.sum
+++ b/cloudevents/go.sum
@@ -143,6 +143,10 @@ github.com/c2h5oh/datasize v0.0.0-20171227191756-4eba002a5eae/go.mod h1:S/7n9cop
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210615132203-8e93cb616045 h1:7OxBfPTKazzqkATM4vnqXC8CBdzsDuIKial39YilRjw=
 github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210615132203-8e93cb616045/go.mod h1:xghRV+aIAccdyXaxtjeIxY/JhE8jrnEzBI6Ut+ZVS2Y=
+github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210616124232-6d6ea603dad5 h1:S6xY+fPVldKDy7qcxFPqegdaPOoM579S2Wvvw7pmE7Y=
+github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210616124232-6d6ea603dad5/go.mod h1:xghRV+aIAccdyXaxtjeIxY/JhE8jrnEzBI6Ut+ZVS2Y=
+github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210619194635-1b767876db95 h1:My49U1iBg9IvCwWx/8ohRmXf8H4NMzdNduwyobwC3vc=
+github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210619194635-1b767876db95/go.mod h1:xghRV+aIAccdyXaxtjeIxY/JhE8jrnEzBI6Ut+ZVS2Y=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0 h1:t/LhUZLVitR1Ow2YOnduCsavhwFUklBMoGVYUCqmCqk=

--- a/cloudevents/pkg/reconciler/events/cloudevent/artifacts.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/artifacts.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevent
+
+import (
+	"fmt"
+	cdeevents "github.com/cdfoundation/sig-events/cde/sdk/go/pkg/cdf/events"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"knative.dev/pkg/apis"
+)
+
+var (
+	mappings = map[string]resultMapping{
+		"artifactId": {
+			defaultResultName:       "cd.artifact.id",
+			annotationResultNameKey: "cd.events/results.artifact.id",
+		},
+		"artifactName": {
+			defaultResultName:       "cd.artifact.name",
+			annotationResultNameKey: "cd.events/results.artifact.name",
+		},
+		"artifactVersion": {
+			defaultResultName:       "cd.artifact.version",
+			annotationResultNameKey: "cd.events/results.artifact.version",
+		},
+	}
+)
+
+const ArtifactPackagedEventAnnotation cdEventAnnotationType = "cd.artifact.packaged"
+const ArtifactPublishedEventAnnotation cdEventAnnotationType = "cd.artifact.published"
+
+// getArtifactEventType returns an eventType is conditions are met
+func getArtifactEventType(runObject objectWithCondition, cdEventType cdeevents.CDEventType) (*EventType, error) {
+	c := runObject.GetStatusCondition().GetCondition(apis.ConditionSucceeded)
+	if c == nil {
+		return nil, fmt.Errorf("no condition for ConditionSucceeded in %T", runObject)
+	}
+	if !c.IsTrue() {
+		return nil, fmt.Errorf("no artifact event for condition %T", c)
+	}
+	eventType := &EventType{
+		Type: cdEventType,
+	}
+	switch runObject.(type) {
+	case *v1beta1.TaskRun, *v1beta1.PipelineRun:
+		return eventType, nil
+	}
+	return nil, fmt.Errorf("unknown type of Tekton resource")
+}
+
+// getArtifactPackagedEventType returns a CDF Artifact Packaged EventType if objectWithCondition meets conditions
+func getArtifactPackagedEventType(runObject objectWithCondition) (*EventType, error) {
+	annotations := runObject.GetObjectMeta().GetAnnotations()
+	if name, ok := annotations[CDEventAnnotationTypeKey]; ok {
+		if name == string(ArtifactPackagedEventAnnotation) {
+			return getArtifactEventType(runObject, cdeevents.ArtifactPackagedEventV1)
+		}
+	}
+	return nil, fmt.Errorf("no %s annotation found", CDEventAnnotationTypeKey)
+}
+
+// getArtifactPublishedEventType returns a CDF Artifact Published EventType if objectWithCondition meets conditions
+func getArtifactPublishedEventType(runObject objectWithCondition) (*EventType, error) {
+	annotations := runObject.GetObjectMeta().GetAnnotations()
+	if name, ok := annotations[CDEventAnnotationTypeKey]; ok {
+		if name == string(ArtifactPublishedEventAnnotation) {
+			return getArtifactEventType(runObject, cdeevents.ArtifactPublishedEventV1)
+		}
+	}
+	return nil, fmt.Errorf("no %s annotation found", CDEventAnnotationTypeKey)
+}
+
+// getArtifactEventData
+func getArtifactEventData(runObject objectWithCondition) (CDECloudEventData, error) {
+	cdeCloudEventData, err := getEventData(runObject)
+	if err != nil {
+		return nil, err
+	}
+	for mappingName, mapping := range mappings {
+		mappingValue, err := resultForMapping(runObject, mapping)
+		if err != nil {
+			return nil, err
+		}
+		cdeCloudEventData[mappingName] = mappingValue
+	}
+	return cdeCloudEventData, nil
+}
+
+// getArtifactPackagedEventData returns the data for a CDF Artifact Packaged Event
+func getArtifactPackagedEventData(runObject objectWithCondition) (CDECloudEventData, error) {
+	return getArtifactEventData(runObject)
+}
+
+// getArtifactPublishedEventData returns the data for a CDF Artifact Packaged Event
+func getArtifactPublishedEventData(runObject objectWithCondition) (CDECloudEventData, error) {
+	return getArtifactEventData(runObject)
+}
+
+func artifactPackagedEvenForObjectWithCondition(runObject objectWithCondition) (*cloudevents.Event, error) {
+	etype, err := getArtifactPackagedEventType(runObject)
+	if err != nil {
+		return nil, err
+	}
+	data, err := getArtifactPackagedEventData(runObject)
+	if err != nil {
+		return nil, err
+	}
+	params := cdeevents.ArtifactEventParams{
+		ArtifactName:    data["artifactName"],
+		ArtifactVersion: data["artifactVersion"],
+		ArtifactId:      data["artifactId"],
+		ArtifactData:    data,
+	}
+	event, err := cdeevents.CreateArtifactEvent(etype.Type, params)
+	if err != nil {
+		return nil, err
+	}
+	return &event, nil
+}
+
+func artifactPublishedEvenForObjectWithCondition(runObject objectWithCondition) (*cloudevents.Event, error) {
+	etype, err := getArtifactPublishedEventType(runObject)
+	if err != nil {
+		return nil, err
+	}
+	data, err := getArtifactPublishedEventData(runObject)
+	if err != nil {
+		return nil, err
+	}
+	params := cdeevents.ArtifactEventParams{
+		ArtifactName:    data["artifactName"],
+		ArtifactVersion: data["artifactVersion"],
+		ArtifactId:      data["artifactId"],
+		ArtifactData:    data,
+	}
+	event, err := cdeevents.CreateArtifactEvent(etype.Type, params)
+	if err != nil {
+		return nil, err
+	}
+	return &event, nil
+}

--- a/cloudevents/pkg/reconciler/events/cloudevent/artifacts_test.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/artifacts_test.go
@@ -1,0 +1,478 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevent
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tektoncd/pipeline/test/diff"
+	"testing"
+
+	cdeevents "github.com/cdfoundation/sig-events/cde/sdk/go/pkg/cdf/events"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test/names"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func getTaskRunByConditionAndResults(status corev1.ConditionStatus, reason string, annotations map[string]string, results map[string]string) *v1beta1.TaskRun {
+	taskRun := getTaskRunByCondition(status, reason)
+	taskRunResults := []v1beta1.TaskRunResult{}
+	for key, value := range results {
+		taskRunResults = append(taskRunResults, v1beta1.TaskRunResult{
+			Name:  key,
+			Value: value,
+		})
+	}
+	taskRun.Status.TaskRunResults = taskRunResults
+	taskRun.ObjectMeta.Annotations = annotations
+	return taskRun
+}
+
+func getPipelineRunByConditionAndResults(status corev1.ConditionStatus, reason string, annotations map[string]string, results map[string]string) *v1beta1.PipelineRun {
+	pipelineRun := getPipelineRunByCondition(status, reason)
+	pipelineRunResults := []v1beta1.PipelineRunResult{}
+	for key, value := range results {
+		pipelineRunResults = append(pipelineRunResults, v1beta1.PipelineRunResult{
+			Name:  key,
+			Value: value,
+		})
+	}
+	pipelineRun.Status.PipelineResults = pipelineRunResults
+	pipelineRun.ObjectMeta.Annotations = annotations
+	return pipelineRun
+}
+
+var (
+	artifactPackagedEventType  = &EventType{Type: cdeevents.ArtifactPackagedEventV1}
+	artifactPublishedEventType = &EventType{Type: cdeevents.ArtifactPublishedEventV1}
+)
+
+func TestArtifactEventsForTaskRun(t *testing.T) {
+	taskRunTests := []struct {
+		desc      string
+		taskRun   *v1beta1.TaskRun
+		wantError bool
+	}{{
+		desc:      "taskrun with no annotations",
+		taskRun:   getTaskRunByCondition(corev1.ConditionUnknown, v1beta1.TaskRunReasonStarted.String()),
+		wantError: true,
+	}, {
+		desc: "taskrun with annotation, started",
+		taskRun: getTaskRunByConditionAndResults(
+			corev1.ConditionUnknown,
+			v1beta1.TaskRunReasonStarted.String(),
+			map[string]string{CDEventAnnotationTypeKey: string(ArtifactPackagedEventAnnotation)},
+			map[string]string{}),
+		wantError: true,
+	}, {
+		desc: "taskrun with annotation, finished, failed",
+		taskRun: getTaskRunByConditionAndResults(
+			corev1.ConditionFalse,
+			"meh",
+			map[string]string{CDEventAnnotationTypeKey: string(ArtifactPackagedEventAnnotation)},
+			map[string]string{}),
+		wantError: true,
+	}, {
+		desc: "taskrun with annotation, finished, succeeded",
+		taskRun: getTaskRunByConditionAndResults(
+			corev1.ConditionTrue,
+			"yay",
+			map[string]string{CDEventAnnotationTypeKey: string(ArtifactPackagedEventAnnotation)},
+			map[string]string{}),
+		wantError: false,
+	}}
+
+	for _, c := range taskRunTests {
+		t.Run(c.desc, func(t *testing.T) {
+			names.TestingSeed()
+
+			got, err := getArtifactPackagedEventType(c.taskRun)
+			if err != nil {
+				if !c.wantError {
+					t.Fatalf("I did not expect an error but I got %s", err)
+				}
+			} else {
+				if c.wantError {
+					t.Fatalf("I did expect an error but I got %s", got)
+				}
+				if d := cmp.Diff(artifactPackagedEventType, got); d != "" {
+					t.Errorf("Wrong Event Type %s", diff.PrintWantGot(d))
+				}
+			}
+		})
+	}
+}
+
+func TestArtifactEventsForPipelineRun(t *testing.T) {
+	pipelineRunTests := []struct {
+		desc        string
+		pipelineRun *v1beta1.PipelineRun
+		wantError   bool
+	}{{
+		desc:        "pipelinerun with no annotations",
+		pipelineRun: getPipelineRunByCondition(corev1.ConditionUnknown, v1beta1.PipelineRunReasonStarted.String()),
+		wantError:   true,
+	}, {
+		desc: "pipelinerun with annotation, started",
+		pipelineRun: getPipelineRunByConditionAndResults(
+			corev1.ConditionUnknown,
+			v1beta1.PipelineRunReasonStarted.String(),
+			map[string]string{CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{}),
+		wantError: true,
+	}, {
+		desc: "pipelinerun with annotation, finished, failed",
+		pipelineRun: getPipelineRunByConditionAndResults(
+			corev1.ConditionFalse,
+			"meh",
+			map[string]string{CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{}),
+		wantError: true,
+	}, {
+		desc: "pipelinerun with annotation, finished, succeeded",
+		pipelineRun: getPipelineRunByConditionAndResults(
+			corev1.ConditionTrue,
+			"yay",
+			map[string]string{CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{}),
+		wantError: false,
+	}}
+
+	for _, c := range pipelineRunTests {
+		t.Run(c.desc, func(t *testing.T) {
+			names.TestingSeed()
+
+			got, err := getArtifactPublishedEventType(c.pipelineRun)
+			if err != nil {
+				if !c.wantError {
+					t.Fatalf("I did not expect an error but I got %s", err)
+				}
+			} else {
+				if c.wantError {
+					t.Fatalf("I did expect an error but I got %s", got)
+				}
+				if d := cmp.Diff(artifactPublishedEventType, got); d != "" {
+					t.Errorf("Wrong Event Type %s", diff.PrintWantGot(d))
+				}
+			}
+		})
+	}
+}
+
+func TestGetArtifactEventDataPipelineRun(t *testing.T) {
+	pipelineRunTests := []struct {
+		desc        string
+		pipelineRun *v1beta1.PipelineRun
+		wantData    CDECloudEventData
+		wantError   bool
+	}{{
+		desc: "pipelinerun with default results, all",
+		pipelineRun: getPipelineRunByConditionAndResults(
+			corev1.ConditionUnknown,
+			v1beta1.PipelineRunReasonStarted.String(),
+			map[string]string{
+				CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{
+				"cd.artifact.id":      "test123",
+				"cd.artifact.version": "v123",
+				"cd.artifact.name":    "testArtifact",
+			}),
+		wantData: CDECloudEventData{
+			"artifactId":      "test123",
+			"artifactVersion": "v123",
+			"artifactName":    "testArtifact"},
+		wantError: false,
+	}, {
+		desc: "pipelinerun with default results, missing",
+		pipelineRun: getPipelineRunByConditionAndResults(
+			corev1.ConditionUnknown,
+			v1beta1.PipelineRunReasonStarted.String(),
+			map[string]string{
+				CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{
+				"cd.artifact.id":      "test123",
+				"cd.artifact.version": "v123",
+			}),
+		wantData:  nil,
+		wantError: true,
+	}, {
+		desc: "pipelinerun with overwritten results, all",
+		pipelineRun: getPipelineRunByConditionAndResults(
+			corev1.ConditionUnknown,
+			v1beta1.PipelineRunReasonStarted.String(),
+			map[string]string{
+				CDEventAnnotationTypeKey:                            string(ArtifactPublishedEventAnnotation),
+				mappings["artifactId"].annotationResultNameKey:      "builtImage",
+				mappings["artifactVersion"].annotationResultNameKey: "tag"},
+			map[string]string{
+				"builtImage":       "test123",
+				"cd.artifact.name": "testimage",
+				"tag":              "v123",
+			}),
+		wantData: CDECloudEventData{
+			"artifactId":      "test123",
+			"artifactVersion": "v123",
+			"artifactName":    "testimage"},
+		wantError: false,
+	}, {
+		desc: "pipelinerun with overwritten results, missing an overwritten one",
+		pipelineRun: getPipelineRunByConditionAndResults(
+			corev1.ConditionUnknown,
+			v1beta1.PipelineRunReasonStarted.String(),
+			map[string]string{
+				CDEventAnnotationTypeKey:                            string(ArtifactPublishedEventAnnotation),
+				mappings["artifactId"].annotationResultNameKey:      "builtImage",
+				mappings["artifactVersion"].annotationResultNameKey: "tag"},
+			map[string]string{
+				"builtImage":       "test123",
+				"cd.artifact.name": "testimage",
+			}),
+		wantData:  nil,
+		wantError: true,
+	}}
+
+	for _, c := range pipelineRunTests {
+		t.Run(c.desc, func(t *testing.T) {
+			names.TestingSeed()
+
+			got, err := getArtifactEventData(c.pipelineRun)
+			if err != nil {
+				if !c.wantError {
+					t.Fatalf("I did not expect an error but I got %s", err)
+				}
+			} else {
+				if c.wantError {
+					t.Fatalf("I did expect an error but I got %s", got)
+				}
+				opt := cmpopts.IgnoreMapEntries(func(k string, v string) bool { return k == "pipelinerun" })
+				if d := cmp.Diff(c.wantData, got, opt); d != "" {
+					t.Errorf("Wrong Event Data %s", diff.PrintWantGot(d))
+				}
+			}
+		})
+	}
+}
+
+func TestGetArtifactEventDataTaskRun(t *testing.T) {
+	taskRunTests := []struct {
+		desc      string
+		taskRun   *v1beta1.TaskRun
+		wantData  CDECloudEventData
+		wantError bool
+	}{{
+		desc: "taskrun with default results, all",
+		taskRun: getTaskRunByConditionAndResults(
+			corev1.ConditionUnknown,
+			v1beta1.TaskRunReasonStarted.String(),
+			map[string]string{
+				CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{
+				"cd.artifact.id":      "test123",
+				"cd.artifact.version": "v123",
+				"cd.artifact.name":    "testArtifact",
+			}),
+		wantData: CDECloudEventData{
+			"artifactId":      "test123",
+			"artifactVersion": "v123",
+			"artifactName":    "testArtifact"},
+		wantError: false,
+	}, {
+		desc: "taskrun with default results, missing",
+		taskRun: getTaskRunByConditionAndResults(
+			corev1.ConditionUnknown,
+			v1beta1.TaskRunReasonStarted.String(),
+			map[string]string{
+				CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{
+				"cd.artifact.id":      "test123",
+				"cd.artifact.version": "v123",
+			}),
+		wantData:  nil,
+		wantError: true,
+	}, {
+		desc: "taskrun with overwritten results, all",
+		taskRun: getTaskRunByConditionAndResults(
+			corev1.ConditionUnknown,
+			v1beta1.TaskRunReasonStarted.String(),
+			map[string]string{
+				CDEventAnnotationTypeKey:                            string(ArtifactPublishedEventAnnotation),
+				mappings["artifactId"].annotationResultNameKey:      "builtImage",
+				mappings["artifactVersion"].annotationResultNameKey: "tag"},
+			map[string]string{
+				"builtImage":       "test123",
+				"cd.artifact.name": "testimage",
+				"tag":              "v123",
+			}),
+		wantData: CDECloudEventData{
+			"artifactId":      "test123",
+			"artifactVersion": "v123",
+			"artifactName":    "testimage"},
+		wantError: false,
+	}, {
+		desc: "taskrun with overwritten results, missing an overwritten one",
+		taskRun: getTaskRunByConditionAndResults(
+			corev1.ConditionUnknown,
+			v1beta1.TaskRunReasonStarted.String(),
+			map[string]string{
+				CDEventAnnotationTypeKey:                            string(ArtifactPublishedEventAnnotation),
+				mappings["artifactId"].annotationResultNameKey:      "builtImage",
+				mappings["artifactVersion"].annotationResultNameKey: "tag"},
+			map[string]string{
+				"builtImage":       "test123",
+				"cd.artifact.name": "testimage",
+			}),
+		wantData:  nil,
+		wantError: true,
+	}}
+
+	for _, c := range taskRunTests {
+		t.Run(c.desc, func(t *testing.T) {
+			names.TestingSeed()
+
+			got, err := getArtifactEventData(c.taskRun)
+			if err != nil {
+				if !c.wantError {
+					t.Fatalf("I did not expect an error but I got %s", err)
+				}
+			} else {
+				if c.wantError {
+					t.Fatalf("I did expect an error but I got %s", got)
+				}
+				opt := cmpopts.IgnoreMapEntries(func(k string, v string) bool { return k == "taskrun" })
+				if d := cmp.Diff(c.wantData, got, opt); d != "" {
+					t.Errorf("Wrong Event Data %s", diff.PrintWantGot(d))
+				}
+			}
+		})
+	}
+}
+
+func TestArtifactPublishedEvent(t *testing.T) {
+	artifactPublishedTests := []struct {
+		desc                string
+		object              interface{}
+		wantEventExtensions map[string]interface{}
+	}{{
+		desc: "artifact event for taskrun",
+		object: getTaskRunByConditionAndResults(
+			corev1.ConditionTrue,
+			v1beta1.TaskRunReasonSuccessful.String(),
+			map[string]string{
+				CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{
+				"cd.artifact.id":      "test123",
+				"cd.artifact.version": "v123",
+				"cd.artifact.name":    "testArtifact",
+			}),
+		wantEventExtensions: map[string]interface{}{
+			"artifactid":      "test123",
+			"artifactversion": "v123",
+			"artifactname":    "testArtifact",
+		},
+	}, {
+		desc: "artifact event for pipelinerun",
+		object: getPipelineRunByConditionAndResults(
+			corev1.ConditionTrue,
+			v1beta1.PipelineRunReasonSuccessful.String(),
+			map[string]string{
+				CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{
+				"cd.artifact.id":      "test123",
+				"cd.artifact.version": "v123",
+				"cd.artifact.name":    "testArtifact",
+			}),
+		wantEventExtensions: map[string]interface{}{
+			"artifactid":      "test123",
+			"artifactversion": "v123",
+			"artifactname":    "testArtifact",
+		},
+	}}
+
+	for _, c := range artifactPublishedTests {
+		t.Run(c.desc, func(t *testing.T) {
+			names.TestingSeed()
+
+			got, err := artifactPublishedEvenForObjectWithCondition(c.object.(objectWithCondition))
+			if err != nil {
+				t.Fatalf("I did not expect an error but I got %s", err)
+			} else {
+				extensions := got.Extensions()
+				if d := cmp.Diff(c.wantEventExtensions, extensions); d != "" {
+					t.Errorf("Wrong Event Extenstions %s", diff.PrintWantGot(d))
+				}
+			}
+		})
+	}
+}
+
+func TestArtifactPackagedEvent(t *testing.T) {
+	artifactPackagedTests := []struct {
+		desc                string
+		object              interface{}
+		wantEventExtensions map[string]interface{}
+	}{{
+		desc: "artifact event for taskrun",
+		object: getTaskRunByConditionAndResults(
+			corev1.ConditionTrue,
+			v1beta1.TaskRunReasonSuccessful.String(),
+			map[string]string{
+				CDEventAnnotationTypeKey: string(ArtifactPackagedEventAnnotation)},
+			map[string]string{
+				"cd.artifact.id":      "test123",
+				"cd.artifact.version": "v123",
+				"cd.artifact.name":    "testArtifact",
+			}),
+		wantEventExtensions: map[string]interface{}{
+			"artifactid":      "test123",
+			"artifactversion": "v123",
+			"artifactname":    "testArtifact",
+		},
+	}, {
+		desc: "artifact event for pipelinerun",
+		object: getPipelineRunByConditionAndResults(
+			corev1.ConditionTrue,
+			v1beta1.PipelineRunReasonSuccessful.String(),
+			map[string]string{
+				CDEventAnnotationTypeKey: string(ArtifactPackagedEventAnnotation)},
+			map[string]string{
+				"cd.artifact.id":      "test123",
+				"cd.artifact.version": "v123",
+				"cd.artifact.name":    "testArtifact",
+			}),
+		wantEventExtensions: map[string]interface{}{
+			"artifactid":      "test123",
+			"artifactversion": "v123",
+			"artifactname":    "testArtifact",
+		},
+	}}
+
+	for _, c := range artifactPackagedTests {
+		t.Run(c.desc, func(t *testing.T) {
+			names.TestingSeed()
+
+			got, err := artifactPackagedEvenForObjectWithCondition(c.object.(objectWithCondition))
+			if err != nil {
+				t.Fatalf("I did not expect an error but I got %s", err)
+			} else {
+				extensions := got.Extensions()
+				if d := cmp.Diff(c.wantEventExtensions, extensions); d != "" {
+					t.Errorf("Wrong Event Extenstions %s", diff.PrintWantGot(d))
+				}
+			}
+		})
+	}
+}

--- a/cloudevents/pkg/reconciler/events/cloudevent/cloudevent_test.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/cloudevent_test.go
@@ -219,3 +219,10 @@ func TestEventForPipelineRun(t *testing.T) {
 		})
 	}
 }
+
+func TestEventTypeInvalidType(t *testing.T) {
+	eventType, err := eventForObjectWithCondition(myObjectWithCondition{})
+	if err == nil {
+		t.Fatalf("expected an error, got nil and eventType %s", eventType)
+	}
+}

--- a/cloudevents/pkg/reconciler/events/cloudevent/interface.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/interface.go
@@ -1,6 +1,7 @@
 package cloudevent
 
 import (
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
@@ -18,3 +19,12 @@ type objectWithCondition interface {
 	// GetStatusCondition returns a ConditionAccessor for the status of the RunsToCompletion
 	GetStatusCondition() apis.ConditionAccessor
 }
+
+// cdEventAnnotationKey is the name of the annotations used to store the kind of CD Event
+const CDEventAnnotationTypeKey string = "cd.events/type"
+
+// cdEventAnnotationType is an ENUM with all possible values for cdEventAnnotationKey
+type cdEventAnnotationType string
+
+// cdEventCreate is a function that creates a cd event from an objectWithCondition
+type cdEventCreator func(runObject objectWithCondition) (*cloudevents.Event, error)

--- a/cloudevents/pkg/reconciler/events/cloudevent/interface_test.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/interface_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevent
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/apis"
+)
+
+// myObjectWithCondition is an objectWithCondition that is not PipelineRUn or TaskRun
+type myObjectWithCondition struct{}
+
+func (mowc myObjectWithCondition) DeepCopyObject() runtime.Object             { return nil }
+func (mowc myObjectWithCondition) GetObjectKind() schema.ObjectKind           { return nil }
+func (mowc myObjectWithCondition) GetObjectMeta() metav1.Object               { return nil }
+func (mowc myObjectWithCondition) GetStatusCondition() apis.ConditionAccessor { return nil }

--- a/cloudevents/pkg/reconciler/events/cloudevent/results.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/results.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevent
+
+import (
+	"fmt"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type resultMapping struct {
+	defaultResultName       string
+	annotationResultNameKey string
+}
+
+func resultName(objectMeta metav1.Object, mapping resultMapping) string {
+	if name, ok := objectMeta.GetAnnotations()[mapping.annotationResultNameKey]; ok {
+		return name
+	}
+	return mapping.defaultResultName
+}
+
+func resultFromObjectWithCondition(runObject objectWithCondition, resultName string) (string, error) {
+	switch run := runObject.(type) {
+	case *v1beta1.TaskRun:
+		for _, result := range run.Status.TaskRunResults {
+			if result.Name == resultName {
+				return result.Value, nil
+			}
+		}
+		return "", fmt.Errorf("no result with name %s found", resultName)
+	case *v1beta1.PipelineRun:
+		for _, result := range run.Status.PipelineResults {
+			if result.Name == resultName {
+				return result.Value, nil
+			}
+		}
+		return "", fmt.Errorf("no result with name %s found", resultName)
+	}
+	return "", fmt.Errorf("unknown type of Tekton resource")
+}
+
+func resultForMapping(runObject objectWithCondition, mapping resultMapping) (string, error) {
+	name := resultName(runObject.GetObjectMeta(), mapping)
+	return resultFromObjectWithCondition(runObject, name)
+}

--- a/cloudevents/pkg/reconciler/events/cloudevent/results_test.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/results_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevent
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/test/diff"
+	"github.com/tektoncd/pipeline/test/names"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestResultFromObjectWithCondition(t *testing.T) {
+	var myObject myObjectWithCondition
+	myObject = myObjectWithCondition{}
+	resultTests := []struct {
+		desc       string
+		object     interface{}
+		resultName string
+		wantResult string
+		wantError  bool
+	}{{
+		desc:       "not a taskrun or pipelinerun",
+		object:     &myObject,
+		resultName: "foobar",
+		wantResult: "",
+		wantError:  true,
+	}, {
+		desc: "pipelinerun with result",
+		object: getPipelineRunByConditionAndResults(
+			corev1.ConditionUnknown,
+			"somethingsomething",
+			map[string]string{},
+			map[string]string{"test1": "value1", "test2": "value2"}),
+		resultName: "test2",
+		wantResult: "value2",
+		wantError:  false,
+	}, {
+		desc: "pipelinerun without result",
+		object: getPipelineRunByConditionAndResults(
+			corev1.ConditionUnknown,
+			"somethingsomething",
+			map[string]string{},
+			map[string]string{"test1": "value1", "test2": "value2"}),
+		resultName: "missing",
+		wantResult: "",
+		wantError:  true,
+	}, {
+		desc: "taskrun with result",
+		object: getTaskRunByConditionAndResults(
+			corev1.ConditionUnknown,
+			"somethingsomething",
+			map[string]string{},
+			map[string]string{"test1": "value1", "test2": "value2"}),
+		resultName: "test2",
+		wantResult: "value2",
+		wantError:  false,
+	}, {
+		desc: "taskrun without result",
+		object: getTaskRunByConditionAndResults(
+			corev1.ConditionUnknown,
+			"somethingsomething",
+			map[string]string{},
+			map[string]string{"test1": "value1", "test2": "value2"}),
+		resultName: "missing",
+		wantResult: "",
+		wantError:  true,
+	}}
+
+	for _, c := range resultTests {
+		t.Run(c.desc, func(t *testing.T) {
+			names.TestingSeed()
+
+			got, err := resultFromObjectWithCondition(c.object.(objectWithCondition), c.resultName)
+			if err != nil {
+				if !c.wantError {
+					t.Fatalf("I did not expect an error but I got %s", err)
+				}
+			} else {
+				if c.wantError {
+					t.Fatalf("I did expect an error but I got %s", got)
+				}
+				if d := cmp.Diff(c.wantResult, got); d != "" {
+					t.Errorf("Wrong result %s", diff.PrintWantGot(d))
+				}
+			}
+		})
+	}
+}

--- a/cloudevents/pkg/reconciler/pipelinerun/reconciler.go
+++ b/cloudevents/pkg/reconciler/pipelinerun/reconciler.go
@@ -30,49 +30,6 @@ import (
 
 type CDEventType string
 
-const (
-//// Environment Annotation
-//cdEnv = "tekton.dev/cd.environment.v1"
-//// Environment Annotation Values
-//cdEnvCreated = "created"
-//cdEnvModified = "modified"
-//cdEnvDeleted = "deleted"
-//
-//// Service Annotation
-//cdSvc = "tekton.dev/cd.service.v1"
-//// states
-//cdSvcStarted = "deployed"
-//cdSvcUpgraded = "upgraded"
-//cdSvcRolledback = "rolledback"
-//cdSvcRemoved = "removed"
-//
-//// TaskRun Annotation
-//cdTR = "tekton.dev/cd.taskrun.v1"
-//// states
-//cdTRStarted = "started"
-//cdTRFinished = "finished"
-//cdTRQueued = "queued"
-//
-//// Repository Annotation
-//cdRepo = "tekton.dev/cd.repository.v1"
-//// states
-//cdRepoCreated = "created"
-//cdRepoModified = "modified"
-//cdRepoDeleted = "deleted"
-
-//// PipelineRun Annotations
-//cdPipelineRunID = "cd.tekton.dev/pipelinerun.v1/id"
-//// states
-//cdPRStarted = "started"
-//cdPRFinished = "finished"
-//cdPRQueued = "queued"
-//
-//// PipelineRun events
-//PipelineRunStartedEventV1 CDEventType = "cd.pipelinerun.started.v1"
-//PipelineRunFinishedEventV1 CDEventType = "cd.pipelinerun.finished.v1"
-//PipelineRunQueuedEventV1 CDEventType = "cd.pipelinerun.queued.v1"
-)
-
 func (t CDEventType) String() string {
 	return string(t)
 }


### PR DESCRIPTION
# Changes

Add a new module that implements artifact event types, with the
corresponding selection logic.

WIP, still todo:
- function to build data
- change core logic to send all matching events

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._