### PR TITLE
[Pipeline-in-pod] Apply workspace volume mounts

### DIFF
--- a/pipeline-in-pod/README.md
+++ b/pipeline-in-pod/README.md
@@ -18,5 +18,12 @@ ko apply -f config
 
 ## Supported Features
 This custom task currently supports only running tasks together in a pod with params, a pipeline-level timeout and workspaces.
-In this implementation, workspace volumes are accessible to all tasks, but this can be changed.
 The next feature on the roadmap is OCI bundles or remote tasks.
+
+### Results support
+This custom task supports outputting task results, but does not support passing results of one task into the
+parameters of another task.
+
+### Workspaces support
+This custom task supports workspaces backed by emptyDir; they may be optional or required.
+Workspace volumes are mounted only onto the steps that need them.

--- a/pipeline-in-pod/examples/inline-pipeline-inline-tasks.yaml
+++ b/pipeline-in-pod/examples/inline-pipeline-inline-tasks.yaml
@@ -20,31 +20,45 @@ spec:
         params:
         - name: git-url
           type: string
+        - name: branch
+          type: string
+          default: "main"
         tasks:
         - name: clone
           params:
           - name: url
             value: $(params.git-url)
+          - name: branch
+            value: $(params.branch)
           taskSpec:
             workspaces:
             - name: output
+            results:
+            - name: commit
             steps:
               - name: git-clone
                 image: ubuntu
                 script: |
                   #!/usr/bin/env bash
-                  echo "$(params.url)" >> $(workspaces.output.path)
+                  echo $(params.branch)
+                  echo "$(params.url)" >> $(workspaces.output.path)/file
+                  echo "commit-sha: 1234" >> $(results.commit.path)
           workspaces:
           - name: output
             workspace: source-code
-        - name: echo-good-afternoon
+        - name: read-git-output
           taskSpec:
             steps:
               - name: echo2
                 image: ubuntu
                 script: |
                   #!/usr/bin/env bash
-                  echo "Good Afternoon!"
+                  cat $(workspaces.input.path)/file
+            workspaces:
+            - name: input
+          workspaces:
+          - name: input
+            workspace: source-code
           runAfter:
           - clone
         - name: echo-good-morning

--- a/pipeline-in-pod/examples/inline-pipeline-taskrefs.yaml
+++ b/pipeline-in-pod/examples/inline-pipeline-taskrefs.yaml
@@ -6,6 +6,9 @@ spec:
   params:
   - name: url
     type: string 
+  - name: branch
+    type: string
+    default: "main"
   workspaces:
   - name: output
   steps:
@@ -13,22 +16,29 @@ spec:
     image: ubuntu
     script: |
       #!/usr/bin/env bash
-      echo "$(params.url)" >> $(workspaces.output.path)
+      echo $(params.branch)
+      echo "$(params.url)" >> $(workspaces.output.path)/file
+      echo "commit-sha: 1234" >>$(results.commit.path)
+  results:
+  - name: commit
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: echo-greeting
+  name: echo-greeting-read-workspace
 spec:
   params:
   - name: greeting
     type: string
+  workspaces:
+  - name: input
   steps:
   - name: echo
     image: ubuntu
     script: |
       #!/usr/bin/env bash
       echo "$(params.greeting)"
+      ls $(workspaces.input.path)
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: Run
@@ -66,7 +76,10 @@ spec:
           - name: greeting
             value: "Good Afternoon!"
           taskRef:
-            name: echo-greeting
+            name: echo-greeting-read-workspace
+          workspaces:
+          - name: input
+            workspace: source-code
           runAfter:
           - clone-repo
         - name: echo-good-morning
@@ -74,6 +87,9 @@ spec:
           - name: greeting
             value: "Good Morning!"
           taskRef:
-            name: echo-greeting
+            name: echo-greeting-read-workspace
+          workspaces:
+          - name: input
+            workspace: source-code
           runAfter:
           - clone-repo

--- a/pipeline-in-pod/examples/pipelineref.yaml
+++ b/pipeline-in-pod/examples/pipelineref.yaml
@@ -7,6 +7,8 @@ spec:
   - name: source-code
   params:
   - name: git-url
+  - name: branch
+    default: "main"
   tasks:
   - name: clone
     workspaces:
@@ -15,18 +17,25 @@ spec:
     params:
     - name: url
       value: $(params.git-url)
+    - name: branch
+      value: $(params.branch)
     taskSpec:
       steps:
       - name: clone
         image: ubuntu
         script: |
           #!/usr/bin/env bash
-          echo "$(params.url)" >> $(workspaces.output.path)
+          echo "$(params.url):$(params.branch)" >> $(workspaces.output.path)
+          echo "commit-sha: 1234" >>$(results.commit.path)
       workspaces:
       - name: output
       params:
       - name: url
         type: string
+      - name: branch
+        type: string
+      results:
+      - name: commit
   - name: echo-good-afternoon
     taskSpec:
       steps:
