### PR TITLE
[commit-status-tracker] git-repo and git-revision via annotations

### DIFF
--- a/commit-status-tracker/README.md
+++ b/commit-status-tracker/README.md
@@ -98,6 +98,26 @@ The annotations are:
     <td>No</td>
     <td>""</td>
   </tr>
+  <tr>
+    <th>
+     tekton.dev/git-repo
+    </th>
+    <td>
+      If provided together with <i>tekton.dev/git-revision</i> detecting the git repository from PiplineResource is skipped and given repository url is used
+    </td>
+    <td>No</td>
+    <td></td>
+  </tr>
+  <tr>
+    <th>
+     tekton.dev/git-revision
+    </th>
+    <td>
+      If provided together with <i>tekton.dev/git-repo</i> detecting the git repository from PiplineResource is skipped and given commit sha is used
+    </td>
+    <td>No</td>
+    <td></td>
+  </tr>
 </table>
 
 ## Detecting the Git Repository
@@ -109,6 +129,8 @@ It looks for a single `PipelineResource` of type `git` and pulls the *url* and *
 If no suitable `PipelineResource` is found, then this will be logged as an
 error, and _not_ retried.
 
+To override this behaviour (e.g. to support `Pipelines` which uses the _git-clone_ `Task`)
+provide a git repository url and a commit sha via annotations
 ## Private Git repository hosts
 
 You'll need to configure the deployment:

--- a/commit-status-tracker/pkg/controller/pipelinerun/annotations.go
+++ b/commit-status-tracker/pkg/controller/pipelinerun/annotations.go
@@ -21,4 +21,8 @@ const (
 
 	// TODO: This could also come from a ConfigMap based on the context.
 	statusDescriptionName = "tekton.dev/status-description"
+
+	// Annotations to override PipelineResource discovery behaviour
+	gitRepoToReportTo = "tekton.dev/git-repo"
+	gitRevision       = "tekton.dev/git-revision"
 )


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
I added the possibility to provide the git-repo and git-revision as annotations.
This is should be useful when no git PipelineResource is used (e.g. git-clone Task) to fetch code from a repo.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
