### PR TITLE
[cloudevents] Fix source and subject

### DIFF
--- a/cloudevents/pkg/reconciler/events/cloudevent/artifacts.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/artifacts.go
@@ -124,6 +124,7 @@ func artifactPackagedEventForObjectWithCondition(runObject objectWithCondition) 
 	if err != nil {
 		return nil, err
 	}
+	event.SetSubject(runObject.GetObjectMeta().GetName())
 	event.SetSource(getSource(runObject))
 	return &event, nil
 }
@@ -147,6 +148,7 @@ func artifactPublishedEventForObjectWithCondition(runObject objectWithCondition)
 	if err != nil {
 		return nil, err
 	}
+	event.SetSubject(runObject.GetObjectMeta().GetName())
 	event.SetSource(getSource(runObject))
 	return &event, nil
 }

--- a/cloudevents/pkg/reconciler/events/cloudevent/services.go
+++ b/cloudevents/pkg/reconciler/events/cloudevent/services.go
@@ -127,6 +127,7 @@ func serviceEventFromType(eventType *EventType, runObject objectWithCondition) (
 	if err != nil {
 		return nil, err
 	}
+	event.SetSubject(runObject.GetObjectMeta().GetName())
 	event.SetSource(getSource(runObject))
 	return &event, nil
 }


### PR DESCRIPTION
Remove the resource name from the source and make sure it's set
always as subject. The resource name in the source makes it harder
to setup event filters / triggers based on source, so it should not
be included in there. That information is available in the subject
anyways already.

The group/kind/version information is missing in the objects passed
to "ReconcileKind", so for now do not use them to build the source.
The kind (PipelineRun vs. TaskRun) can be identified from the object
type, group is always tekton.dev for Tekton resources, and the version
store is also always v1beta1, so they don't add any interesting info
to the source anyways.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
