### PR TITLE
Create common release resources for custom tasks

### DIFF
--- a/cel/tekton/README.md
+++ b/cel/tekton/README.md
@@ -1,3 +1,5 @@
+TODO(#805): Migrate to use common release pipeline
+
 # Tekton Resources
 
 This folder contains tekton resources used build and release the CEL custom task.

--- a/cloudevents/tekton/README.md
+++ b/cloudevents/tekton/README.md
@@ -1,3 +1,5 @@
+TODO(#805): Migrate to use common release pipeline
+
 # Tekton Resources
 
 This folder contains tekton resources used build and release the cloudevents controller.

--- a/pipeline-to-taskrun/tekton/README.md
+++ b/pipeline-to-taskrun/tekton/README.md
@@ -1,3 +1,5 @@
+TODO(#805): Migrate to use common release pipeline
+
 # Tekton Resources
 
 This folder contains tekton resources used build and release the custom task.

--- a/pipelines-in-pipelines/tekton/README.md
+++ b/pipelines-in-pipelines/tekton/README.md
@@ -1,3 +1,5 @@
+TODO(#805): Migrate to use common release pipeline
+
 # Tekton Resources
 
 This folder contains tekton resources used build and release the Pipelines in Pipelines custom task.

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -1,15 +1,17 @@
-TODO(#805): Migrate to use common release pipeline
-
 # Tekton Resources
 
-This folder contains tekton resources used build and release the Task Loops custom task.
+This folder contains tekton resources used build and release custom tasks.
 The resources included in `kustomization.yaml` are installed nightly on the `dogfooding`
 cluster, and used to run nightly releases.
+
+Individual projects will be updated to use these common release resources
+([#805](https://github.com/tektoncd/experimental/issues/805)). Please don't
+add more copy-pasted release Pipelines for releasing Custom Tasks.
 
 ## Nightly releases
 
 [The release pipeline](release-pipeline.yaml) is
-[triggered nightly by Tekton](https://github.com/tektoncd/plumbing/tree/master/tekton/resources/nightly-release).
+[triggered nightly by Tekton](https://github.com/tektoncd/plumbing/tree/main/tekton/resources/nightly-release).
 
 This Pipeline uses:
 

--- a/tekton/customtask-release-pipeline.yaml
+++ b/tekton/customtask-release-pipeline.yaml
@@ -1,0 +1,173 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: release
+spec:
+  params:
+  - name: package
+    description: package to release
+    default: github.com/tektoncd/experimental
+  - name: subfolder
+    description: folder to release within package
+  - name: gitRevision
+    description: the git revision to release
+  - name: imageRegistry
+    default: gcr.io
+  - name: imageRegistryPath
+    description: The path (project) in the image registry
+  - name: versionTag
+    description: The X.Y.Z version that the artifacts should be tagged with
+  - name: releaseBucket
+    description: bucket where the release is stored. The bucket must be project specific.
+  - name: releaseAsLatest
+    description: Whether to tag and publish this release as Pipelines' latest
+    default: "true"
+  - name: platforms
+    description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
+    default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+  - name: serviceAccountPath
+    description: The path to the service account file within the release-secret workspace
+  workspaces:
+    - name: workarea
+      description: The workspace where the repo will be cloned.
+    - name: release-secret
+      description: The secret that contains a service account authorized to push to the imageRegistry and to the output bucket
+  results:
+    - name: commit-sha
+      description: the sha of the commit that was released
+      value: $(tasks.git-clone.results.commit)
+    - name: release-file
+      description: the URL of the release file
+      value: $(tasks.report-bucket.results.release)
+    - name: release-file-no-tag
+      description: the URL of the release file
+      value: $(tasks.report-bucket.results.release-no-tag)
+  tasks:
+    - name: git-clone
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: workarea
+          subpath: git
+      params:
+        - name: url
+          value: https://$(params.package)
+        - name: revision
+          value: $(params.gitRevision)
+    - name: unit-tests
+      runAfter: [git-clone]
+      taskRef:
+        name: golang-test
+      params:
+        - name: package
+          value: $(params.package)
+        - name: context
+          value: $(params.subfolder)
+        - name: flags
+          value: -v
+      workspaces:
+        - name: source
+          workspace: workarea
+          subpath: git
+    - name: build
+      runAfter: [git-clone]
+      taskRef:
+        name: golang-build
+      params:
+        - name: package
+          value: $(params.package)/$(params.subfolder)
+      workspaces:
+        - name: source
+          workspace: workarea
+          subpath: git/$(params.subfolder)
+    - name: publish-images
+      runAfter: [build, unit-tests]
+      taskRef:
+        name: publish-release
+      params:
+        - name: package
+          value: $(params.package)
+        - name: subfolder
+          value: $(params.subfolder)
+        - name: versionTag
+          value: $(params.versionTag)
+        - name: imageRegistry
+          value: $(params.imageRegistry)
+        - name: imageRegistryPath
+          value: $(params.imageRegistryPath)
+        - name: releaseAsLatest
+          value: $(params.releaseAsLatest)
+        - name: platforms
+          value: $(params.platforms)
+        - name: serviceAccountPath
+          value: $(params.serviceAccountPath)
+      workspaces:
+        - name: source
+          workspace: workarea
+          subpath: git
+        - name: output
+          workspace: workarea
+          subpath: bucket
+        - name: release-secret
+          workspace: release-secret
+    - name: publish-to-bucket
+      runAfter: [publish-images]
+      taskRef:
+        name: gcs-upload
+      workspaces:
+        - name: credentials
+          workspace: release-secret
+        - name: source
+          workspace: workarea
+          subpath: bucket
+      params:
+        - name: location
+          value: $(params.releaseBucket)/previous/$(params.versionTag)
+        - name: path
+          value: $(params.versionTag)
+        - name: serviceAccountPath
+          value: $(params.serviceAccountPath)
+    - name: publish-to-bucket-latest
+      runAfter: [publish-images]
+      when:
+        - input: "$(params.releaseAsLatest)"
+          operator: in
+          values: ["true"]
+      taskRef:
+        name: gcs-upload
+      workspaces:
+        - name: credentials
+          workspace: release-secret
+        - name: source
+          workspace: workarea
+          subpath: bucket
+      params:
+        - name: location
+          value: $(params.releaseBucket)/latest
+        - name: path
+          value: $(params.versionTag)
+        - name: serviceAccountPath
+          value: $(params.serviceAccountPath)
+    - name: report-bucket
+      runAfter: [publish-to-bucket]
+      params:
+        - name: releaseBucket
+          value: $(params.releaseBucket)
+        - name: versionTag
+          value: $(params.versionTag)
+      taskSpec:
+        params:
+          - name: releaseBucket
+          - name: versionTag
+        results:
+          - name: release
+            description: The full URL of the release file in the bucket
+          - name: release-no-tag
+            description: The full URL of the release file (no tag) in the bucket
+        steps:
+          - name: create-results
+            image: alpine
+            script: |
+              echo "$(params.releaseBucket)/previous/$(params.versionTag)/release.yaml" > $(results.release.path)
+              echo "$(params.releaseBucket)/previous/$(params.versionTag)/release.notag.yaml" > $(results.release-no-tag.path)

--- a/tekton/kustomization.yaml
+++ b/tekton/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - publish-customtask.yaml
+  - customtask-release-pipeline.yaml

--- a/tekton/publish-customtask.yaml
+++ b/tekton/publish-customtask.yaml
@@ -1,0 +1,187 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: publish-release
+spec:
+  params:
+  - name: package
+    description: package to release (e.g. github.com/<org>/<project>
+  - name: subfolder
+    description: folder within the package for which to publish a release
+  - name: versionTag
+    description: The vX.Y.Z version that the artifacts should be tagged with (including `v`)
+  - name: imageRegistry
+    description: The target image registry
+  - name: imageRegistryPath
+    description: The path (project) in the image registry
+  - name: imageRegistryRegions
+    description: The target image registry regions
+    default: "us eu asia"
+  - name: releaseAsLatest
+    description: Whether to tag and publish this release as Pipelines' latest
+  - name: platforms
+    description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
+    default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+  - name: serviceAccountPath
+    description: The name of the service account path within the release-secret workspace
+  workspaces:
+    - name: source
+      description: The workspace where the repo has been cloned
+    - name: release-secret
+      description: The secret that contains a service account authorized to push to the imageRegistry and to the output bucket
+    - name: output
+      description: The release YAML will be written to this workspace
+  stepTemplate:
+    env:
+      - name: "GIT_ROOT"
+        value: "/workspace/go/src/$(params.package)"
+      - name: "PROJECT_ROOT"
+        value: "/workspace/go/src/$(params.package)/$(params.subfolder)"
+      - name: CONTAINER_REGISTRY
+        value: "$(params.imageRegistry)/$(params.imageRegistryPath)"
+      - name: CONTAINER_REGISTY_CREDENTIALS
+        value: "$(workspaces.release-secret.path)/$(params.serviceAccountPath)"
+      - name: REGIONS
+        value: "$(params.imageRegistryRegions)"
+  steps:
+
+  - name: create-ko-yaml
+    image: busybox
+    script: |
+      #!/bin/sh
+      set -ex
+
+      mkdir -p $GIT_ROOT
+      cp -R "$(workspaces.source.path)"/* ${GIT_ROOT}
+
+      cat <<EOF > ${PROJECT_ROOT}/.ko.yaml
+      # This matches the value configured in .ko.yaml
+      defaultBaseImage: gcr.io/distroless/static:nonroot
+      EOF
+
+      cat ${PROJECT_ROOT}/.ko.yaml
+
+  - name: container-registry-auth
+    image: gcr.io/go-containerregistry/crane:debug
+    script: |
+      #!/busybox/sh
+      set -ex
+
+      # Login to $(params.imageRegistry)
+      DOCKER_CONFIG=$(cat ${CONTAINER_REGISTY_CREDENTIALS} | \
+        crane auth login -u _json_key --password-stdin $(params.imageRegistry) 2>&1 | \
+        sed 's,^.*logged in via \(.*\)$,\1,g')
+
+      # Auth with account credentials for all regions.
+      for region in ${REGIONS}
+      do
+        HOSTNAME=${region}.$(params.imageRegistry)
+        cat ${CONTAINER_REGISTY_CREDENTIALS} | crane auth login -u _json_key --password-stdin ${HOSTNAME}
+      done
+      cp ${DOCKER_CONFIG} /workspace/docker-config.json
+
+  - name: run-ko
+    image: gcr.io/tekton-releases/dogfooding/ko:latest
+    env:
+    - name: KO_DOCKER_REPO
+      value: $(params.imageRegistry)/$(params.imageRegistryPath)
+    - name: GOPATH
+      value: /workspace/go
+    - name: GO111MODULE
+      value: "on"
+    script: |
+      #!/usr/bin/env sh
+      set -ex
+
+      # Setup docker-auth
+      DOCKER_CONFIG=~/.docker
+      mkdir -p ${DOCKER_CONFIG}
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
+
+      # Change to directory with our .ko.yaml
+      cd ${PROJECT_ROOT}
+
+      # For each cmd/* directory, include a full gzipped tar of all source in
+      # vendor/. This is overkill. Some deps' licenses require the source to be
+      # included in the container image when they're used as a dependency.
+      # Rather than trying to determine which deps have this requirement (and
+      # probably get it wrong), we'll just targz up the whole vendor tree and
+      # include it. As of 9/20/2019, this amounts to about 11MB of additional
+      # data in each image.
+      go mod vendor
+      TMPDIR=$(mktemp -d)
+      tar cfz ${TMPDIR}/source.tar.gz vendor/
+      for d in cmd/*; do
+        if [ -d ${d}/kodata/ ]; then
+          ln -s ${TMPDIR}/source.tar.gz ${d}/kodata/
+        fi
+      done
+
+      # Rewrite "devel" to params.versionTag
+      sed -i -e 's/\(pipeline.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\("-version"\), "devel"/\1, "$(params.versionTag)"/g' ${PROJECT_ROOT}/config/*.yaml
+
+      OUTPUT_RELEASE_DIR="$(workspaces.output.path)/$(params.versionTag)"
+      mkdir -p $OUTPUT_RELEASE_DIR
+
+      # Publish images and create release.yaml
+      ko resolve --platform=$(params.platforms) --preserve-import-paths -t $(params.versionTag) -f ${PROJECT_ROOT}/config/ > $OUTPUT_RELEASE_DIR/release.yaml
+      # Publish images and create release.notags.yaml
+      # This is useful if your container runtime doesn't support the `image-reference:tag@digest` notation
+      # This is currently the case for `cri-o` (and most likely others)
+      ko resolve --platform=$(params.platforms) --preserve-import-paths -f ${PROJECT_ROOT}/config/ > $OUTPUT_RELEASE_DIR/release.notags.yaml
+
+  - name: koparse
+    image: gcr.io/tekton-releases/dogfooding/koparse:latest
+    script: |
+      set -ex
+
+      IMAGES_PATH=${CONTAINER_REGISTRY}/$(params.package)
+      if [ "$(params.subfolder)" != "" ]; then
+        IMAGES_PATH=${IMAGES_PATH}/$(params.subfolder)
+      fi
+
+      for d in cmd/*
+      do
+        IMAGES="${IMAGES} ${IMAGES_PATH}/${d}:$(params.versionTag)"
+      done
+
+      # Parse the built images from the release.yaml generated by ko
+      koparse \
+        --path $(workspaces.output.path)/$(params.versionTag)/release.yaml \
+        --base ${IMAGES_PATH} --images ${IMAGES} > /workspace/built_images
+
+  - name: tag-images
+    image: gcr.io/go-containerregistry/crane:debug
+    script: |
+      #!/busybox/sh
+      set -ex
+
+      # Setup docker-auth
+      DOCKER_CONFIG=~/.docker
+      mkdir -p ${DOCKER_CONFIG}
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
+
+      # Tag the images in all regions
+      for IMAGE in $(cat /workspace/built_images)
+      do
+        IMAGE_WITHOUT_SHA=${IMAGE%%@*}
+        IMAGE_WITHOUT_SHA_AND_TAG=${IMAGE_WITHOUT_SHA%%:*}
+        IMAGE_WITH_SHA=${IMAGE_WITHOUT_SHA_AND_TAG}@${IMAGE##*@}
+        if [[ "$(params.releaseAsLatest)" == "true" ]]
+        then
+          crane cp ${IMAGE_WITH_SHA} ${IMAGE_WITHOUT_SHA_AND_TAG}:latest
+        fi
+        for REGION in ${REGIONS}
+        do
+          if [[ "$(params.releaseAsLatest)" == "true" ]]
+          then
+            for TAG in "latest" $(params.versionTag)
+            do
+              crane cp ${IMAGE_WITH_SHA} ${REGION}.${IMAGE_WITHOUT_SHA_AND_TAG}:$TAG
+            done
+          else
+            TAG="$(params.versionTag)"
+            crane cp ${IMAGE_WITH_SHA} ${REGION}.${IMAGE_WITHOUT_SHA_AND_TAG}:$TAG
+          fi
+        done
+      done


### PR DESCRIPTION
# Changes
This commit moves the release pipeline and task that are copy-pasted in many places in experimental/
to a common location. Individual projects in experimental should be migrated to use this Pipeline and Task
with appropriate parameter values, instead of continuing to copy paste these definitions in multiple places.
This will be used first for the pipeline-in-pod project (the ColocatedPipelineRun custom task).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- n/a Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._

Part 1 of #805 