### PR TITLE
[notifiers/github] fixed RBAC permissions

### DIFF
--- a/notifiers/github-app/config/rbac.yaml
+++ b/notifiers/github-app/config/rbac.yaml
@@ -35,7 +35,7 @@ rules:
   - apiGroups: ["tekton.dev"]
     resources: ["taskruns", "pipelineruns"]
     verbs: ["list", "get", "patch", "update"]
-  - apiGroups: ["", "metrics.k8s.io", "extensions", "apps"]
+  - apiGroups: [""]
     resources:
       - "pods/log"
       - "pods"


### PR DESCRIPTION
fix permissions prevents notifier from reading pod/logs and update taskruns

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

added  ["list", "get"] for
resources:
      - "pods/log"
      - "events"
      - "nodes"
      - "pods"
      - "deployments"

added ["patch", "update"] for
resources:
     - "taskruns"
     - "pipelineruns"
 
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
