### PR TITLE
[pipeline-to-taskrun] Support optional workspace ⚙️

### DIFF
--- a/pipeline-to-taskrun/README.md
+++ b/pipeline-to-taskrun/README.md
@@ -81,6 +81,7 @@ Currently supported features:
 * Sequential tasks (specified using [`runAfter`](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#using-the-runafter-parameter))
 * [String params](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#specifying-parameters)
 * [Workspaces](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#specifying-workspaces)
+  * Including [optional workspaces](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#optional-workspaces)
 
 ### Potential future features
 
@@ -100,7 +101,6 @@ These features may be added in the future:
 * Workspace features:
   * [mountPaths](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#using-workspaces-in-tasks)
   * [subPaths](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#using-workspaces-in-pipelines)
-  * [optional](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#optional-workspaces)
   * [readOnly](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#using-workspaces-in-tasks)
   * [isolated](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#isolating-workspaces-to-specific-steps-or-sidecars)
   * In addition further thought will have to be given to support workspaces that combine

--- a/pipeline-to-taskrun/pkg/reconciler/pipelinetotaskrun/pipelinetotaskrun_test.go
+++ b/pipeline-to-taskrun/pkg/reconciler/pipelinetotaskrun/pipelinetotaskrun_test.go
@@ -656,29 +656,6 @@ spec:
         claimName: pvc
 `),
 	}, {
-		name:            "optional workspaces - TODO(community#447)",
-		expectedErrText: []string{"optional"},
-		pipeline: test.MustParsePipeline(t, `
-metadata:
-  name: pipeline
-  namespace: foo
-spec:
-  tasks:
-  - name: use-workspace
-    taskSpec:
-      steps:
-      - image: ubuntu
-      workspaces:
-      - name: task-workspace
-        optional: true
-    workspaces:
-    - name: task-workspace
-      workspace: pipeline-workspace
-  workspaces:
-  - name: pipeline-workspace
-`),
-		run: test.MustParseRun(t, run),
-	}, {
 		name:            "embedded tasks with labels and annotations - TODO(community#447)",
 		expectedErrText: []string{"label", "annotation"},
 		pipeline: test.MustParsePipeline(t, `

--- a/pipeline-to-taskrun/pkg/reconciler/pipelinetotaskrun/steps.go
+++ b/pipeline-to-taskrun/pkg/reconciler/pipelinetotaskrun/steps.go
@@ -165,6 +165,11 @@ func (pti PipelineTaskInfo) RenameWorkspaces(newMapping map[string]string) Pipel
 	// create a mapping of the replacements that can be used to update the steps
 	replacements := map[string]string{}
 	for oldName, newName := range newMapping {
+		// this value will be blank for optional workspaces that aren't provided
+		// for those we shouldn't do any replacement
+		if newName == "" {
+			continue
+		}
 		// we need to explicitly replace every known workspace variable
 		for _, variable := range []string{"path", "bound", "claim", "volume"} {
 			// this is the format that ApplyReplacements expects the replacements to arrive in; it infers the surrounding

--- a/pipeline-to-taskrun/pkg/reconciler/pipelinetotaskrun/steps_test.go
+++ b/pipeline-to-taskrun/pkg/reconciler/pipelinetotaskrun/steps_test.go
@@ -412,6 +412,7 @@ func TestRenameWorkspaces(t *testing.T) {
   - name: grab-source-clone
     image: some-git-image
     script: |
+      echo $(workspaces.optional.bound)
       echo $(workspaces.foobar.bound)
       echo $(workspaces.foobar.claim)
       echo $(workspaces.foobar.volume)
@@ -430,6 +431,7 @@ func TestRenameWorkspaces(t *testing.T) {
   - name: grab-source-clone
     image: some-git-image
     script: |
+      echo $(workspaces.optional.bound)
       echo $(workspaces.the-ultimate-volume.bound)
       echo $(workspaces.the-ultimate-volume.claim)
       echo $(workspaces.the-ultimate-volume.volume)
@@ -438,7 +440,7 @@ func TestRenameWorkspaces(t *testing.T) {
   - name: commit
     description: "The precise commit SHA that was fetched by this Task"
 `)
-	newMapping := map[string]string{"foobar": "the-ultimate-volume"}
+	newMapping := map[string]string{"foobar": "the-ultimate-volume", "optional": ""}
 	updatedPti := pti.RenameWorkspaces(newMapping)
 	if d := cmp.Diff(expected, updatedPti); d != "" {
 		t.Errorf("didn't get expected updated info. Diff: %s", diff.PrintWantGot(d))

--- a/pipeline-to-taskrun/pkg/reconciler/pipelinetotaskrun/testdata/expected-taskrun.yaml
+++ b/pipeline-to-taskrun/pkg/reconciler/pipelinetotaskrun/testdata/expected-taskrun.yaml
@@ -143,6 +143,8 @@ spec:
       # when the script block is in the middle of the file and absent when at the end of the file
       script: |-
         #!/bin/sh
+        echo "$(workspaces.ssh-directory.bound)"
+
         set -eu -o pipefail
         if [[ "$(params.grab-source-verbose)" == "true" ]] ; then
           set -x
@@ -233,6 +235,8 @@ spec:
     workspaces:
     - name: where-it-all-happens
     - name: gcs-creds
+    - name: ssh-directory
+      optional: true
   workspaces:
   - name: where-it-all-happens
     persistentVolumeClaim:

--- a/pipeline-to-taskrun/pkg/reconciler/pipelinetotaskrun/testdata/gcs-upload.yaml
+++ b/pipeline-to-taskrun/pkg/reconciler/pipelinetotaskrun/testdata/gcs-upload.yaml
@@ -18,6 +18,8 @@ spec:
   workspaces:
     - name: credentials
       description: A secret with a service account key to use as GOOGLE_APPLICATION_CREDENTIALS.
+      # The task won't work without this workspace, but we're setting it to optional to make sure we test the case where an optional workspace is provided
+      optional: true
     - name: source
       description: A workspace where files will be uploaded from.
   params:

--- a/pipeline-to-taskrun/pkg/reconciler/pipelinetotaskrun/testdata/git-clone.yaml
+++ b/pipeline-to-taskrun/pkg/reconciler/pipelinetotaskrun/testdata/git-clone.yaml
@@ -22,6 +22,8 @@ spec:
   workspaces:
     - name: output
       description: The git repo will be cloned onto the volume backing this workspace
+    - name: ssh-directory
+      optional: true
   params:
     - name: url
       description: git url to clone
@@ -89,6 +91,8 @@ spec:
       # when the script block is in the middle of the file and absent when at the end of the file
       script: |-
         #!/bin/sh
+        echo "$(workspaces.ssh-directory.bound)"
+
         set -eu -o pipefail
         if [[ "$(params.verbose)" == "true" ]] ; then
           set -x

--- a/pipeline-to-taskrun/pkg/reconciler/pipelinetotaskrun/validate.go
+++ b/pipeline-to-taskrun/pkg/reconciler/pipelinetotaskrun/validate.go
@@ -99,9 +99,6 @@ func validateTaskSpec(taskSpec *v1beta1.TaskSpec) error {
 		if w.ReadOnly {
 			return fmt.Errorf("readOnly workspaces are not supported but %s is readOnly", w.Name)
 		}
-		if w.Optional {
-			return fmt.Errorf("optional workspaces are not supported but %s is optional", w.Name)
-		}
 	}
 	for _, p := range taskSpec.Params {
 		if p.Type == v1beta1.ParamTypeArray {

--- a/pipeline-to-taskrun/pkg/reconciler/pipelinetotaskrun/workspaces.go
+++ b/pipeline-to-taskrun/pkg/reconciler/pipelinetotaskrun/workspaces.go
@@ -17,13 +17,14 @@ limitations under the License.
 package pipelinetotaskrun
 
 import (
+	"fmt"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
 type PipelineTaskToWorkspaces map[string]map[string]string
 
 // getNewWorkspaceMapping will create an object that maps from the mapped workspaces in each pipeline task in pTasks to
-// the pipeline level workspace that is actually used. It returns a map where they keys are pipeline task names, and
+// the pipeline level workspace that is actually used. It returns a map where the keys are pipeline task names, and
 // the values are dictionaries that map each of the task's declared workspaces to the actual workspaces used.
 func getNewWorkspaceMapping(pTasks []v1beta1.PipelineTask) PipelineTaskToWorkspaces {
 	mapping := PipelineTaskToWorkspaces{}
@@ -36,4 +37,22 @@ func getNewWorkspaceMapping(pTasks []v1beta1.PipelineTask) PipelineTaskToWorkspa
 	}
 
 	return mapping
+}
+
+// getUnboundOptionalWorkspaces returns a list of all the optional workspaces that are declared in taskSpecs but not actually
+// bound in newWorkspaceMapping, or an error if an unbound workspace is not optional.
+func getUnboundOptionalWorkspaces(taskSpecs map[string]*v1beta1.TaskSpec, newWorkspaceMapping PipelineTaskToWorkspaces) ([]v1beta1.WorkspaceDeclaration, error) {
+	optionalWS := []v1beta1.WorkspaceDeclaration{}
+	for pt, mappings := range newWorkspaceMapping {
+		taskSpec := taskSpecs[pt]
+		for _, ws := range taskSpec.Workspaces {
+			if _, ok := mappings[ws.Name]; !ok {
+				if !ws.Optional {
+					return nil, fmt.Errorf("workspace %s is not bound in %s but is not optional", ws.Name, pt)
+				}
+				optionalWS = append(optionalWS, ws)
+			}
+		}
+	}
+	return optionalWS, nil
 }


### PR DESCRIPTION
# Changes

Initially I left this out just to reduce the number of cases I needed to
cover but it was actually pretty easy to add. The functionality will be:
- When an optional workspace is provided, we do the same remapping we do
  for other workspace
- When an optional workspace is not provided, we don't do any remapping
  and just declare the same workspace as optional in the merged Task

I ran into this b/c I was trying to use pipeline to taskrun with the
latest git clone task in the catalog (0.4) which declares an optional
ssh-directory and I was frustrated that it didn't work.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
