### PR TITLE
[concurrency] Move PipelineRun mutation into separate webhook

### DIFF
--- a/concurrency/config/500-webhook-configuration.yaml
+++ b/concurrency/config/500-webhook-configuration.yaml
@@ -33,7 +33,7 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: webhook.concurrency.custom.tekton.dev
+  name: defaulting.webhook.concurrency.custom.tekton.dev
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
@@ -41,6 +41,7 @@ metadata:
     pipeline.tekton.dev/release: "devel"
 webhooks:
 - admissionReviewVersions:
+  - v1
   - v1beta1
   clientConfig:
     service:
@@ -48,4 +49,25 @@ webhooks:
       namespace: tekton-concurrency
   failurePolicy: Fail
   sideEffects: None
-  name: webhook.concurrency.custom.tekton.dev
+  name: defaulting.webhook.concurrency.custom.tekton.dev
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutation.webhook.concurrency.custom.tekton.dev
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-experimental-concurrency
+    pipeline.tekton.dev/release: "devel"
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: tekton-concurrency-webhook
+      namespace: tekton-concurrency
+  failurePolicy: Fail
+  sideEffects: None
+  name: mutation.webhook.concurrency.custom.tekton.dev

--- a/concurrency/go.mod
+++ b/concurrency/go.mod
@@ -3,6 +3,7 @@ module github.com/tektoncd/experimental/concurrency
 go 1.18
 
 require (
+	github.com/gobuffalo/flect v0.2.4
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/golang-lru v0.5.4
@@ -45,7 +46,6 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
-	github.com/gobuffalo/flect v0.2.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/concurrency/pkg/mutatingwebhook/mutatingwebhook.go
+++ b/concurrency/pkg/mutatingwebhook/mutatingwebhook.go
@@ -1,0 +1,254 @@
+package mutatingwebhook
+
+// Much of this code comes from https://github.com/knative/pkg/blob/f5c1a03ab4f1efa8642fc7021960c1b86da5613f/webhook/resourcesemantics/defaulting/defaulting.go
+// Upstream support for a generic admission webhook is tracked in https://github.com/knative/pkg/issues/2644
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"go.uber.org/zap"
+	"gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	admissionlisters "k8s.io/client-go/listers/admissionregistration/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	defaultconfig "github.com/tektoncd/experimental/concurrency/pkg/apis/config"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	mwhinformer "knative.dev/pkg/client/injection/kube/informers/admissionregistration/v1/mutatingwebhookconfiguration"
+	"knative.dev/pkg/controller"
+	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
+	"knative.dev/pkg/kmp"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/ptr"
+	pkgreconciler "knative.dev/pkg/reconciler"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
+	certresources "knative.dev/pkg/webhook/certificates/resources"
+	"knative.dev/pkg/webhook/json"
+)
+
+var (
+	pendPipelineRunPatchBytes []byte
+)
+
+func init() {
+	var err error
+	pendPipelineRunPatchBytes, err = json.Marshal([]jsonpatch.JsonPatchOperation{
+		{
+			Operation: "add",
+			Path:      "/spec/status",
+			Value:     v1beta1.PipelineRunSpecStatusPending,
+		}, {
+			Operation: "add",
+			Path:      "/metadata/labels/tekton.dev~1ok-to-start", // ~1 is used to escape "/" characters in keys
+			Value:     "true",
+		}})
+	if err != nil {
+		log.Fatalf("failed to marshal PipelineRun patch bytes: %v", err)
+	}
+}
+
+// NewAdmissionController constructs a reconciler
+func NewAdmissionController(
+	ctx context.Context,
+	name, path string,
+	wc func(context.Context) context.Context,
+) *controller.Impl {
+
+	client := kubeclient.Get(ctx)
+	mwhInformer := mwhinformer.Get(ctx)
+	secretInformer := secretinformer.Get(ctx)
+	options := webhook.GetOptions(ctx)
+
+	key := types.NamespacedName{Name: name}
+
+	wh := &reconciler{
+		LeaderAwareFuncs: pkgreconciler.LeaderAwareFuncs{
+			// Have this reconciler enqueue our singleton whenever it becomes leader.
+			PromoteFunc: func(bkt pkgreconciler.Bucket, enq func(pkgreconciler.Bucket, types.NamespacedName)) error {
+				enq(bkt, key)
+				return nil
+			},
+		},
+		key:          key,
+		path:         path,
+		withContext:  wc,
+		secretName:   options.SecretName,
+		client:       client,
+		mwhlister:    mwhInformer.Lister(),
+		secretlister: secretInformer.Lister(),
+	}
+
+	logger := logging.FromContext(ctx)
+	const queueName = "MutatingWebhook"
+	c := controller.NewContext(ctx, wh, controller.ControllerOptions{WorkQueueName: queueName, Logger: logger.Named(queueName)})
+
+	// Reconcile when the named MutatingWebhookConfiguration changes.
+	mwhInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterWithName(name),
+		// It doesn't matter what we enqueue because we will always Reconcile
+		// the named MWH resource.
+		Handler: controller.HandleAll(c.Enqueue),
+	})
+
+	// Reconcile when the cert bundle changes.
+	secretInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterWithNameAndNamespace(system.Namespace(), wh.secretName),
+		// It doesn't matter what we enqueue because we will always Reconcile
+		// the named MWH resource.
+		Handler: controller.HandleAll(c.Enqueue),
+	})
+
+	return c
+}
+
+// reconciler implements the AdmissionController for resources
+type reconciler struct {
+	webhook.StatelessAdmissionImpl
+	pkgreconciler.LeaderAwareFuncs
+	key          types.NamespacedName
+	path         string
+	withContext  func(context.Context) context.Context
+	client       kubernetes.Interface
+	mwhlister    admissionlisters.MutatingWebhookConfigurationLister
+	secretlister corelisters.SecretLister
+	secretName   string
+}
+
+var _ controller.Reconciler = (*reconciler)(nil)
+var _ pkgreconciler.LeaderAware = (*reconciler)(nil)
+var _ webhook.AdmissionController = (*reconciler)(nil)
+var _ webhook.StatelessAdmissionController = (*reconciler)(nil)
+
+// Reconcile implements controller.Reconciler
+func (ac *reconciler) Reconcile(ctx context.Context, key string) error {
+	logger := logging.FromContext(ctx)
+
+	if !ac.IsLeaderFor(ac.key) {
+		return controller.NewSkipKey(key)
+	}
+
+	// Look up the webhook secret, and fetch the CA cert bundle.
+	secret, err := ac.secretlister.Secrets(system.Namespace()).Get(ac.secretName)
+	if err != nil {
+		logger.Errorw("Error fetching secret", zap.Error(err))
+		return err
+	}
+	caCert, ok := secret.Data[certresources.CACert]
+	if !ok {
+		return fmt.Errorf("secret %q is missing %q key", ac.secretName, certresources.CACert)
+	}
+
+	// Reconcile the webhook configuration.
+	return ac.reconcileMutatingWebhook(ctx, caCert)
+}
+
+// Path implements AdmissionController
+func (ac *reconciler) Path() string {
+	return ac.path
+}
+
+// Admit implements AdmissionController
+func (ac *reconciler) Admit(ctx context.Context, request *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+	if ac.withContext != nil {
+		ctx = ac.withContext(ctx)
+	}
+
+	logger := logging.FromContext(ctx)
+	cfg := defaultconfig.FromContext(ctx)
+	if len(cfg.AllowedNamespaces) > 0 && !cfg.AllowedNamespaces.Has(request.Namespace) {
+		logger.Infof("PipelineRun %s/%s is not in an allowed namespace, skipping concurrency controls", request.Namespace, request.Name)
+		return &admissionv1.AdmissionResponse{Allowed: true}
+	} else {
+		logger.Infof("PipelineRun %s/%s is in an allowed namespace, applying concurrency controls", request.Namespace, request.Name)
+	}
+
+	return &admissionv1.AdmissionResponse{
+		Patch:   pendPipelineRunPatchBytes,
+		Allowed: true,
+		PatchType: func() *admissionv1.PatchType {
+			pt := admissionv1.PatchTypeJSONPatch
+			return &pt
+		}(),
+	}
+}
+
+func (ac *reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byte) error {
+	logger := logging.FromContext(ctx)
+	rules := []admissionregistrationv1.RuleWithOperations{{
+		Operations: []admissionregistrationv1.OperationType{
+			admissionregistrationv1.Create,
+		},
+		Rule: admissionregistrationv1.Rule{
+			APIGroups:   []string{"tekton.dev"},
+			APIVersions: []string{"v1beta1"},
+			Resources:   []string{"pipelineruns"},
+		},
+	}}
+
+	configuredWebhook, err := ac.mwhlister.Get(ac.key.Name)
+	if err != nil {
+		return fmt.Errorf("error retrieving webhook: %w", err)
+	}
+
+	current := configuredWebhook.DeepCopy()
+
+	ns, err := ac.client.CoreV1().Namespaces().Get(ctx, system.Namespace(), metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to fetch namespace: %w", err)
+	}
+	nsRef := *metav1.NewControllerRef(ns, corev1.SchemeGroupVersion.WithKind("Namespace"))
+	current.OwnerReferences = []metav1.OwnerReference{nsRef}
+
+	for i, wh := range current.Webhooks {
+		if wh.Name != current.Name {
+			continue
+		}
+
+		cur := &current.Webhooks[i]
+		cur.Rules = rules
+
+		cur.NamespaceSelector = webhook.EnsureLabelSelectorExpressions(
+			cur.NamespaceSelector,
+			&metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "webhooks.knative.dev/exclude",
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+				}},
+			})
+
+		cur.ClientConfig.CABundle = caCert
+		if cur.ClientConfig.Service == nil {
+			return fmt.Errorf("missing service reference for webhook: %s", wh.Name)
+		}
+		cur.ClientConfig.Service.Path = ptr.String(ac.Path())
+
+		cur.ReinvocationPolicy = ptrReinvocationPolicyType(admissionregistrationv1.IfNeededReinvocationPolicy)
+	}
+
+	if ok, err := kmp.SafeEqual(configuredWebhook, current); err != nil {
+		return fmt.Errorf("error diffing webhooks: %w", err)
+	} else if !ok {
+		logger.Info("Updating webhook")
+		mwhclient := ac.client.AdmissionregistrationV1().MutatingWebhookConfigurations()
+		if _, err := mwhclient.Update(ctx, current, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to update webhook: %w", err)
+		}
+	} else {
+		logger.Info("Webhook is valid")
+	}
+	return nil
+}
+
+func ptrReinvocationPolicyType(r admissionregistrationv1.ReinvocationPolicyType) *admissionregistrationv1.ReinvocationPolicyType {
+	return &r
+}


### PR DESCRIPTION
This commit writes a new mutating admission webhook to patch PipelineRuns as pending. This addresses two bugs:

1. The existing mutating webhook calls PipelineRun.SetDefaults, which is the responsibility of the PipelineRun admission webhook rather than the concurrency admission webhook. If the version of Pipelines installed on the cluster differs from the version used in the concurrency webhook, this could cause bugs.

2. A resource's namespace isn't always available in the unstructured object provided by knative's defaulting admission controller. This commit rewrites the admission webhook to have access to the entire AdmissionRequest, which has the namespace populated.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
