### PR TITLE
[concurrency] Support multiple cancelation strategies

### DIFF
--- a/concurrency/README.md
+++ b/concurrency/README.md
@@ -30,3 +30,10 @@ kubectl create -f examples/pipelinerun.yaml
 ```
 
 The first PipelineRun should be canceled, and the second one should execute normally.
+
+### Supported concurrency strategies
+
+Supported strategies are "Cancel", "GracefullyCancel", and "GracefullyStop"
+(corresponding to canceling, gracefully canceling, and gracefully stopping a PipelineRun, respectively).
+The default strategy is "GracefullyCancel".
+If multiple ConcurrencyControls with different strategies apply to the same PipelineRun, concurrency controls will fail.

--- a/concurrency/config/500-webhook-configuration.yaml
+++ b/concurrency/config/500-webhook-configuration.yaml
@@ -51,11 +51,6 @@ webhooks:
     service:
       name: tekton-concurrency-webhook
       namespace: tekton-concurrency
-  rules:
-  - operations: ["CREATE"]
-    apiGroups: ["tekton.dev"]
-    apiVersions: ["v1beta1", "v1"]
-    resources: ["pipelineruns"]
   failurePolicy: Fail
   sideEffects: None
   name: webhook.concurrency.custom.tekton.dev

--- a/concurrency/examples/concurrencycontrol.yaml
+++ b/concurrency/examples/concurrencycontrol.yaml
@@ -4,7 +4,6 @@ metadata:
   name: cc
   namespace: concurrency
 spec:
-  strategy: Cancel
   selector:
     matchLabels:
       foo: bar

--- a/concurrency/pkg/apis/concurrency/v1alpha1/concurrency_types_test.go
+++ b/concurrency/pkg/apis/concurrency/v1alpha1/concurrency_types_test.go
@@ -20,12 +20,25 @@ func TestValidateConcurrencyControl(t *testing.T) {
 			},
 		},
 	}, {
-		name: "valid cancel: Lowercase",
+		name: "valid gracefully cancel",
 		cc: &v1alpha1.ConcurrencyControl{
 			Spec: v1alpha1.ConcurrencySpec{
-				Strategy: "cancel",
+				Strategy: "GracefullyCancel",
 			},
 		},
+	}, {
+		name: "valid gracefully stop",
+		cc: &v1alpha1.ConcurrencyControl{
+			Spec: v1alpha1.ConcurrencySpec{
+				Strategy: "GracefullyStop",
+			},
+		},
+	}, {
+		name: "no strategy specified",
+		cc: &v1alpha1.ConcurrencyControl{
+			Spec: v1alpha1.ConcurrencySpec{},
+		},
+		wantErr: true,
 	}, {
 		name: "invalid strategy",
 		cc: &v1alpha1.ConcurrencyControl{


### PR DESCRIPTION
# Changes
This commit adds support for all three PipelineRun cancelation strategies to ConcurrencyControls. There is currently no default strategy. If multiple strategies could apply to a PipelineRun, concurrency controls will fail.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
