### PR TITLE
[pipelines-in-pipelines] Support cancellation for pipelines-in-pipelines

### DIFF
--- a/pipelines-in-pipelines/pkg/reconciler/pip/piprun.go
+++ b/pipelines-in-pipelines/pkg/reconciler/pip/piprun.go
@@ -85,6 +85,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, run *v1beta1.CustomRun) 
 		events.Emit(ctx, nil, afterCondition, run)
 	}
 
+	// If the run has been cancelled, cancel the pipelineRun
+	if run.IsCancelled() {
+		if err := r.cancelPipelineRun(ctx, run); err != nil {
+			logger.Errorf("Failed to cancel PipelineRun created by CustomRun %s/%s due to %v", run.Namespace, run.Name, err)
+		}
+	}
+
 	if run.IsDone() {
 		logger.Infof("Run %s/%s is done", run.Namespace, run.Name)
 		return nil
@@ -230,6 +237,25 @@ func getObjectMeta(run *v1beta1.CustomRun) metav1.ObjectMeta {
 		Labels:      getPipelineRunLabels(run),
 		Annotations: getPipelineRunAnnotations(run),
 	}
+}
+
+func (r *Reconciler) cancelPipelineRun(ctx context.Context, run *v1beta1.CustomRun) error {
+	if pr := r.getPipelineRun(ctx, run); pr != nil {
+		logger := logging.FromContext(ctx)
+		logger.Infof("Cancelling PipelineRun created by CustomRun %s/%s", pr.Namespace, pr.Name)
+		mergePatch := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"status": v1beta1.PipelineRunSpecStatusCancelled,
+			},
+		}
+		patch, err := json.Marshal(mergePatch)
+		if err != nil {
+			return err
+		}
+		_, err = r.pipelineClientSet.TektonV1beta1().PipelineRuns(pr.Namespace).Patch(ctx, pr.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+		return err
+	}
+	return nil
 }
 
 func getPipelineRunSpec(run *v1beta1.CustomRun, ownerPipelineRun *v1beta1.PipelineRun) v1beta1.PipelineRunSpec {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The Pipelines-in-Pipelines is provided by a controller that implements the Custom Task interface. Currently, the cancellation is not implemented for the customRun so when the main pipelineRun is cancelled, the pipelineRuns spawned by the customRuns won't be cancelled accordingly, which can lead to confusion.

This PR addresses the above issue, by cancelling the spawned pipelineRuns when the corresponding customRuns are marked as Cancelled.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
