### PR TITLE
[github-notifier] Add missing METRICS_DOMAIN env var

### DIFF
--- a/notifiers/github-app/config/deployment.yaml
+++ b/notifiers/github-app/config/deployment.yaml
@@ -48,6 +48,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: KUBERNETES_MIN_VERSION
               value: 1.18.0
+            - name: METRICS_DOMAIN
+              value: experimental.tekton.dev/github-notifier
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This PR adds the `METRICS_DOMAIN` environment variable to the deployment configuration for the github-notifier, without this it panics and gets stuck in a crash loop. Related: #792 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
