### PR TITLE
[concurrency] Add namespace allowlist

### DIFF
--- a/concurrency/README.md
+++ b/concurrency/README.md
@@ -37,3 +37,9 @@ Supported strategies are "Cancel", "GracefullyCancel", and "GracefullyStop"
 (corresponding to canceling, gracefully canceling, and gracefully stopping a PipelineRun, respectively).
 The default strategy is "GracefullyCancel".
 If multiple ConcurrencyControls with different strategies apply to the same PipelineRun, concurrency controls will fail.
+
+### Configuration
+
+To restrict the concurrency webhook and controller to only modify PipelineRuns in a subset of namespaces,
+edit the "allowed-namespaces" field of the [concurrency configMap](./config/concurrency-config.yaml) to be
+a comma-separated list of these namespaces, for example: `allowed-namespaces: "default,another-namespace"`.

--- a/concurrency/config/201-clusterrole.yaml
+++ b/concurrency/config/201-clusterrole.yaml
@@ -28,6 +28,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "update", "patch"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/concurrency/config/concurrency-config.yaml
+++ b/concurrency/config/concurrency-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: concurrency-config
+  namespace: tekton-concurrency
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-concurrency
+data:
+  # An optional comma-separated list of namespaces that can use concurrency controls.
+  # Defaults to empty, meaning all namespaces are allowed.
+  allowed-namespaces: ""

--- a/concurrency/pkg/apis/config/config.go
+++ b/concurrency/pkg/apis/config/config.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"context"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/pkg/configmap"
+)
+
+type cfgKey struct{}
+
+const ConcurrencyConfigMapName = "concurrency-config"
+const ConcurrencyNamespace = "tekton-concurrency"
+
+// Config holds the collection of configurations that we attach to contexts.
+// +k8s:deepcopy-gen=false
+type Config struct {
+	AllowedNamespaces sets.String
+}
+
+// Store is a typed wrapper around configmap.Untyped store to handle our configmaps.
+// +k8s:deepcopy-gen=false
+type Store struct {
+	*configmap.UntypedStore
+}
+
+// ToContext attaches the current Config state to the provided context.
+func (s *Store) ToContext(ctx context.Context) context.Context {
+	return ToContext(ctx, s.Load())
+}
+
+// ToContext attaches the provided Config to the provided context, returning the
+// new context with the Config attached.
+func ToContext(ctx context.Context, c *Config) context.Context {
+	return context.WithValue(ctx, cfgKey{}, c)
+}
+
+// FromContext extracts a Config from the provided context.
+func FromContext(ctx context.Context) *Config {
+	x, ok := ctx.Value(cfgKey{}).(*Config)
+	if ok {
+		return x
+	}
+	return nil
+}
+
+// NewConfigFromConfigMap parses a Config struct from a ConfigMap
+func NewConfigFromConfigMap(config *corev1.ConfigMap) (*Config, error) {
+	c := Config{}
+	if config == nil {
+		return &c, nil
+	}
+	if v, ok := config.Data["allowed-namespaces"]; ok {
+		if v == "" {
+			c.AllowedNamespaces = sets.NewString()
+		} else {
+			c.AllowedNamespaces = sets.NewString(strings.Split(v, ",")...)
+		}
+	}
+	return &c, nil
+}
+
+// NewStore creates a new store of Configs and optionally calls functions when ConfigMaps are updated.
+func NewStore(logger configmap.Logger) *Store {
+	store := &Store{
+		UntypedStore: configmap.NewUntypedStore(
+			"concurrency-config",
+			logger,
+			configmap.Constructors{
+				// Tells knative how to parse the Config struct from the concurrency configMap
+				// Function signature must be func(*k8s.io/api/core/v1.ConfigMap) (... , error)
+				ConcurrencyConfigMapName: NewConfigFromConfigMap,
+			},
+		),
+	}
+	return store
+}
+
+// Load creates a Config from the current config state of the Store.
+func (s *Store) Load() *Config {
+	c := s.UntypedLoad(ConcurrencyConfigMapName)
+	return c.(*Config)
+}

