### PR TITLE
[Pipeline-in-pod] Add presubmit tests

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -58,7 +58,7 @@ function should_test_folder() {
 # Get list of changed files
 initialize_environment
 
-projects="cel commit-status-tracker generators helm hub oci pipeline/cleanup pipeline/trusted-resources pipelines-in-pipelines pipeline-to-taskrun tekdoc task-loops notifiers/github-app cloudevents"
+projects="cel commit-status-tracker generators helm hub oci pipeline/cleanup pipeline/trusted-resources pipelines-in-pipelines pipeline-to-taskrun pipeline-in-pod tekdoc task-loops notifiers/github-app cloudevents"
 inanyprojectregex=$(echo "^${projects// /\/.* ^}\/.*" | sed 's/ /\\|/g')
 
 for proj in $projects; do


### PR DESCRIPTION
# Changes

This commit adds presubmit tests for pipeline in a pod following instructions
in [contributing.md](https://github.com/tektoncd/experimental/blob/823989b2ceed7268d08c18e7d236a45f83f0d3a6/CONTRIBUTING.md#adding-a-new-project).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
