### PR TITLE
Add details about adding Owners for new projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,6 @@ PRs are welcome, and will follow
 Once [your experimental project proposal has been accepted](https://github.com/tektoncd/community/blob/main/process.md#proposing-projects):
 
 - Create a new folder for your project
+- Add an [OWNERS](https://github.com/tektoncd/community/blob/master/process.md#OWNERS) file only in the initial pull request so that the project owners can approve subsequent pull requests for your project
 - Add a README describing your project
-- Add an [OWNERS](https://github.com/tektoncd/community/blob/master/process.md#OWNERS) file
 - Add your project [to the list of projects in presubmit-tests.sh](https://github.com/tektoncd/experimental/blob/main/test/presubmit-tests.sh#L61)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

If projects are opened without the Owners file being merged first, then the top level owners of experimental repo have to review the whole project in the first pull request (which are usually big PRs as proof of concepts)

In this change, we recommend that contributors open an initial PR with the Owners file only so that the approvers of that specific project get permissions to approve the subsequent pull requests for that specific project 

This will remove the requirement that top level experimental maintainers, who may not be owners of the specific experimental project, have to review the whole project (and distributes the maintenance load from them)

Saw this scenario in https://github.com/tektoncd/experimental/pull/770#issuecomment-899700330


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [n/a] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md) for more details._

/cc @bobcatfish 