### PR TITLE
[Pipeline-in-pod] Use customResourceDefinition v1

### DIFF
--- a/pipeline-in-pod/config/300-colocatedpipelinerun.yaml
+++ b/pipeline-in-pod/config/300-colocatedpipelinerun.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: colocatedpipelineruns.custom.tekton.dev
@@ -10,24 +10,29 @@ metadata:
 spec:
   group: custom.tekton.dev
   preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      # One can use x-kubernetes-preserve-unknown-fields: true
-      # at the root of the schema (and inside any properties, additionalProperties)
-      # to get the traditional CRD behaviour that nothing is pruned, despite
-      # setting spec.preserveUnknownProperties: false.
-      #
-      # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
-      # See issue: https://github.com/knative/serving/issues/912
-      x-kubernetes-preserve-unknown-fields: true
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
   names:
     kind: ColocatedPipelineRun
     plural: colocatedpipelineruns
+    singular: colocatedpipelinerun
     categories:
     - tekton
     - tekton-pipelines
@@ -35,7 +40,3 @@ spec:
     - cpr
     - cprs
   scope: Namespaced
-  # Opt into the status subresource so metadata.generation
-  # starts to increment
-  subresources:
-    status: {}


### PR DESCRIPTION
# Changes
This commit updates the colocatedPipelineRun CRD to use apiextensions.k8s.io/v1.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
