### PR TITLE
Use cmpopts.IgnoreFields instead of IgnoreType.

### DIFF
--- a/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun_test.go
+++ b/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun_test.go
@@ -238,7 +238,7 @@ func checkRunStatus(t *testing.T, run *v1alpha1.Run, expectedStatus map[string]p
 			t.Errorf("Run status for PipelineRun %s has iteration number %d instead of %d",
 				expectedPipelineRunName, actualPipelineRunStatus.Iteration, expectedPipelineRunStatus.Iteration)
 		}
-		if d := cmp.Diff(expectedPipelineRunStatus.Status, actualPipelineRunStatus.Status, cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)); d != "" {
+		if d := cmp.Diff(expectedPipelineRunStatus.Status, actualPipelineRunStatus.Status, cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime.Inner.Time")); d != "" {
 			t.Errorf("Run status for PipelineRun %s is incorrect. Diff %s", expectedPipelineRunName, diff.PrintWantGot(d))
 		}
 	}

--- a/task-loops/pkg/reconciler/tasklooprun/tasklooprun_test.go
+++ b/task-loops/pkg/reconciler/tasklooprun/tasklooprun_test.go
@@ -277,7 +277,7 @@ func checkRunStatus(t *testing.T, run *v1alpha1.Run, expectedStatus map[string]t
 					t.Errorf("Run status for TaskRun %s has iteration number %d instead of %d",
 						actualTaskRunName, actualTaskRunStatus.Iteration, expectedTaskRunStatus.Iteration)
 				}
-				if d := cmp.Diff(expectedTaskRunStatus.Status, actualTaskRunStatus.Status, cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)); d != "" {
+				if d := cmp.Diff(expectedTaskRunStatus.Status, actualTaskRunStatus.Status, cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime.Inner.Time")); d != "" {
 					t.Errorf("Run status for TaskRun %s is incorrect. Diff %s", actualTaskRunName, diff.PrintWantGot(d))
 				}
 				break

--- a/task-loops/test/tasklooprun_test.go
+++ b/task-loops/test/tasklooprun_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*
@@ -715,7 +716,7 @@ func TestTaskLoopRun(t *testing.T) {
 					t.Errorf("TaskRun %s does not have expected labels. Diff %s", actualTaskRun.Name, diff.PrintWantGot(d))
 				}
 				if d := cmp.Diff(expectedTaskRun.Status.Status.Conditions, actualTaskRun.Status.Status.Conditions,
-					cmpopts.IgnoreTypes(apis.Condition{}.Message, apis.Condition{}.LastTransitionTime)); d != "" {
+					cmpopts.IgnoreFields(apis.Condition{}, "Message", "LastTransitionTime")); d != "" {
 					t.Errorf("TaskRun %s does not have expected status condition. Diff %s", actualTaskRun.Name, diff.PrintWantGot(d))
 				}
 
@@ -728,7 +729,7 @@ func TestTaskLoopRun(t *testing.T) {
 					t.Errorf("Run status does not include TaskRun status for TaskRun %s", actualTaskRun.Name)
 				} else {
 					if d := cmp.Diff(expectedTaskRun.Status.Status.Conditions, taskRunStatusInTaskLoopRun.Status.Status.Conditions,
-						cmpopts.IgnoreTypes(apis.Condition{}.Message, apis.Condition{}.LastTransitionTime)); d != "" {
+						cmpopts.IgnoreFields(apis.Condition{}, "Message", "LastTransitionTime")); d != "" {
 						t.Errorf("Run status for TaskRun %s does not have expected status condition. Diff %s",
 							actualTaskRun.Name, diff.PrintWantGot(d))
 					}


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

From
https://pkg.go.dev/github.com/google/go-cmp/cmp/cmpopts#IgnoreTypes:

IgnoreTypes returns an Option that ignores all values assignable to certain types,
which are specified by passing in a value of each type.

This means when we pass in apis.Condition{}.LastTransitionTime.Inner.Time,
we are actually ignoring all time.Time, not just that particular field.
Similarly for apis.Condition{}.Message, we are ignoring all strings.

This change uses IgnoreFields to correct the behavior. Luckily, this doesn't
impact the tests in a meaningful way.

See https://github.com/tektoncd/triggers/issues/1245 for issue where this was discovered.

/kind bug

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
