### PR TITLE
[pipeline-in-pod] Timeouts.Pipeline support

### DIFF
--- a/pipeline-in-pod/README.md
+++ b/pipeline-in-pod/README.md
@@ -6,5 +6,5 @@ This is an experimental solution to [TEP-0044](https://github.com/tektoncd/commu
 This task can be built and installed with `ko`.
 
 ## Supported Features
-This custom task currently supports only running sequential tasks together in a pod.
+This custom task currently supports only running sequential tasks together in a pod with a pipeline-level timeout.
 The next features on the roadmap are params, workspaces, and parallel tasks.

--- a/pipeline-in-pod/examples/inline-pipeline-inline-tasks.yaml
+++ b/pipeline-in-pod/examples/inline-pipeline-inline-tasks.yaml
@@ -9,7 +9,7 @@ spec:
     # metadata: # for labels and annotations
     spec:
       timeouts:
-        pipeline: 5m
+        pipeline: 15s
       params:
       - name: greeting
         value: "Good Morning!"
@@ -21,7 +21,6 @@ spec:
         - name: echo-good-morning
           params:
           - name: greeting
-            type: string
             value: $(params.greeting)
           taskSpec:
             steps:
@@ -30,6 +29,7 @@ spec:
                 script: |
                   #!/usr/bin/env bash
                   echo "$(params.greeting)"
+                  sleep 20
         - name: echo-good-afternoon
           taskSpec:
             steps:

--- a/pipeline-in-pod/pkg/apis/colocatedpipelinerun/v1alpha1/colocated_pipelinerun_types_test.go
+++ b/pipeline-in-pod/pkg/apis/colocatedpipelinerun/v1alpha1/colocated_pipelinerun_types_test.go
@@ -1,0 +1,25 @@
+package v1alpha1_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	cprv1alpha1 "github.com/tektoncd/experimental/pipeline-in-pod/pkg/apis/colocatedpipelinerun/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetTimeout(t *testing.T) {
+	cpr := cprv1alpha1.ColocatedPipelineRun{
+		Spec: cprv1alpha1.ColocatedPipelineRunSpec{
+			Timeouts: &v1beta1.TimeoutFields{Pipeline: &metav1.Duration{Duration: time.Duration(15 * time.Second)}},
+		},
+	}
+	timeout := cpr.PipelineTimeout(context.Background())
+	expected := time.Duration(15 * time.Second)
+	if d := cmp.Diff(expected, timeout); d != "" {
+		t.Errorf("wrong timeout: %s", d)
+	}
+}

--- a/pipeline-in-pod/pkg/apis/colocatedpipelinerun/v1alpha1/colocated_pipelinerun_validation.go
+++ b/pipeline-in-pod/pkg/apis/colocatedpipelinerun/v1alpha1/colocated_pipelinerun_validation.go
@@ -6,7 +6,7 @@ func ValidateColocatedPipelineRun(cpr *ColocatedPipelineRun) error {
 		- only one of PipelineRef, PipelineSpec
 		- spec.ref not populated
 		- spec.Kind = colocatedPipelineRun
-		- timeouts has only timeouts.pipeline
+		- colocatedpipelinerun timeouts has only timeouts.pipeline
 	*/
 	return nil
 }

