### PR TITLE
[github notifier] Short circuit if resources do not contain matching annotations.

### DIFF
--- a/notifiers/github-app/pkg/controller/controller.go
+++ b/notifiers/github-app/pkg/controller/controller.go
@@ -60,6 +60,11 @@ func (r *GitHubAppReconciler) Reconcile(ctx context.Context, reconcileKey string
 	}
 	log = log.With(zap.String("uid", string(tr.UID)))
 
+	if tr.Annotations[key("owner")] == "" || tr.Annotations[key("repo")] == "" {
+		log.Info("no GitHub annotations found, skipping.")
+		return nil
+	}
+
 	log.Info("Sending update")
 
 	// If no installation is associated, assume a non-GitHub App status.


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Previously we would attempt to process the trigger, even if we didn't
find the information we needed, which would cause reconcile loops since
we'd report error. This changes the behavior to only process resources
that contain the GitHub annotations.


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._

/kind bug