### PR TITLE
[pipeline/trusted-resources] Refact/clean error on return vals

### DIFF
--- a/pipeline/trusted-resources/pkg/trustedtask/trustedpipeline_test.go
+++ b/pipeline/trusted-resources/pkg/trustedtask/trustedpipeline_test.go
@@ -22,7 +22,7 @@ func Test_verifyPipeline(t *testing.T) {
 	ctx := logging.WithLogger(context.Background(), zaptest.NewLogger(t).Sugar())
 	k8sClient := fakek8s.NewSimpleClientset(sa)
 	tektonClient := faketekton.NewSimpleClientset()
-	signer, secretpath, _ := getSignerFromFile(t, ctx, k8sClient)
+	signer, secretpath := getSignerFromFile(t, ctx, k8sClient)
 	ctx = setupContext(ctx, k8sClient, secretpath)
 
 	pipeline := v1beta1.Pipeline{

--- a/pipeline/trusted-resources/pkg/trustedtask/trustedpipelinerun_test.go
+++ b/pipeline/trusted-resources/pkg/trustedtask/trustedpipelinerun_test.go
@@ -62,10 +62,7 @@ func TestVerifyPipelineRun_APIPipeline(t *testing.T) {
 	k8sclient := fakek8s.NewSimpleClientset()
 
 	// Get Signer
-	signer, secretpath, err := getSignerFromFile(t, ctx, k8sclient)
-	if err != nil {
-		t.Fatal(err)
-	}
+	signer, secretpath := getSignerFromFile(t, ctx, k8sclient)
 	ctx = setupContext(ctx, k8sclient, secretpath)
 
 	prWithoutTasks := &TrustedPipelineRun{
@@ -136,10 +133,7 @@ func TestVerifyPipelineRun_PipelineOCIBundle(t *testing.T) {
 	tektonClient := faketekton.NewSimpleClientset()
 
 	// Get Signer
-	signer, secretpath, err := getSignerFromFile(t, ctx, k8sclient)
-	if err != nil {
-		t.Fatal(err)
-	}
+	signer, secretpath := getSignerFromFile(t, ctx, k8sclient)
 	ctx = setupContext(ctx, k8sclient, secretpath)
 
 	// Create registry server
@@ -148,7 +142,7 @@ func TestVerifyPipelineRun_PipelineOCIBundle(t *testing.T) {
 	u, _ := url.Parse(s.URL)
 
 	unsignedPipeline := getUnsignedPipeline("unsigned")
-	if _, err = pushPipelineImage(t, u, unsignedPipeline); err != nil {
+	if _, err := pushPipelineImage(t, u, unsignedPipeline); err != nil {
 		t.Fatal(err)
 	}
 
@@ -224,10 +218,7 @@ func TestVerifyPipelineRun_TaskOCIBundle(t *testing.T) {
 	tektonClient := faketekton.NewSimpleClientset()
 
 	// Get Signer
-	signer, secretpath, err := getSignerFromFile(t, ctx, k8sclient)
-	if err != nil {
-		t.Fatal(err)
-	}
+	signer, secretpath := getSignerFromFile(t, ctx, k8sclient)
 	ctx = setupContext(ctx, k8sclient, secretpath)
 
 	// Create registry server
@@ -244,7 +235,7 @@ func TestVerifyPipelineRun_TaskOCIBundle(t *testing.T) {
 			Kind:   "Task",
 			Bundle: u.Host + "/task/" + unsignedTask.Name,
 		}}}
-	pipelineWithUnsignedTask, err = getSignedPipeline(pipelineWithUnsignedTask, signer)
+	pipelineWithUnsignedTask, err := getSignedPipeline(pipelineWithUnsignedTask, signer)
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}
@@ -359,10 +350,7 @@ func TestVerifyPipelineRun_PipelineRef(t *testing.T) {
 	k8sclient := fakek8s.NewSimpleClientset()
 
 	// Get Signer
-	signer, secretpath, err := getSignerFromFile(t, ctx, k8sclient)
-	if err != nil {
-		t.Fatal(err)
-	}
+	signer, secretpath := getSignerFromFile(t, ctx, k8sclient)
 	ctx = setupContext(ctx, k8sclient, secretpath)
 
 	unsignedPipeline := getUnsignedPipeline("unsigned")
@@ -426,10 +414,7 @@ func TestVerifyPipelineRun_TaskRef(t *testing.T) {
 	k8sclient := fakek8s.NewSimpleClientset()
 
 	// Get Signer
-	signer, secretpath, err := getSignerFromFile(t, ctx, k8sclient)
-	if err != nil {
-		t.Fatal(err)
-	}
+	signer, secretpath := getSignerFromFile(t, ctx, k8sclient)
 	ctx = setupContext(ctx, k8sclient, secretpath)
 
 	// signed pipelineref with unsigned taskref
@@ -440,7 +425,7 @@ func TestVerifyPipelineRun_TaskRef(t *testing.T) {
 			Name: unsignedTask.Name,
 			Kind: "Task",
 		}}}
-	pipelineWithUnsignedTask, err = getSignedPipeline(pipelineWithUnsignedTask, signer)
+	pipelineWithUnsignedTask, err := getSignedPipeline(pipelineWithUnsignedTask, signer)
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}

--- a/pipeline/trusted-resources/pkg/trustedtask/trustedtask_test.go
+++ b/pipeline/trusted-resources/pkg/trustedtask/trustedtask_test.go
@@ -25,7 +25,7 @@ func Test_verifyTask(t *testing.T) {
 	ctx := logging.WithLogger(context.Background(), zaptest.NewLogger(t).Sugar())
 	k8sClient := fakek8s.NewSimpleClientset(sa)
 	tektonClient := faketekton.NewSimpleClientset()
-	signer, secretpath, _ := getSignerFromFile(t, ctx, k8sClient)
+	signer, secretpath := getSignerFromFile(t, ctx, k8sClient)
 	ctx = setupContext(ctx, k8sClient, secretpath)
 
 	task := v1beta1.Task{

--- a/pipeline/trusted-resources/pkg/trustedtask/trustedtaskrun_test.go
+++ b/pipeline/trusted-resources/pkg/trustedtask/trustedtaskrun_test.go
@@ -119,10 +119,7 @@ func TestVerifyTaskRun_OCIBundle(t *testing.T) {
 	tektonClient := faketekton.NewSimpleClientset()
 
 	// Get Signer
-	signer, secretpath, err := getSignerFromFile(t, ctx, k8sclient)
-	if err != nil {
-		t.Fatal(err)
-	}
+	signer, secretpath := getSignerFromFile(t, ctx, k8sclient)
 	ctx = setupContext(ctx, k8sclient, secretpath)
 
 	unsignedTask := getUnsignedTask()
@@ -211,10 +208,7 @@ func TestVerifyTaskRun_TaskRef(t *testing.T) {
 	k8sclient := fakek8s.NewSimpleClientset()
 
 	// Get Signer
-	signer, secretpath, err := getSignerFromFile(t, ctx, k8sclient)
-	if err != nil {
-		t.Fatal(err)
-	}
+	signer, secretpath := getSignerFromFile(t, ctx, k8sclient)
 
 	ctx = setupContext(ctx, k8sclient, secretpath)
 
@@ -404,7 +398,7 @@ func setupContext(ctx context.Context, k8sclient kubernetes.Interface, secretpat
 }
 
 // Generate key files to tmpdir, return signer and pubkey path
-func getSignerFromFile(t *testing.T, ctx context.Context, k8sclient kubernetes.Interface) (signature.Signer, string, error) {
+func getSignerFromFile(t *testing.T, ctx context.Context, k8sclient kubernetes.Interface) (signature.Signer, string) {
 	t.Helper()
 
 	tmpDir := t.TempDir()
@@ -417,7 +411,7 @@ func getSignerFromFile(t *testing.T, ctx context.Context, k8sclient kubernetes.I
 		t.Fatal(err)
 	}
 
-	return signer, filepath.Join(tmpDir, "cosign.pub"), nil
+	return signer, filepath.Join(tmpDir, "cosign.pub")
 }
 
 func pushOCIImage(t *testing.T, u *url.URL, task *v1beta1.Task) (typesv1.Hash, error) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Refactor the helper func `getSignerFromFile` to remove the unused `error` return val
 
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing) - not user facing as for refactoring work
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
