### PR TITLE
[concurrency] Add functionality to group by labels

### DIFF
--- a/concurrency/examples/concurrencycontrol.yaml
+++ b/concurrency/examples/concurrencycontrol.yaml
@@ -7,3 +7,5 @@ spec:
   selector:
     matchLabels:
       foo: bar
+  groupBy:
+  - baz

--- a/concurrency/examples/pipelinerun.yaml
+++ b/concurrency/examples/pipelinerun.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: testme-
   labels:
     foo: bar
+    baz: qux
   namespace: concurrency
 spec:
   params:

--- a/concurrency/go.mod
+++ b/concurrency/go.mod
@@ -4,6 +4,8 @@ go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.9
+	github.com/hashicorp/errwrap v1.1.0
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/tektoncd/pipeline v0.40.0
 	go.uber.org/zap v1.23.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
@@ -52,9 +54,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/concurrency/pkg/apis/concurrency/v1alpha1/concurrency_types.go
+++ b/concurrency/pkg/apis/concurrency/v1alpha1/concurrency_types.go
@@ -47,6 +47,13 @@ type ConcurrencySpec struct {
 	Strategy string `json:"strategy,omitempty"`
 	// + optional
 	Selector metav1.LabelSelector `json:"selector,omitempty"`
+	// Label keys that identify the concurrency group of a PipelineRun.
+	// All PipelineRuns with the same value for all of these labels are part of the
+	// same concurrency group.
+	// If a PipelineRun has no value for a key in GroupBy, other PipelineRuns that
+	// also have no value for that key will be part of the same concurrency group.
+	// + optional
+	GroupBy []string `json:"groupBy,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/concurrency/pkg/apis/concurrency/v1alpha1/zz_generated.deepcopy.go
+++ b/concurrency/pkg/apis/concurrency/v1alpha1/zz_generated.deepcopy.go
@@ -88,6 +88,11 @@ func (in *ConcurrencyControlList) DeepCopyObject() runtime.Object {
 func (in *ConcurrencySpec) DeepCopyInto(out *ConcurrencySpec) {
 	*out = *in
 	in.Selector.DeepCopyInto(&out.Selector)
+	if in.GroupBy != nil {
+		in, out := &in.GroupBy, &out.GroupBy
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
# Changes
This commit adds a new "groupBy" field to concurrencyControl, allowing grouping by multiple label keys. PipelineRuns with all the same matching values for these label keys are part of the same concurrency group.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
