### PR TITLE
[notifiers/github] Add display name annotation.

### DIFF
--- a/notifiers/github-app/README.md
+++ b/notifiers/github-app/README.md
@@ -5,9 +5,11 @@ integration values to post information back to GitHub.
 
 This runs in 2 modes:
 
-- GitHub App : Converts the TaskRun into a [CheckRun](https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api) with
-corresponding status and logs.
-- GitHub OAuth : Converts the TaskRun into a [Status](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks).
+- GitHub App : Converts the TaskRun into a
+  [CheckRun](https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api)
+  with corresponding status and logs.
+- GitHub OAuth : Converts the TaskRun into a
+  [Status](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks).
 
 This does not do anything to grant the running TaskRun access to GitHub
 credentials (e.g. for cloning the repo) -
@@ -20,12 +22,13 @@ fine-grained installation permissions).
 The controller uses annotations with the prefix `github.integrations.tekton.dev`
 to identify and track TaskRuns to publish.
 
-| Annotation                                  | Description                                                                                                                                                                                                                                                         |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Annotation                                  | Description                                                                                                                                                                                                                                                                           |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | github.integrations.tekton.dev/installation | (GitHub App only) GitHub App Installation ID. This can be found in GitHub webhook events under the [`installations.id` field](https://docs.github.com/en/enterprise-server@2.20/developers/webhooks-and-events/webhook-events-and-payloads#webhook-payload-object-common-properties). |
-| github.integrations.tekton.dev/owner        | GitHub org or user who owns the repo (for `github.com/tektoncd/test`, this should be `tektoncd`).                                                                                                                                                                   |
-| github.integrations.tekton.dev/repo         | GitHub repo name (for `github.com/tektoncd/test`, this should be `test`).                                                                                                                                                                                           |
-| github.integrations.tekton.dev/checkrun     | (GitHub App / output only) GitHub CheckRun ID. If set, the controller will update this CheckRun instead of creating a new one.                                                                                                                                                   |
+| github.integrations.tekton.dev/owner        | GitHub org or user who owns the repo (for `github.com/tektoncd/test`, this should be `tektoncd`).                                                                                                                                                                                     |
+| github.integrations.tekton.dev/repo         | GitHub repo name (for `github.com/tektoncd/test`, this should be `test`).                                                                                                                                                                                                             |
+| github.integrations.tekton.dev/checkrun     | (GitHub App / output only) GitHub CheckRun ID. If set, the controller will update this CheckRun instead of creating a new one.                                                                                                                                                        |
+| github.integrations.tekton.dev/name         | Display name to use for GitHub CheckRun/Status. If not specified, defaults to the Tasks name.                                                                                                                                                                                         |
 
 For an example a full TaskRun with the initial annotations set, see
 [pkg/controller/testdata/taskrun.yaml](pkg/controller/testdata/taskrun.yaml)
@@ -33,10 +36,11 @@ For an example a full TaskRun with the initial annotations set, see
 
 ## Running the controller
 
-| Environment Variable | Description                                                                                                                                                            |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| GITHUB_APP_ID        | ID of your GitHub App. Can be found under https://github.com/settings/apps > Edit > General > About > App ID                                                           |
-| GITHUB_APP_KEY       | Path to the [private key of your GitHub App](https://docs.github.com/en/free-pro-team@latest/developers/apps/authenticating-with-github-apps#generating-a-private-key) |
+| Environment Variable | Description                                                                                                                                                                                                                |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GITHUB_APP_ID        | ID of your GitHub App. Can be found under https://github.com/settings/apps > Edit > General > About > App ID                                                                                                               |
+| GITHUB_APP_KEY       | Path to the [private key of your GitHub App](https://docs.github.com/en/free-pro-team@latest/developers/apps/authenticating-with-github-apps#generating-a-private-key)                                                     |
 | GITHUB_TOKEN         | GitHub Personal Access Token (https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). We strongly recommend **not** using your own personal GitHub Account - use a bot user instead. |
 
-If both GitHub App and GitHub OAuth variables are provided, the controller will use GitHub App.
+If both GitHub App and GitHub OAuth variables are provided, the controller will
+use GitHub App.

--- a/notifiers/github-app/pkg/controller/checkrun.go
+++ b/notifiers/github-app/pkg/controller/checkrun.go
@@ -74,6 +74,10 @@ func UpsertCheckRun(ctx context.Context, client *github.Client, tr *v1beta1.Task
 	owner := tr.Annotations[key("owner")]
 	repo := tr.Annotations[key("repo")]
 	commit := tr.Annotations[key("commit")]
+	name := tr.Annotations[key("name")]
+	if name == "" {
+		name = tr.GetNamespacedName().String()
+	}
 
 	status, conclusion := status(tr.Status)
 
@@ -85,7 +89,7 @@ func UpsertCheckRun(ctx context.Context, client *github.Client, tr *v1beta1.Task
 		}
 		cr, _, err := client.Checks.UpdateCheckRun(ctx, owner, repo, n, github.UpdateCheckRunOptions{
 			ExternalID:  github.String(tr.GetSelfLink()),
-			Name:        tr.Name,
+			Name:        name,
 			Status:      github.String(status),
 			Conclusion:  github.String(conclusion),
 			HeadSHA:     github.String(commit),
@@ -103,7 +107,7 @@ func UpsertCheckRun(ctx context.Context, client *github.Client, tr *v1beta1.Task
 	// There's no existing CheckRun - create.
 	cr, _, err := client.Checks.CreateCheckRun(ctx, tr.Annotations[key("owner")], tr.Annotations[key("repo")], github.CreateCheckRunOptions{
 		ExternalID:  github.String(tr.GetSelfLink()),
-		Name:        tr.GetNamespacedName().String(),
+		Name:        name,
 		Status:      github.String(status),
 		Conclusion:  github.String(conclusion),
 		HeadSHA:     tr.Annotations[key("commit")],

--- a/notifiers/github-app/pkg/controller/status.go
+++ b/notifiers/github-app/pkg/controller/status.go
@@ -19,12 +19,16 @@ func (r *GitHubAppReconciler) HandleStatus(ctx context.Context, tr *v1beta1.Task
 	owner := tr.Annotations[key("owner")]
 	repo := tr.Annotations[key("repo")]
 	commit := tr.Annotations[key("commit")]
+	name := tr.Annotations[key("name")]
+	if name == "" {
+		name = tr.GetNamespacedName().String()
+	}
 
 	status := &github.RepoStatus{
 		State:       state(tr.Status),
 		Description: truncateDesc(tr.GetStatusCondition().GetCondition(apis.ConditionSucceeded).GetMessage()),
 		TargetURL:   github.String(dashboardURL(tr)),
-		Context:     github.String(tr.GetName()),
+		Context:     github.String(name),
 	}
 	_, _, err = client.Repositories.CreateStatus(ctx, owner, repo, commit, status)
 	return err


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adds an optional annotation to control what the statuses display name in
GitHub. If not specified, this defaults to the Task's name.


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._

Fixes #779 
