### PR TITLE
[cloudevents] Allow for multiple annotations

### DIFF
--- a/cloudevents/pkg/reconciler/events/cloudevent/artifacts.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/artifacts.go
@@ -66,23 +66,19 @@ func getArtifactEventType(runObject objectWithCondition, cdEventType cdeevents.C
 // getArtifactPackagedEventType returns a CDF Artifact Packaged EventType if objectWithCondition meets conditions
 func getArtifactPackagedEventType(runObject objectWithCondition) (*EventType, error) {
 	annotations := runObject.GetObjectMeta().GetAnnotations()
-	if name, ok := annotations[CDEventAnnotationTypeKey]; ok {
-		if name == string(ArtifactPackagedEventAnnotation) {
-			return getArtifactEventType(runObject, cdeevents.ArtifactPackagedEventV1)
-		}
+	if _, ok := annotations[ArtifactPackagedEventAnnotation.String()]; ok {
+		return getArtifactEventType(runObject, cdeevents.ArtifactPackagedEventV1)
 	}
-	return nil, fmt.Errorf("no %s annotation found", CDEventAnnotationTypeKey)
+	return nil, fmt.Errorf("no %s annotation found", ArtifactPackagedEventAnnotation.String())
 }
 
 // getArtifactPublishedEventType returns a CDF Artifact Published EventType if objectWithCondition meets conditions
 func getArtifactPublishedEventType(runObject objectWithCondition) (*EventType, error) {
 	annotations := runObject.GetObjectMeta().GetAnnotations()
-	if name, ok := annotations[CDEventAnnotationTypeKey]; ok {
-		if name == string(ArtifactPublishedEventAnnotation) {
-			return getArtifactEventType(runObject, cdeevents.ArtifactPublishedEventV1)
-		}
+	if _, ok := annotations[ArtifactPublishedEventAnnotation.String()]; ok {
+		return getArtifactEventType(runObject, cdeevents.ArtifactPublishedEventV1)
 	}
-	return nil, fmt.Errorf("no %s annotation found", CDEventAnnotationTypeKey)
+	return nil, fmt.Errorf("no %s annotation found", ArtifactPublishedEventAnnotation.String())
 }
 
 // getArtifactEventData
@@ -130,6 +126,7 @@ func artifactPackagedEvenForObjectWithCondition(runObject objectWithCondition) (
 	if err != nil {
 		return nil, err
 	}
+	event.SetSource(getSource(runObject))
 	return &event, nil
 }
 
@@ -152,5 +149,6 @@ func artifactPublishedEvenForObjectWithCondition(runObject objectWithCondition) 
 	if err != nil {
 		return nil, err
 	}
+	event.SetSource(getSource(runObject))
 	return &event, nil
 }

--- a/cloudevents/pkg/reconciler/events/cloudevent/artifacts_test.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/artifacts_test.go
@@ -75,7 +75,7 @@ func TestArtifactEventsForTaskRun(t *testing.T) {
 		taskRun: getTaskRunByConditionAndResults(
 			corev1.ConditionUnknown,
 			v1beta1.TaskRunReasonStarted.String(),
-			map[string]string{CDEventAnnotationTypeKey: string(ArtifactPackagedEventAnnotation)},
+			map[string]string{ArtifactPackagedEventAnnotation.String(): ""},
 			map[string]string{}),
 		wantError: true,
 	}, {
@@ -83,7 +83,7 @@ func TestArtifactEventsForTaskRun(t *testing.T) {
 		taskRun: getTaskRunByConditionAndResults(
 			corev1.ConditionFalse,
 			"meh",
-			map[string]string{CDEventAnnotationTypeKey: string(ArtifactPackagedEventAnnotation)},
+			map[string]string{ArtifactPackagedEventAnnotation.String(): ""},
 			map[string]string{}),
 		wantError: true,
 	}, {
@@ -91,7 +91,7 @@ func TestArtifactEventsForTaskRun(t *testing.T) {
 		taskRun: getTaskRunByConditionAndResults(
 			corev1.ConditionTrue,
 			"yay",
-			map[string]string{CDEventAnnotationTypeKey: string(ArtifactPackagedEventAnnotation)},
+			map[string]string{ArtifactPackagedEventAnnotation.String(): ""},
 			map[string]string{}),
 		wantError: false,
 	}}
@@ -131,7 +131,7 @@ func TestArtifactEventsForPipelineRun(t *testing.T) {
 		pipelineRun: getPipelineRunByConditionAndResults(
 			corev1.ConditionUnknown,
 			v1beta1.PipelineRunReasonStarted.String(),
-			map[string]string{CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{ArtifactPublishedEventAnnotation.String(): ""},
 			map[string]string{}),
 		wantError: true,
 	}, {
@@ -139,7 +139,7 @@ func TestArtifactEventsForPipelineRun(t *testing.T) {
 		pipelineRun: getPipelineRunByConditionAndResults(
 			corev1.ConditionFalse,
 			"meh",
-			map[string]string{CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{ArtifactPublishedEventAnnotation.String(): ""},
 			map[string]string{}),
 		wantError: true,
 	}, {
@@ -147,7 +147,7 @@ func TestArtifactEventsForPipelineRun(t *testing.T) {
 		pipelineRun: getPipelineRunByConditionAndResults(
 			corev1.ConditionTrue,
 			"yay",
-			map[string]string{CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{ArtifactPublishedEventAnnotation.String(): ""},
 			map[string]string{}),
 		wantError: false,
 	}}
@@ -184,8 +184,7 @@ func TestGetArtifactEventDataPipelineRun(t *testing.T) {
 		pipelineRun: getPipelineRunByConditionAndResults(
 			corev1.ConditionUnknown,
 			v1beta1.PipelineRunReasonStarted.String(),
-			map[string]string{
-				CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{ArtifactPublishedEventAnnotation.String(): ""},
 			map[string]string{
 				"cd.artifact.id":      "test123",
 				"cd.artifact.version": "v123",
@@ -201,8 +200,7 @@ func TestGetArtifactEventDataPipelineRun(t *testing.T) {
 		pipelineRun: getPipelineRunByConditionAndResults(
 			corev1.ConditionUnknown,
 			v1beta1.PipelineRunReasonStarted.String(),
-			map[string]string{
-				CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{ArtifactPublishedEventAnnotation.String(): ""},
 			map[string]string{
 				"cd.artifact.id":      "test123",
 				"cd.artifact.version": "v123",
@@ -215,7 +213,7 @@ func TestGetArtifactEventDataPipelineRun(t *testing.T) {
 			corev1.ConditionUnknown,
 			v1beta1.PipelineRunReasonStarted.String(),
 			map[string]string{
-				CDEventAnnotationTypeKey:                            string(ArtifactPublishedEventAnnotation),
+				ArtifactPublishedEventAnnotation.String():           "",
 				mappings["artifactId"].annotationResultNameKey:      "builtImage",
 				mappings["artifactVersion"].annotationResultNameKey: "tag"},
 			map[string]string{
@@ -234,7 +232,7 @@ func TestGetArtifactEventDataPipelineRun(t *testing.T) {
 			corev1.ConditionUnknown,
 			v1beta1.PipelineRunReasonStarted.String(),
 			map[string]string{
-				CDEventAnnotationTypeKey:                            string(ArtifactPublishedEventAnnotation),
+				ArtifactPublishedEventAnnotation.String():           "",
 				mappings["artifactId"].annotationResultNameKey:      "builtImage",
 				mappings["artifactVersion"].annotationResultNameKey: "tag"},
 			map[string]string{
@@ -278,8 +276,7 @@ func TestGetArtifactEventDataTaskRun(t *testing.T) {
 		taskRun: getTaskRunByConditionAndResults(
 			corev1.ConditionUnknown,
 			v1beta1.TaskRunReasonStarted.String(),
-			map[string]string{
-				CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{ArtifactPublishedEventAnnotation.String(): ""},
 			map[string]string{
 				"cd.artifact.id":      "test123",
 				"cd.artifact.version": "v123",
@@ -295,8 +292,7 @@ func TestGetArtifactEventDataTaskRun(t *testing.T) {
 		taskRun: getTaskRunByConditionAndResults(
 			corev1.ConditionUnknown,
 			v1beta1.TaskRunReasonStarted.String(),
-			map[string]string{
-				CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{ArtifactPublishedEventAnnotation.String(): ""},
 			map[string]string{
 				"cd.artifact.id":      "test123",
 				"cd.artifact.version": "v123",
@@ -309,7 +305,7 @@ func TestGetArtifactEventDataTaskRun(t *testing.T) {
 			corev1.ConditionUnknown,
 			v1beta1.TaskRunReasonStarted.String(),
 			map[string]string{
-				CDEventAnnotationTypeKey:                            string(ArtifactPublishedEventAnnotation),
+				ArtifactPublishedEventAnnotation.String():           "",
 				mappings["artifactId"].annotationResultNameKey:      "builtImage",
 				mappings["artifactVersion"].annotationResultNameKey: "tag"},
 			map[string]string{
@@ -328,7 +324,7 @@ func TestGetArtifactEventDataTaskRun(t *testing.T) {
 			corev1.ConditionUnknown,
 			v1beta1.TaskRunReasonStarted.String(),
 			map[string]string{
-				CDEventAnnotationTypeKey:                            string(ArtifactPublishedEventAnnotation),
+				ArtifactPublishedEventAnnotation.String():           "",
 				mappings["artifactId"].annotationResultNameKey:      "builtImage",
 				mappings["artifactVersion"].annotationResultNameKey: "tag"},
 			map[string]string{
@@ -371,8 +367,7 @@ func TestArtifactPublishedEvent(t *testing.T) {
 		object: getTaskRunByConditionAndResults(
 			corev1.ConditionTrue,
 			v1beta1.TaskRunReasonSuccessful.String(),
-			map[string]string{
-				CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{ArtifactPublishedEventAnnotation.String(): ""},
 			map[string]string{
 				"cd.artifact.id":      "test123",
 				"cd.artifact.version": "v123",
@@ -388,8 +383,7 @@ func TestArtifactPublishedEvent(t *testing.T) {
 		object: getPipelineRunByConditionAndResults(
 			corev1.ConditionTrue,
 			v1beta1.PipelineRunReasonSuccessful.String(),
-			map[string]string{
-				CDEventAnnotationTypeKey: string(ArtifactPublishedEventAnnotation)},
+			map[string]string{ArtifactPublishedEventAnnotation.String(): ""},
 			map[string]string{
 				"cd.artifact.id":      "test123",
 				"cd.artifact.version": "v123",
@@ -430,7 +424,7 @@ func TestArtifactPackagedEvent(t *testing.T) {
 			corev1.ConditionTrue,
 			v1beta1.TaskRunReasonSuccessful.String(),
 			map[string]string{
-				CDEventAnnotationTypeKey: string(ArtifactPackagedEventAnnotation)},
+				ArtifactPackagedEventAnnotation.String(): ""},
 			map[string]string{
 				"cd.artifact.id":      "test123",
 				"cd.artifact.version": "v123",
@@ -447,7 +441,7 @@ func TestArtifactPackagedEvent(t *testing.T) {
 			corev1.ConditionTrue,
 			v1beta1.PipelineRunReasonSuccessful.String(),
 			map[string]string{
-				CDEventAnnotationTypeKey: string(ArtifactPackagedEventAnnotation)},
+				ArtifactPackagedEventAnnotation.String(): ""},
 			map[string]string{
 				"cd.artifact.id":      "test123",
 				"cd.artifact.version": "v123",

--- a/cloudevents/pkg/reconciler/events/cloudevent/interface.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/interface.go
@@ -20,11 +20,12 @@ type objectWithCondition interface {
 	GetStatusCondition() apis.ConditionAccessor
 }
 
-// cdEventAnnotationKey is the name of the annotations used to store the kind of CD Event
-const CDEventAnnotationTypeKey string = "cd.events/type"
-
 // cdEventAnnotationType is an ENUM with all possible values for cdEventAnnotationKey
 type cdEventAnnotationType string
+
+func (cdea cdEventAnnotationType) String() string {
+	return string(cdea)
+}
 
 // cdEventCreate is a function that creates a cd event from an objectWithCondition
 type cdEventCreator func(runObject objectWithCondition) (*cloudevents.Event, error)

--- a/cloudevents/pkg/reconciler/pipelinerun/reconciler_test.go
+++ b/cloudevents/pkg/reconciler/pipelinerun/reconciler_test.go
@@ -280,7 +280,7 @@ func TestReconcile_CloudEvents(t *testing.T) {
 		},
 		startTime: true,
 		annotations: map[string]string{
-			cloudevent.CDEventAnnotationTypeKey: string(cloudevent.ArtifactPackagedEventAnnotation),
+			cloudevent.ArtifactPackagedEventAnnotation.String(): "",
 		},
 		results: map[string]string{
 			"cd.artifact.id":      "456",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Annotations is a dictionary so each key is unique.
Because of this, pipeline and tasks were previously limited to
one extra kind of cd event.

Change the notation to move the event type to the key, and thus
allow multiple events to be attached. The value is irrelevan for now
but it might be used in future to express extra configurations.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
