### PR TITLE
Fix missing parenthesis in the tekton release files

### DIFF
--- a/cel/tekton/release-pipeline.yaml
+++ b/cel/tekton/release-pipeline.yaml
@@ -38,7 +38,7 @@ spec:
   results:
     - name: commit-sha
       description: the sha of the commit that was released
-      value: $(tasks.git-clone.results.commit
+      value: $(tasks.git-clone.results.commit)
     - name: release-file
       description: the URL of the release file
       value: $(tasks.report-bucket.results.release)

--- a/cloudevents/tekton/release-pipeline.yaml
+++ b/cloudevents/tekton/release-pipeline.yaml
@@ -38,7 +38,7 @@ spec:
   results:
     - name: commit-sha
       description: the sha of the commit that was released
-      value: $(tasks.git-clone.results.commit
+      value: $(tasks.git-clone.results.commit)
     - name: release-file
       description: the URL of the release file
       value: $(tasks.report-bucket.results.release)

--- a/pipelines-in-pipelines/tekton/release-pipeline.yaml
+++ b/pipelines-in-pipelines/tekton/release-pipeline.yaml
@@ -38,7 +38,7 @@ spec:
   results:
     - name: commit-sha
       description: the sha of the commit that was released
-      value: $(tasks.git-clone.results.commit
+      value: $(tasks.git-clone.results.commit)
     - name: release-file
       description: the URL of the release file
       value: $(tasks.report-bucket.results.release)

--- a/task-loops/tekton/release-pipeline.yaml
+++ b/task-loops/tekton/release-pipeline.yaml
@@ -38,7 +38,7 @@ spec:
   results:
     - name: commit-sha
       description: the sha of the commit that was released
-      value: $(tasks.git-clone.results.commit
+      value: $(tasks.git-clone.results.commit)
     - name: release-file
       description: the URL of the release file
       value: $(tasks.report-bucket.results.release)

--- a/wait-task/tekton/release-pipeline.yaml
+++ b/wait-task/tekton/release-pipeline.yaml
@@ -38,7 +38,7 @@ spec:
   results:
     - name: commit-sha
       description: the sha of the commit that was released
-      value: $(tasks.git-clone.results.commit
+      value: $(tasks.git-clone.results.commit)
     - name: release-file
       description: the URL of the release file
       value: $(tasks.report-bucket.results.release)


### PR DESCRIPTION
Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fix missing parenthesis in Tekton resources.
This is currently breaking deployment of Tekton resources to the cluster

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
