### PR TITLE
Add or Update METRICS_DOMAIN to deployment 🍡

### DIFF
--- a/cel/config/500-controller.yaml
+++ b/cel/config/500-controller.yaml
@@ -60,6 +60,8 @@ spec:
             # values in the "configmaps" "get" rule.
             - name: CONFIG_LOGGING_NAME
               value: config-logging
+            - name: METRICS_DOMAIN
+              value: experimental.tekton.dev/cel
       volumes:
         - name: config-logging
           configMap:

--- a/cloudevents/config/controller.yaml
+++ b/cloudevents/config/controller.yaml
@@ -74,6 +74,8 @@ spec:
         # values in the "configmaps" "get" rule.
         - name: CONFIG_LOGGING_NAME
           value: config-logging
+        - name: METRICS_DOMAIN
+          value: experimental.tekton.dev/cloudevents
       volumes:
         - name: config-logging
           configMap:

--- a/pipeline-to-taskrun/config/500-controller.yaml
+++ b/pipeline-to-taskrun/config/500-controller.yaml
@@ -60,6 +60,8 @@ spec:
             # values in the "configmaps" "get" rule.
             - name: CONFIG_LOGGING_NAME
               value: config-logging
+            - name: METRICS_DOMAIN
+              value: experimental.tekton.dev/pipeline-to-taskrun
       volumes:
         - name: config-logging
           configMap:

--- a/pipelines-in-pipelines/config/500-controller.yaml
+++ b/pipelines-in-pipelines/config/500-controller.yaml
@@ -60,6 +60,8 @@ spec:
             # values in the "configmaps" "get" rule.
             - name: CONFIG_LOGGING_NAME
               value: config-logging
+            - name: METRICS_DOMAIN
+              value: experimental.tekton.dev/pipelines-in-pipelines
       volumes:
         - name: config-logging
           configMap:

--- a/task-loops/config/500-controller.yaml
+++ b/task-loops/config/500-controller.yaml
@@ -67,8 +67,7 @@ spec:
         - name: CONFIG_OBSERVABILITY_NAME
           value: config-observability
         - name: METRICS_DOMAIN
-          value: tekton.dev/pipeline
+          value: experimental.tekton.dev/task-loops
         securityContext:
           allowPrivilegeEscalation: false
           runAsUser: 1001
-

--- a/task-loops/config/500-webhook.yaml
+++ b/task-loops/config/500-webhook.yaml
@@ -70,7 +70,7 @@ spec:
         - name: WEBHOOK_SECRET_NAME
           value: tekton-taskloop-webhook-certs
         - name: METRICS_DOMAIN
-          value: tekton.dev/pipeline
+          value: experimental.tekton.dev/task-loops
         securityContext:
           allowPrivilegeEscalation: false
           runAsUser: 1001

--- a/wait-task/config/controller.yaml
+++ b/wait-task/config/controller.yaml
@@ -202,6 +202,8 @@ spec:
         # values in the "configmaps" "get" rule.
         - name: CONFIG_LOGGING_NAME
           value: config-logging
+        - name: METRICS_DOMAIN
+          value: experimental.tekton.dev/wait-task
       volumes:
         - name: config-logging
           configMap:


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

knative/pkg based controller and webhook need this environement
variable in order to not panic if metrics are enabled (through a
configmap).

This adds missing values for some of the project, and correct wrong
values for others.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

Fixes #791 

/cc @afrittoli @jerop @bobcatfish @sbwsg @wlynch @dibyom @DrissiReda

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
