### PR TITLE
[pipeline-in-pod] Add ClusterRole + Binding

### DIFF
--- a/pipeline-in-pod/config/201-clusterrole.yaml
+++ b/pipeline-in-pod/config/201-clusterrole.yaml
@@ -46,3 +46,34 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # This is the access that the controller needs on a per-namespace basis.
+  name: tekton-pipeline-in-pod-controller-tenant-access
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipeline-in-pod
+rules:
+  # Read-write access to create Pods and PVCs (for Workspaces)
+  - apiGroups: [""]
+    resources: ["pods", "persistentvolumeclaims"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  # Write permissions to publish events.
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "update", "patch"]
+  # Read-only access to these.
+  - apiGroups: [""]
+    resources: ["configmaps", "limitranges", "secrets", "serviceaccounts"]
+    verbs: ["get", "list", "watch"]
+  # Read-write access to StatefulSets for Affinity Assistant.
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  # Read-write access to ResolutionRequest for remote resolution.
+  - apiGroups: ["resolution.tekton.dev"]
+    resources: ["resolutionrequests"]
+    verbs: ["get", "list", "watch", "create", "delete"]

--- a/pipeline-in-pod/config/202-clusterrolebinding.yaml
+++ b/pipeline-in-pod/config/202-clusterrolebinding.yaml
@@ -28,3 +28,24 @@ roleRef:
   kind: ClusterRole
   name: pipeline-in-pod-controller-cluster-access
   apiGroup: rbac.authorization.k8s.io
+---
+# If this ClusterRoleBinding is replaced with a RoleBinding
+# then the ClusterRole would be namespaced. The access described by
+# the tekton-pipelines-controller-tenant-access ClusterRole would
+# be scoped to individual tenant namespaces.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-pipeline-in-pod-controller-tenant-access
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipeline-in-pod
+subjects:
+  - kind: ServiceAccount
+    name: pipeline-in-pod-controller
+    namespace: tekton-pipeline-in-pod
+roleRef:
+  kind: ClusterRole
+  name: tekton-pipeline-in-pod-controller-tenant-access
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
# Changes
This ClusterRole and ClusterRole binding are the same as those applied to
the tekton pipelines controller. These are necessary for accessing service accounts
and creating workspace volumes.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
