### PR TITLE
[notifiers/github] Truncate GitHub status if > 140 chars

### DIFF
--- a/notifiers/github-app/pkg/controller/status_test.go
+++ b/notifiers/github-app/pkg/controller/status_test.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -67,5 +69,34 @@ func TestDashboardURL(t *testing.T) {
 	got := dashboardURL(taskrun("testdata/taskrun.yaml"))
 	if want != got {
 		t.Errorf("want: %s, got: %s", want, got)
+	}
+}
+
+func TestTruncateDescription(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want *string
+	}{
+		{
+			in:   "",
+			want: nil,
+		},
+		{
+			in:   "~",
+			want: github.String("~"),
+		},
+		{
+			in:   strings.Repeat("~", 140),
+			want: github.String(strings.Repeat("~", 140)),
+		},
+		{
+			in:   strings.Repeat("~", 141),
+			want: github.String(strings.Repeat("~", 137) + "..."),
+		},
+	} {
+		out := truncateDesc(tc.in)
+		if !reflect.DeepEqual(out, tc.want) {
+			t.Errorf("truncDesc(%s) = %v, want %v", tc.in, out, tc.want)
+		}
 	}
 }


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Certain statuses are failing with the error:

```
description is too long (maximum is 140 characters)
```

This truncates and descriptions to 140 characters if they exceed the
limit.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
