### PR TITLE
[task-loops] Fix release without vendor

### DIFF
--- a/task-loops/tekton/publish.yaml
+++ b/task-loops/tekton/publish.yaml
@@ -88,9 +88,7 @@ spec:
     - name: GOPATH
       value: /workspace/go
     - name: GO111MODULE
-      value: "off"
-    - name: GOFLAGS
-      value: "-mod=vendor"
+      value: "on"
     script: |
       #!/usr/bin/env sh
       set -ex
@@ -110,6 +108,7 @@ spec:
       # probably get it wrong), we'll just targz up the whole vendor tree and
       # include it. As of 9/20/2019, this amounts to about 11MB of additional
       # data in each image.
+      go mod vendor
       TMPDIR=$(mktemp -d)
       tar cfz ${TMPDIR}/source.tar.gz vendor/
       for d in cmd/*; do


### PR DESCRIPTION
We don't have a vendor folder in task-loop anymore. Fix the publish
task so that it can still work without vendor.

Recent failure: https://dashboard.dogfooding.tekton.dev/#/namespaces/tekton-nightly/pipelineruns/task-loops-release-nightly-vr9kv?pipelineTask=publish-images&step=run-ko

```
+ tar cfz /tmp/tmp.OHEppb/source.tar.gz vendor/
tar: vendor: No such file or directory
tar: error exit delayed from previous errors
```

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
