### PR TITLE
[pipeline-to-taskrun] Get ready to run presubmit tests 🏁

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -58,7 +58,7 @@ function should_test_folder() {
 # Get list of changed files
 initialize_environment
 
-projects="catalogs cel commit-status-tracker generators helm hub oci pipeline/cleanup pipelines-in-pipelines tekdoc task-loops notifiers/github-app cloudevents"
+projects="catalogs cel commit-status-tracker generators helm hub oci pipeline/cleanup pipelines-in-pipelines pipeline-to-taskrun tekdoc task-loops notifiers/github-app cloudevents"
 inanyprojectregex=$(echo "^${projects// /\/.* ^}\/.*" | sed 's/ /\\|/g')
 
 for proj in $projects; do


### PR DESCRIPTION
# Changes

In #770 I tried to add the custom task and OWNERS file - with @jerop's
help I realized it would be easier to add the OWNERS file first so that
OWNERS can review the custom task itself - but even after that I was
still changing a file in the top level test dir to add the custom task
to the list of tests kicked off which needs top level OWNERS approval -
so this commit is doing that separately. Looking at the script it should
be safe to add a directory that doesn't exist because it should just get
ignored

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
