### PR TITLE
[Task-loops] Remove ClusterTask tests

### DIFF
--- a/task-loops/test/tasklooprun_test.go
+++ b/task-loops/test/tasklooprun_test.go
@@ -554,24 +554,6 @@ func TestTaskLoopRun(t *testing.T) {
 			ev{"Iterations completed: 2", true},
 			ev{"All TaskRuns completed successfully", true}},
 	}, {
-		name:           "successful TaskLoop using a cluster task",
-		clustertask:    aClusterTask,
-		taskloop:       aTaskLoopUsingAClusterTask,
-		run:            runTaskLoopUsingAClusterTaskSuccess,
-		expectedStatus: corev1.ConditionTrue,
-		expectedReason: taskloopv1alpha1.TaskLoopRunReasonSucceeded,
-		expectedTaskRuns: []*v1beta1.TaskRun{
-			getExpectedTaskRunForClusterTask(expectedTaskRunIteration1Success),
-			getExpectedTaskRunForClusterTask(expectedTaskRunIteration2Success),
-			getExpectedTaskRunForClusterTask(expectedTaskRunIteration3Success),
-		},
-		expectedEvents: []ev{
-			ev{startedEventMessage, true},
-			ev{"Iterations completed: 0", true},
-			ev{"Iterations completed: 1", true},
-			ev{"Iterations completed: 2", true},
-			ev{"All TaskRuns completed successfully", true}},
-	}, {
 		name:           "successful TaskLoop with concurrency limit",
 		task:           aTask,
 		taskloop:       getTaskLoopWithConcurrency(aTaskLoop, concurrencyLimit2),
@@ -608,6 +590,7 @@ func TestTaskLoopRun(t *testing.T) {
 			ev{"Iterations completed: 2", false}, // Optional event depending on timing
 			ev{"All TaskRuns completed successfully", true}},
 	}}
+	// TODO: TaskLoop tests using a ClusterTask
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
# Changes
This test is broken and blocking PRs in other experimental projects from being submitted. Tekton has chosen to deprecate ClusterTasks, and the TaskLoop functionality has now been implemented by Matrix, so it's not clear that we are getting much value from this test right now.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