--- a/pipeline-in-pod/pkg/reconciler/pipelineinpod/pod.go
+++ b/pipeline-in-pod/pkg/reconciler/pipelineinpod/pod.go
@@ -109,7 +109,7 @@ type pipelineTaskContainers struct {
 func getPod(ctx context.Context, runMeta metav1.ObjectMeta, cpr *cprv1alpha1.ColocatedPipelineRun, tasks []v1beta1.PipelineTask, images pipeline.Images, entrypointCache EntrypointCache) (*corev1.Pod, map[string]StepInfo, error) {
 	activeDeadlineSeconds := int64(60 * 60)
 	if cpr.Spec.Timeouts != nil && cpr.Spec.Timeouts.Pipeline != nil {
-		activeDeadlineSeconds = int64(cpr.Spec.Timeouts.Pipeline.Seconds() * 1.5)
+		activeDeadlineSeconds = int64(cpr.Spec.Timeouts.Pipeline.Seconds() * 2)
 	}
 
 	var initContainers []corev1.Container

--- a/pipeline-in-pod/pkg/reconciler/pipelineinpod/run.go
+++ b/pipeline-in-pod/pkg/reconciler/pipelineinpod/run.go
@@ -1,6 +1,7 @@
 package pipelineinpod
 
 import (
+	"bytes"
 	"encoding/json"
 
 	cprv1alpha1 "github.com/tektoncd/experimental/pipeline-in-pod/pkg/apis/colocatedpipelinerun/v1alpha1"
@@ -13,7 +14,10 @@ func DecodeExtraFields(run v1alpha1.RunSpec, into interface{}) error {
 	if run.Spec == nil || len(run.Spec.Spec.Raw) == 0 {
 		return nil
 	}
-	return json.Unmarshal(run.Spec.Spec.Raw, into)
+	dec := json.NewDecoder(bytes.NewReader(run.Spec.Spec.Raw))
+	dec.DisallowUnknownFields() // Force errors
+
+	return dec.Decode(into)
 }
 
 func EncodeExtraFields(run *v1alpha1.RunSpec, from interface{}) error {
@@ -27,7 +31,7 @@ func EncodeExtraFields(run *v1alpha1.RunSpec, from interface{}) error {
 	return nil
 }
 
-func toColocatedPipelineRun(run *v1alpha1.Run) (cprv1alpha1.ColocatedPipelineRun, error) {
+func ToColocatedPipelineRun(run *v1alpha1.Run) (cprv1alpha1.ColocatedPipelineRun, error) {
 	var cpr cprv1alpha1.ColocatedPipelineRun
 
 	spec := &cprv1alpha1.ColocatedPipelineRunSpec{}
@@ -40,6 +44,9 @@ func toColocatedPipelineRun(run *v1alpha1.Run) (cprv1alpha1.ColocatedPipelineRun
 	}
 	cpr.Spec = *spec
 	cpr.Status = *status
+	cpr.Status.Status = run.Status.Status
+	cpr.Status.StartTime = run.Status.StartTime
+	cpr.Status.CompletionTime = run.Status.CompletionTime
 	cpr.TypeMeta = metav1.TypeMeta{
 		Kind:       run.Spec.Spec.Kind,
 		APIVersion: run.Spec.Spec.APIVersion,
@@ -58,11 +65,13 @@ func toColocatedPipelineRun(run *v1alpha1.Run) (cprv1alpha1.ColocatedPipelineRun
 	return cpr, nil
 }
 
-func updateRunFromColocatedPipelineRun(run *v1alpha1.Run, cpr cprv1alpha1.ColocatedPipelineRun) error {
+func UpdateRunFromColocatedPipelineRun(run *v1alpha1.Run, cpr cprv1alpha1.ColocatedPipelineRun) error {
 	if err := run.Status.EncodeExtraFields(cpr.Status); err != nil {
 		return err
 	}
 	// TODO: smarter translation e.g. translating reasons
 	run.Status.Status = cpr.Status.Status
+	run.Status.StartTime = cpr.Status.StartTime
+	run.Status.CompletionTime = cpr.Status.CompletionTime
 	return nil
 }

--- a/pipeline-in-pod/pkg/reconciler/pipelineinpod/run_test.go
+++ b/pipeline-in-pod/pkg/reconciler/pipelineinpod/run_test.go
@@ -1,18 +1,181 @@
-package pipelineinpod
+package pipelineinpod_test
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	cprv1alpha1 "github.com/tektoncd/experimental/pipeline-in-pod/pkg/apis/colocatedpipelinerun/v1alpha1"
+	"github.com/tektoncd/experimental/pipeline-in-pod/pkg/reconciler/pipelineinpod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test/parse"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 func TestToColocatedPipelineRun(t *testing.T) {
+	cprSpec := cprv1alpha1.ColocatedPipelineRunSpec{
+		Timeouts: &v1beta1.TimeoutFields{Pipeline: &metav1.Duration{Duration: time.Duration(10 * time.Second)}},
+	}
+	specBytes, err := json.Marshal(cprSpec)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	cprStatus := cprv1alpha1.ColocatedPipelineRunStatus{}
+	statusBytes, err := json.Marshal(cprStatus)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	run := v1alpha1.Run{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Run",
+			APIVersion: "tekton.dev/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-run",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.RunSpec{
+			Spec: &v1alpha1.EmbeddedRunSpec{
+				TypeMeta: runtime.TypeMeta{
+					Kind:       "ColocatedPipelineRun",
+					APIVersion: "tekton.dev/v1alpha1",
+				},
+				Metadata: v1beta1.PipelineTaskMetadata{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec: runtime.RawExtension{
+					Raw: specBytes,
+				},
+			},
+		},
+		Status: v1alpha1.RunStatus{
+			RunStatusFields: v1alpha1.RunStatusFields{
+				ExtraFields: runtime.RawExtension{
+					Raw: statusBytes,
+				},
+			},
+		},
+	}
+	cpr, err := pipelineinpod.ToColocatedPipelineRun(&run)
+	expected := cprv1alpha1.ColocatedPipelineRun{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ColocatedPipelineRun",
+			APIVersion: "tekton.dev/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+			Namespace: "default",
+			Name:      "my-run",
+		},
+		Spec:   cprSpec,
+		Status: cprStatus,
+	}
+	if err != nil {
+		t.Errorf("got err %s", err)
+	}
+	if diff := cmp.Diff(cpr, expected); diff != "" {
+		t.Errorf("got != want: %s", diff)
+	}
+}
 
+func TestToColocatedPipelineRunFromYaml(t *testing.T) {
+	run := parse.MustParseRun(t, `
+apiVersion: tekton.dev/v1alpha1
+kind: Run
+metadata:
+  name: echo-good-morning-run
+spec:
+  spec:
+    apiVersion: tekton.dev/v1alpha1
+    kind: ColocatedPipelineRun
+    spec:
+      params:
+      - name: greeting
+        value: "Good Morning!"
+      timeouts:
+        pipeline: 15s
+      pipelineSpec:
+        params:
+        - name: greeting
+          type: string
+        tasks:
+        - name: echo-good-morning
+          params:
+          - name: greeting
+            value: $(params.greeting)
+          taskSpec:
+            steps:
+            - name: echo
+              image: ubuntu
+`)
+	cpr, err := pipelineinpod.ToColocatedPipelineRun(run)
+	if err != nil {
+		t.Fatalf("error parsing run yaml: %s", err)
+	}
+	expected := cprv1alpha1.ColocatedPipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "echo-good-morning-run",
+		},
+		TypeMeta: metav1.TypeMeta{Kind: "ColocatedPipelineRun", APIVersion: "tekton.dev/v1alpha1"},
+		Spec: cprv1alpha1.ColocatedPipelineRunSpec{
+			Params: []v1beta1.Param{
+				{Name: "greeting", Value: v1beta1.ArrayOrString{StringVal: "Good Morning!", Type: v1beta1.ParamTypeString}},
+			},
+			PipelineSpec: &v1beta1.PipelineSpec{
+				Params: []v1beta1.ParamSpec{
+					{Name: "greeting", Type: v1beta1.ParamTypeString},
+				},
+				Tasks: []v1beta1.PipelineTask{{
+					Name: "echo-good-morning",
+					Params: []v1beta1.Param{{
+						Name: "greeting", Value: v1beta1.ArrayOrString{StringVal: "$(params.greeting)", Type: v1beta1.ParamTypeString}}},
+					TaskSpec: &v1beta1.EmbeddedTask{
+						TaskSpec: v1beta1.TaskSpec{
+							Steps: []v1beta1.Step{{
+								Container: v1.Container{
+									Name:  "echo",
+									Image: "ubuntu",
+								},
+							}},
+						},
+					},
+				}},
+			},
+			Timeouts: &v1beta1.TimeoutFields{Pipeline: &metav1.Duration{Duration: time.Duration(15 * time.Second)}},
+		},
+	}
+	if d := cmp.Diff(expected, cpr); d != "" {
+		t.Errorf("didn't get expected CPR: %s", d)
+	}
+}
+
+func TestUpdateRunFromColocatedPipelineRun(t *testing.T) {
+	now := time.Now()
+	cprStatus := cprv1alpha1.ColocatedPipelineRunStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{
+				apis.Condition{Type: apis.ConditionSucceeded, Status: v1.ConditionFalse, Reason: "failed"},
+			},
+		},
+		ColocatedPipelineRunStatusFields: cprv1alpha1.ColocatedPipelineRunStatusFields{
+			CompletionTime: &metav1.Time{Time: now},
+		}}
+
+	statusBytes, err := json.Marshal(cprStatus)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
 	run := v1alpha1.Run{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Run",
@@ -46,26 +209,62 @@ func TestToColocatedPipelineRun(t *testing.T) {
 			},
 		},
 	}
-	cpr, err := toColocatedPipelineRun(&run)
-	expected := cprv1alpha1.ColocatedPipelineRun{
+
+	cpr := cprv1alpha1.ColocatedPipelineRun{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ColocatedPipelineRun",
 			APIVersion: "tekton.dev/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"foo": "bar",
+				"foo2": "bar2",
 			},
 			Namespace: "default",
 			Name:      "my-run",
 		},
-		Spec:   cprv1alpha1.ColocatedPipelineRunSpec{},
-		Status: cprv1alpha1.ColocatedPipelineRunStatus{},
+		Status: cprStatus,
+	}
+
+	err = pipelineinpod.UpdateRunFromColocatedPipelineRun(&run, cpr)
+	expected := v1alpha1.Run{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Run",
+			APIVersion: "tekton.dev/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-run",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.RunSpec{
+			Spec: &v1alpha1.EmbeddedRunSpec{
+				TypeMeta: runtime.TypeMeta{
+					Kind:       "ColocatedPipelineRun",
+					APIVersion: "tekton.dev/v1alpha1",
+				},
+				Metadata: v1beta1.PipelineTaskMetadata{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec: runtime.RawExtension{
+					Raw: []byte{},
+				},
+			},
+		},
+		Status: v1alpha1.RunStatus{
+			Status: cprStatus.Status,
+			RunStatusFields: v1alpha1.RunStatusFields{
+				ExtraFields: runtime.RawExtension{
+					Raw: statusBytes,
+				},
+				CompletionTime: &metav1.Time{Time: now},
+			},
+		},
 	}
 	if err != nil {
 		t.Errorf("got err %s", err)
 	}
-	if diff := cmp.Diff(cpr, expected); diff != "" {
+	if diff := cmp.Diff(expected, run); diff != "" {
 		t.Errorf("got != want: %s", diff)
 	}
 }

--- a/pipeline-in-pod/pkg/reconciler/pipelineinpod/status.go
+++ b/pipeline-in-pod/pkg/reconciler/pipelineinpod/status.go
@@ -98,14 +98,14 @@ func MakeColocatedPipelineRunStatus(logger *zap.SugaredLogger, cpr cprv1alpha1.C
 	}
 
 	if pending {
-		logger.Infof("Not all TaskRuns in CPR %s have completed", cpr.Name)
+		logger.Infof("Not all Tasks in CPR %s have completed", cpr.Name)
 		markStatusRunning(cprs, "Pending", "Pending")
 	} else if succeeded {
-		logger.Infof("All TaskRuns in PR %s have completed", cpr.Name)
+		logger.Infof("All Tasks in CPR %s have completed", cpr.Name)
 		markStatusSuccess(cprs)
 		markCompletionTime(cprs)
 	} else {
-		logger.Infof("At least one TaskRun in PR %s has failed", cpr.Name)
+		logger.Infof("At least one Task in CPR %s has failed", cpr.Name)
 		markStatusFailure(cprs, "failure", "failure")
 		markCompletionTime(cprs)
 	}

--- a/pipeline-in-pod/pkg/test/yaml_parsing.go
+++ b/pipeline-in-pod/pkg/test/yaml_parsing.go
@@ -1,0 +1,25 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/tektoncd/experimental/pipeline-in-pod/pkg/client/clientset/versioned/scheme"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	cprv1alpha1 "github.com/tektoncd/experimental/pipeline-in-pod/pkg/apis/colocatedpipelinerun/v1alpha1"
+)
+
+func MustParseColocatedPipelineRun(t *testing.T, yaml string) cprv1alpha1.ColocatedPipelineRun {
+	var cpr cprv1alpha1.ColocatedPipelineRun
+	yaml = `apiVersion: tekton.dev/v1alpha1
+	kind: ColocatedPipelineRun
+	` + yaml
+	MustParseYAML(t, yaml, &cpr)
+	return cpr
+}
+
+func MustParseYAML(t *testing.T, yaml string, i runtime.Object) {
+	if _, _, err := scheme.Codecs.UniversalDeserializer().Decode([]byte(yaml), nil, i); err != nil {
+		t.Fatalf("mustParseYAML (%s): %v", yaml, err)
+	}
+}


### PR DESCRIPTION
# Changes

This commit adds support for Timeouts.Pipeline to the ColocatedPipelineRun custom task.
When the timeout is exceeded, the pod is deleted and the ColocatedPipelineRun is marked as failed.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