@@ -34,7 +43,7 @@ spec:
         image: ubuntu
         script: |
           #!/usr/bin/env bash
-          echo "Good Afternoon!"
+          echo "Good Afternoon!s"
     runAfter:
     - clone
   - name: echo-good-morning

--- a/pipeline-in-pod/pkg/reconciler/pipelineinpod/apply_test.go
+++ b/pipeline-in-pod/pkg/reconciler/pipelineinpod/apply_test.go
@@ -1,0 +1,103 @@
+package pipelineinpod
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	cprv1alpha1 "github.com/tektoncd/experimental/pipeline-in-pod/pkg/apis/colocatedpipelinerun/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test/names"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestApplyWorkspacesToTasks(t *testing.T) {
+	names.TestingSeed()
+	tcs := []struct {
+		name             string
+		cpr              cprv1alpha1.ColocatedPipelineRun
+		wantVolumes      map[string]corev1.Volume
+		wantVolumeMounts map[string][]corev1.VolumeMount
+	}{{
+		name: "workspace used in sequential tasks",
+		cpr: cprv1alpha1.ColocatedPipelineRun{
+			Spec: cprv1alpha1.ColocatedPipelineRunSpec{
+				Workspaces: []v1beta1.WorkspaceBinding{{
+					Name:     "source-code",
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				}},
+				PipelineSpec: &v1beta1.PipelineSpec{
+					Workspaces: []v1beta1.PipelineWorkspaceDeclaration{{Name: "source-code"}},
+					Tasks: []v1beta1.PipelineTask{{
+						Name: "clone",
+						Workspaces: []v1beta1.WorkspacePipelineTaskBinding{{
+							Name:      "output",
+							Workspace: "source-code",
+						}},
+					}, {
+						Name: "build",
+						Workspaces: []v1beta1.WorkspacePipelineTaskBinding{{
+							Name:      "input",
+							Workspace: "source-code",
+						}},
+					}, {
+						Name: "unrelated-task",
+					}}},
+			},
+			Status: cprv1alpha1.ColocatedPipelineRunStatus{
+				ColocatedPipelineRunStatusFields: cprv1alpha1.ColocatedPipelineRunStatusFields{
+					PipelineSpec: &v1beta1.PipelineSpec{
+						Workspaces: []v1beta1.PipelineWorkspaceDeclaration{{Name: "source-code"}},
+						Tasks: []v1beta1.PipelineTask{{
+							Name: "clone",
+							Workspaces: []v1beta1.WorkspacePipelineTaskBinding{{
+								Name:      "output",
+								Workspace: "source-code",
+							}},
+						}, {
+							Name: "build",
+							Workspaces: []v1beta1.WorkspacePipelineTaskBinding{{
+								Name:      "input",
+								Workspace: "source-code",
+							}},
+						}, {
+							Name: "unrelated-task",
+						}}},
+					ChildStatuses: []cprv1alpha1.ChildStatus{{
+						PipelineTaskName: "clone",
+						Spec:             &v1beta1.TaskSpec{Workspaces: []v1beta1.WorkspaceDeclaration{{Name: "output"}}},
+					}, {
+						PipelineTaskName: "build",
+						Spec:             &v1beta1.TaskSpec{Workspaces: []v1beta1.WorkspaceDeclaration{{Name: "input"}}},
+					}, {
+						PipelineTaskName: "unrelated-task",
+						Spec:             &v1beta1.TaskSpec{},
+					}},
+				},
+			},
+		},
+		wantVolumes: map[string]corev1.Volume{"source-code": {Name: "ws-9l9zj", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+		wantVolumeMounts: map[string][]corev1.VolumeMount{"clone": {{
+			Name: "ws-9l9zj", MountPath: "/workspace/output",
+		}}, "build": {{
+			Name: "ws-9l9zj", MountPath: "/workspace/input",
+		}}, "unrelated-task": nil},
+	}}
+	runMeta := metav1.ObjectMeta{Name: "foo", Namespace: "default"}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			gotVolumes, gotVolumeMounts, err := ApplyWorkspacesToTasks(context.Background(), runMeta, &tc.cpr)
+			if err != nil {
+				t.Errorf("unexpected error applying workspaces to tasks: %s", err)
+			}
+			if d := cmp.Diff(tc.wantVolumes, gotVolumes); d != "" {
+				t.Errorf("Wrong volumes: %s", d)
+			}
+			if d := cmp.Diff(tc.wantVolumeMounts, gotVolumeMounts); d != "" {
+				t.Errorf("Wrong volume mounts: %s", d)
+			}
+		})
+	}
+}

