### PR TITLE
Modify pipeline-to-taskrun release pipeline

### DIFF
--- a/pipeline-to-taskrun/tekton/publish.yaml
+++ b/pipeline-to-taskrun/tekton/publish.yaml
@@ -140,7 +140,7 @@ spec:
         IMAGES_PATH=${IMAGES_PATH}/$(params.subfolder)
       fi
 
-      for cmd in controller webhook
+      for cmd in controller
       do
         IMAGES="${IMAGES} ${IMAGES_PATH}/cmd/${cmd}:$(params.versionTag)"
       done

--- a/pipeline-to-taskrun/tekton/release-pipeline.yaml
+++ b/pipeline-to-taskrun/tekton/release-pipeline.yaml
@@ -83,7 +83,7 @@ spec:
       workspaces:
         - name: source
           workspace: workarea
-          subpath: git/$(params.subfolder)
+          subpath: git/pipeline-to-taskrun
     - name: publish-images
       runAfter: [build, unit-tests]
       taskRef:


### PR DESCRIPTION
Replace parameter expansion in build test Task workspace subpath with
hardcoded `pipeline-to-taskrun`

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
