### PR TITLE
[PIP] Support the cancellation and timeout for customRun

### DIFF
--- a/pipelines-in-pipelines/pkg/reconciler/pip/piprun_test.go
+++ b/pipelines-in-pipelines/pkg/reconciler/pip/piprun_test.go
@@ -169,6 +169,17 @@ func failed(pr *v1beta1.PipelineRun) *v1beta1.PipelineRun {
 	return prWithStatus
 }
 
+func cancelled(pr *v1beta1.PipelineRun) *v1beta1.PipelineRun {
+	prWithStatus := pr.DeepCopy()
+	prWithStatus.Status.SetCondition(&apis.Condition{
+		Type:   apis.ConditionSucceeded,
+		Status: corev1.ConditionFalse,
+		Reason: v1beta1.PipelineRunReasonCancelled.String(),
+		Message: "PipelineRun run-with-pipeline was cancelled",
+	})
+	return prWithStatus
+}
+
 func withResults(pr *v1beta1.PipelineRun, name string, value string) *v1beta1.PipelineRun {
 	prWithStatus := pr.DeepCopy()
 	prWithStatus.Status.PipelineResults = append(prWithStatus.Status.PipelineResults, v1beta1.PipelineRunResult{
@@ -241,6 +252,21 @@ var runWithPipeline = &v1beta1.CustomRun{
 			Kind:       "Pipeline",
 			Name:       "pipeline",
 		},
+	},
+}
+
+var runWithPipelineCancelled = &v1beta1.CustomRun{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "run-with-pipeline",
+		Namespace: "foo",
+	},
+	Spec: v1beta1.CustomRunSpec{
+		CustomRef: &v1beta1.TaskRef{
+			APIVersion: "tekton.dev/v1beta1",
+			Kind:       "Pipeline",
+			Name:       "pipeline",
+		},
+		Status: "RunCancelled",
 	},
 }
 
@@ -364,6 +390,18 @@ func TestReconcilePipRun(t *testing.T) {
 		expectedEvents: []string{
 			"Normal Started ",
 			"Normal Succeeded ",
+		},
+	}, {
+		name:            "Reconcile a run with a cancelled status",
+		pipeline:        p,
+		run:             runWithPipelineCancelled,
+		pipelineRun:     cancelled(pr),
+		expectedMessage: "PipelineRun run-with-pipeline was cancelled",
+		expectedStatus:  corev1.ConditionFalse,
+		expectedReason:  v1beta1.PipelineRunReasonCancelled,
+		expectedEvents: []string{
+			"Normal Started ",
+			"Warning Failed PipelineRun run-with-pipeline was cancelled",
 		},
 	}}
 	for _, tc := range testcases {


### PR DESCRIPTION
The Pipelines-in-Pipelines is provided by a controller that implements the Custom Task interface. Currently, the cancellation is not implemented for the customRun so when the main pipelineRun is cancelled, the pipelineRuns spawned by the customRuns won't be cancelled accordingly, which can lead to confusion. And also, timeout cannot be specified for the pipelineRun so it can only inherit the default timeout.

This PR addresses the above issues, by cancelling the spawned pipelineRuns when the corresponding customRuns are marked as `Cancelled` and also loading `timeout` from customRun's spec.