--- a/pipeline-in-pod/pkg/reconciler/pipelineinpod/entrypoint.go
+++ b/pipeline-in-pod/pkg/reconciler/pipelineinpod/entrypoint.go
@@ -89,7 +89,7 @@ var (
 // command, we must have fetched the image's ENTRYPOINT before calling this
 // method, using entrypoint_lookup.go.
 // Additionally, Step timeouts are added as entrypoint flag.
-func createContainers(commonExtraEntrypointArgs []string, ptcs []pipelineTaskContainers, breakpointConfig *v1beta1.TaskRunDebug,
+func createContainers(commonExtraEntrypointArgs []string, ptcs []pipelineTaskContainers, volumeMounts map[string][]corev1.VolumeMount, breakpointConfig *v1beta1.TaskRunDebug,
 ) ([]corev1.Container, []corev1.Volume, error) {
 	containers := []corev1.Container{}
 
@@ -184,12 +184,13 @@ func createContainers(commonExtraEntrypointArgs []string, ptcs []pipelineTaskCon
 			steps[i].TerminationMessagePath = terminationPath
 
 			v, vms := getVolumesForStep(ptc, i, runAfter)
+			workspaceVms, _ := volumeMounts[ptc.pt.Name]
+			vms = append(vms, workspaceVms...)
 			steps[i].VolumeMounts = vms
 
 			volumes = append(volumes, v...)
 		}
 		containers = append(containers, steps...)
-		//v := mountVolumesForTask(&ptc, ptNameToPTC)
 	}
 	return containers, volumes, nil
 }

--- a/pipeline-in-pod/pkg/reconciler/pipelineinpod/entrypoint_test.go
+++ b/pipeline-in-pod/pkg/reconciler/pipelineinpod/entrypoint_test.go
@@ -112,7 +112,7 @@ func TestCreateContainersSingleTask(t *testing.T) {
 		}},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	gotContainers, _, err := createContainers([]string{}, tasks, nil)
+	gotContainers, _, err := createContainers([]string{}, tasks, nil, nil)
 	if err != nil {
 		t.Fatalf("createContainers: %v", err)
 	}
@@ -212,7 +212,7 @@ func TestCreateContainersSequentialTasks(t *testing.T) {
 		}},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	gotContainers, _, err := createContainers([]string{}, tasks, nil)
+	gotContainers, _, err := createContainers([]string{}, tasks, nil, nil)
 	if err != nil {
 		t.Fatalf("createContainers: %v", err)
 	}
@@ -308,7 +308,7 @@ func TestCreateContainersParallelTasks(t *testing.T) {
 		}},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	gotContainers, _, err := createContainers([]string{}, tasks, nil)
+	gotContainers, _, err := createContainers([]string{}, tasks, nil, nil)
 	if err != nil {
 		t.Fatalf("createContainers: %v", err)
 	}

--- a/pipeline-in-pod/pkg/reconciler/pipelineinpod/pipelineinpod.go
+++ b/pipeline-in-pod/pkg/reconciler/pipelineinpod/pipelineinpod.go
@@ -187,7 +187,7 @@ func (r *Reconciler) reconcile(ctx context.Context, runMeta metav1.ObjectMeta, c
 }
 
 func (r *Reconciler) createPod(ctx context.Context, runMeta metav1.ObjectMeta, cpr *cprv1alpha1.ColocatedPipelineRun, ps *v1beta1.PipelineSpec) (*corev1.Pod, error) {
-	volumes, err := ApplyWorkspacesToTasks(ctx, runMeta, cpr)
+	volumes, volumeMounts, err := ApplyWorkspacesToTasks(ctx, runMeta, cpr)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +195,7 @@ func (r *Reconciler) createPod(ctx context.Context, runMeta metav1.ObjectMeta, c
 	if err != nil {
 		return nil, err
 	}
-	pod, containerMappings, err := getPod(ctx, runMeta, cpr, tasks, r.Images, r.entrypointCache, volumes)
+	pod, containerMappings, err := getPod(ctx, runMeta, cpr, tasks, r.Images, r.entrypointCache, volumes, volumeMounts)
 	if err != nil {
 		return nil, controller.NewPermanentError(err)
 	}

--- a/pipeline-in-pod/pkg/reconciler/pipelineinpod/status.go
+++ b/pipeline-in-pod/pkg/reconciler/pipelineinpod/status.go
@@ -106,8 +106,9 @@ func MakeColocatedPipelineRunStatus(logger *zap.SugaredLogger, cpr cprv1alpha1.C
 		markStatusSuccess(cprs)
 		markCompletionTime(cprs)
 	} else {
-		logger.Infof("At least one Task in CPR %s has failed", cpr.Name)
-		markStatusFailure(cprs, "failure", "failure")
+		msg := fmt.Sprintf("At least one Task in CPR %s has failed", cpr.Name)
+		logger.Infof(msg)
+		markStatusFailure(cprs, "Failed", msg)
 		markCompletionTime(cprs)
 	}
 


### PR DESCRIPTION
# Changes
This commit applies workspace volume mounts to each container in a Task
that declares that workspace. This allows tasks to share data
in a workspace.

It also adds support for default parameters and replacing result paths.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
