### PR TITLE
Switch Cluster&RoleBindings apiVersion to v1

### DIFF
--- a/cel/config/201-rolebinding.yaml
+++ b/cel/config/201-rolebinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cel-controller

--- a/cel/config/202-clusterrolebinding.yaml
+++ b/cel/config/202-clusterrolebinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cel-controller-cluster-access

--- a/helm/dashboard/templates/clusterrolebinding.yaml
+++ b/helm/dashboard/templates/clusterrolebinding.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "dashboard.fullname" . }}

--- a/helm/pipeline/templates/clusterrolebinding.yaml
+++ b/helm/pipeline/templates/clusterrolebinding.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "pipeline.fullname" . }}

--- a/helm/triggers/templates/clusterrolebinding.yaml
+++ b/helm/triggers/templates/clusterrolebinding.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "triggers.fullname" . }}

--- a/pipelines-in-pipelines/config/201-rolebinding.yaml
+++ b/pipelines-in-pipelines/config/201-rolebinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pip-controller

--- a/pipelines-in-pipelines/config/202-clusterrolebinding.yaml
+++ b/pipelines-in-pipelines/config/202-clusterrolebinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pip-controller-cluster-access

--- a/task-loops/config/201-rolebinding.yaml
+++ b/task-loops/config/201-rolebinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tekton-taskloop-controller
@@ -30,7 +30,7 @@ roleRef:
   name: tekton-taskloop-controller
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tekton-taskloop-webhook

--- a/task-loops/config/202-clusterrolebinding.yaml
+++ b/task-loops/config/202-clusterrolebinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-taskloop-controller-cluster-access
@@ -33,7 +33,7 @@ roleRef:
 # then the ClusterRole would be namespaced. The access described by
 # the tekton-taskloop-controller-tenant-access ClusterRole would
 # be scoped to individual tenant namespaces.
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-taskloop-controller-tenant-access
@@ -50,7 +50,7 @@ roleRef:
   name: tekton-taskloop-controller-tenant-access
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-taskloop-controller-leaderelection
@@ -67,7 +67,7 @@ roleRef:
   name: tekton-taskloop-leader-election
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-taskloop-webhook-cluster-access
@@ -84,7 +84,7 @@ roleRef:
   name: tekton-taskloop-webhook-cluster-access
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-taskloop-webhook-leaderelection


### PR DESCRIPTION
# Changes

The v1beta1 apiVersion will not be served in K8s v1.22 and above
See https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
