### PR TITLE
[pipeline-to-taskrun] Add initial directory for Pipeline to TaskRun custom task 🎁

### DIFF
--- a/pipeline-to-taskrun/OWNERS
+++ b/pipeline-to-taskrun/OWNERS
@@ -1,0 +1,6 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- bobcatfish
+- jerop
+- wlynch

--- a/pipeline-to-taskrun/README.md
+++ b/pipeline-to-taskrun/README.md
@@ -1,0 +1,5 @@
+# Pipeline to TaskRun
+
+This project will be a controller that enables an experimental [custom task](https://github.com/tektoncd/pipeline/blob/main/docs/runs.md)
+that will allow you to execute a Pipeline (with [limited features](#supported-pipeline-features)) via a TaskRun, enabling you to
+run a Pipeline in a pod ([TEP-0044](https://github.com/tektoncd/community/blob/main/teps/0044-decouple-task-composition-from-scheduling.md)).


### PR DESCRIPTION
# Changes

I had tried to add the custom task and OWNERS file all at once in
https://github.com/tektoncd/experimental/pull/770 but @jerop pointed
out it's probably a better approach to just add the OWNERS file first,
which would allow getting the initial approval needed to kick off the
project and from then on the project OWNERS can take care of reviews
(and she documented this in
https://github.com/tektoncd/experimental/pull/782 !)

So this commit adds just the OWNERS (more welcome if anyone else is
interested!) for the pipeline to taskrun custom task, and there will be
a follow-up PR with the initial controller logic.

Project proposal: https://github.com/tektoncd/community/issues/447

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
