### PR TITLE
[task-loops] Repair Task Loops Nightly Builds

### DIFF
--- a/task-loops/tekton/release-pipeline.yaml
+++ b/task-loops/tekton/release-pipeline.yaml
@@ -68,7 +68,7 @@ spec:
         - name: context
           value: $(params.subfolder)
         - name: flags
-          value: -v -mod=vendor
+          value: -v
       workspaces:
         - name: source
           workspace: workarea
@@ -79,13 +79,11 @@ spec:
         name: golang-build
       params:
         - name: package
-          value: $(params.package)
-        - name: packages
-          value: ./$(params.subfolder)/cmd/...
+          value: $(params.package)/$(params.subfolder)
       workspaces:
         - name: source
           workspace: workarea
-          subpath: git
+          subpath: git/task-loops
     - name: publish-images
       runAfter: [build, unit-tests]
       taskRef:


### PR DESCRIPTION
# Changes

The Task Loops nightlies have been failing for a while (most recent example
here:
https://dashboard.dogfooding.tekton.dev/#/namespaces/tekton-nightly/pipelineruns/task-loops-release-nightly-s4qzd?pipelineTask=unit-tests&step=unit-test)

The source of the errors appear to be an extra `-mod=vendor` param in the
`unit-tests` task and the `build` task executing from the root of the repo instead
of the task-loops subdirectory.

This commit fixes both of these issues and should hopefully repair the
task-loops nightlies.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
