### PR TITLE
[pipelines-in-pipelines] Fix SIGSEGV when PipelineRun hasn't started

### DIFF
--- a/pipelines-in-pipelines/pkg/reconciler/pip/piprun.go
+++ b/pipelines-in-pipelines/pkg/reconciler/pip/piprun.go
@@ -143,7 +143,9 @@ func updateRunStatus(ctx context.Context, run *v1alpha1.Run, pipelineRun *v1beta
 	logger := logging.FromContext(ctx)
 
 	c := pipelineRun.GetStatusCondition().GetCondition(apis.ConditionSucceeded)
-	if c.IsTrue() {
+	if c == nil {
+		logger.Infof("PipelineRun created by Run %s/%s hasn't started", run.Namespace, run.Name)
+	} else if c.IsTrue() {
 		logger.Infof("PipelineRun created by Run %s/%s has succeeded", run.Namespace, run.Name)
 		run.Status.MarkRunSucceeded(c.Reason, c.Message)
 		propagateResults(run, pipelineRun)

--- a/pipelines-in-pipelines/pkg/reconciler/pip/piprun_test.go
+++ b/pipelines-in-pipelines/pkg/reconciler/pip/piprun_test.go
@@ -179,6 +179,13 @@ func withResults(pr *v1beta1.PipelineRun, name string, value string) *v1beta1.Pi
 	return prWithStatus
 }
 
+func cancelled(r *v1alpha1.Run) *v1alpha1.Run {
+	cancelledR := r.DeepCopy()
+
+	cancelledR.Spec.Status = v1alpha1.RunSpecStatusCancelled
+	return cancelledR
+}
+
 var p = &v1beta1.Pipeline{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "pipeline",
@@ -241,7 +248,6 @@ var runWithPipeline = &v1alpha1.Run{
 		},
 	},
 }
-
 var runWithoutPipelineName = &v1alpha1.Run{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "run-with-missing-pipeline",
@@ -362,6 +368,16 @@ func TestReconcilePipRun(t *testing.T) {
 		expectedEvents: []string{
 			"Normal Started ",
 			"Normal Succeeded ",
+		},
+	}, {
+		name:           "Reconcile a cancelled run with a created PipelineRun ",
+		pipeline:       p,
+		run:            cancelled(runWithPipeline),
+		pipelineRun:    pr,
+		expectedStatus: corev1.ConditionUnknown,
+		expectedReason: v1beta1.PipelineRunReasonStarted,
+		expectedEvents: []string{
+			"Normal Started ",
 		},
 	}}
 	for _, tc := range testcases {


### PR DESCRIPTION
A SIGSEGV is raised when a Run changes before its child PipelineRun has started because it hasn't a Succeded condition until it starts.

Fix #866

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Check nil ConditionSucceeded and ignore it printing a message

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
