### PR TITLE
[concurrency] Merge mutating admission webhooks

### DIFF
--- a/concurrency/config/500-webhook-configuration.yaml
+++ b/concurrency/config/500-webhook-configuration.yaml
@@ -26,11 +26,6 @@ webhooks:
     service:
       name: tekton-concurrency-webhook
       namespace: tekton-concurrency
-  rules:
-  - operations: ["CREATE", "UPDATE"]
-    apiGroups: ["tekton.dev"]
-    apiVersions: ["v1alpha1"]
-    resources: ["concurrencycontrols"]
   failurePolicy: Fail
   sideEffects: None
   name: validation.webhook.concurrency.custom.tekton.dev


### PR DESCRIPTION
# Changes
With two separate mutating admission webhooks (one for concurrencycontrol defaults and one for patching pipelineruns as pending), one seems to be ignored. This commit merges them into a single mutating admission webhook that applies both sets of configurations.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