--- a/concurrency/pkg/apis/config/config_test.go
+++ b/concurrency/pkg/apis/config/config_test.go
@@ -1,0 +1,58 @@
+package config_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/experimental/concurrency/pkg/apis/config"
+	test "github.com/tektoncd/pipeline/pkg/reconciler/testing"
+	"k8s.io/apimachinery/pkg/util/sets"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+func TestStoreLoadWithContext(t *testing.T) {
+	cfgMap := test.ConfigMapFromTestFile(t, "concurrency-config-all-namespaces")
+
+	expectedCfg, err := config.NewConfigFromConfigMap(cfgMap)
+	if err != nil {
+		t.Fatalf("error loading configmap: %s", err)
+	}
+
+	store := config.NewStore(logtesting.TestLogger(t))
+	store.OnConfigChanged(cfgMap)
+
+	cfg := config.FromContext(store.ToContext(context.Background()))
+
+	if d := cmp.Diff(cfg, expectedCfg); d != "" {
+		t.Errorf("Unexpected config %s", d)
+	}
+}
+
+func TestNewConfigFromConfigMap(t *testing.T) {
+	tcs := []struct {
+		filename       string
+		expectedConfig *config.Config
+	}{{
+		filename:       "concurrency-config-all-namespaces",
+		expectedConfig: &config.Config{AllowedNamespaces: sets.NewString()},
+	}, {
+		filename:       "concurrency-config-one-namespace",
+		expectedConfig: &config.Config{AllowedNamespaces: sets.NewString("default")},
+	}, {
+		filename:       "concurrency-config-multiple-namespaces",
+		expectedConfig: &config.Config{AllowedNamespaces: sets.NewString("default", "another-namespace")},
+	}}
+	for _, tc := range tcs {
+		t.Run(tc.filename, func(t *testing.T) {
+			cm := test.ConfigMapFromTestFile(t, tc.filename)
+			cfg, err := config.NewConfigFromConfigMap(cm)
+			if err != nil {
+				t.Fatalf("error loading configmap: %s", err)
+			}
+			if d := cmp.Diff(tc.expectedConfig, cfg); d != "" {
+				t.Errorf("wrong config: %s", d)
+			}
+		})
+	}
+}

--- a/concurrency/pkg/apis/config/testdata/concurrency-config-all-namespaces.yaml
+++ b/concurrency/pkg/apis/config/testdata/concurrency-config-all-namespaces.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: concurrency-config
+  namespace: tekton-workflows
+data:
+  allowed-namespaces: ""

--- a/concurrency/pkg/apis/config/testdata/concurrency-config-multiple-namespaces.yaml
+++ b/concurrency/pkg/apis/config/testdata/concurrency-config-multiple-namespaces.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: concurrency-config
+  namespace: tekton-workflows
+data:
+  allowed-namespaces: "default,another-namespace"

--- a/concurrency/pkg/apis/config/testdata/concurrency-config-one-namespace.yaml
+++ b/concurrency/pkg/apis/config/testdata/concurrency-config-one-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: concurrency-config
+  namespace: tekton-workflows
+data:
+  allowed-namespaces: "default"


### PR DESCRIPTION
# Changes
This commit adds the ability to configure the behavior of the concurrency controller and webhook via a new configmap "concurrency-config" in the "tekton-concurrency" namespace. It allows the user to specify a list of namespaces where the concurrency controller and webhook should be allowed to modify PipelineRuns, and defaults to all namespaces.

Alternatively, a NamespaceSelector could be applied to the MutatingAdmissionWebhook that patches PipelineRuns as pending. However, this would not prevent the concurrency controller from operating on PipelineRuns in other namespaces.

/cc @afrittoli 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
