### PR TITLE
[pipelines-in-pipelines] Support timeout and pod template for pipelines-in-pipelines

### DIFF
--- a/pipelines-in-pipelines/pkg/reconciler/pip/piprun.go
+++ b/pipelines-in-pipelines/pkg/reconciler/pip/piprun.go
@@ -197,9 +197,19 @@ func (r *Reconciler) getPipelineRun(ctx context.Context, run *v1beta1.CustomRun)
 func (r *Reconciler) createPipelineRun(ctx context.Context, run *v1beta1.CustomRun) (*v1beta1.PipelineRun, error) {
 	logger := logging.FromContext(ctx)
 
+	var ownerPipelineRun *v1beta1.PipelineRun
+	var err error
+	ownerPipelineRunName := getOwnerPipelineRunName(run)
+	if ownerPipelineRunName != "" {
+		ownerPipelineRun, err = r.pipelineRunLister.PipelineRuns(run.Namespace).Get(ownerPipelineRunName)
+		if err != nil {
+			logger.Errorf("Failed to fetch the owner PipelineRun - %v", run.Namespace, ownerPipelineRunName, err)
+		}
+	}
+
 	pr := &v1beta1.PipelineRun{
 		ObjectMeta: getObjectMeta(run),
-		Spec:       getPipelineRunSpec(run),
+		Spec:       getPipelineRunSpec(run, ownerPipelineRun),
 	}
 
 	logger.Infof("Creating a new PipelineRun object %s", pr.Name)
@@ -222,13 +232,27 @@ func getObjectMeta(run *v1beta1.CustomRun) metav1.ObjectMeta {
 	}
 }
 
-func getPipelineRunSpec(run *v1beta1.CustomRun) v1beta1.PipelineRunSpec {
-	return v1beta1.PipelineRunSpec{
+func getPipelineRunSpec(run *v1beta1.CustomRun, ownerPipelineRun *v1beta1.PipelineRun) v1beta1.PipelineRunSpec {
+	pipelineRunSpec := v1beta1.PipelineRunSpec{
 		PipelineRef:        getPipelineRef(run),
 		Params:             run.Spec.Params,
 		ServiceAccountName: run.Spec.ServiceAccountName,
 		Workspaces:         run.Spec.Workspaces,
+		Timeout:            run.Spec.Timeout,
 	}
+	if ownerPipelineRun != nil {
+		pipelineRunSpec.PodTemplate = ownerPipelineRun.Spec.PodTemplate
+	}
+	return pipelineRunSpec
+}
+
+func getOwnerPipelineRunName(run *v1beta1.CustomRun) string {
+	for _, ref := range run.GetOwnerReferences() {
+		if ref.Kind == pipeline.PipelineRunControllerName {
+			return ref.Name
+		}
+	}
+	return ""
 }
 
 func getPipelineRef(run *v1beta1.CustomRun) *v1beta1.PipelineRef {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The Pipelines-in-Pipelines is provided by a controller that implements the Custom Task interface. Currently, the timeout cannot be specified for the pipelines-in-pipelines tasks so it can only inherit the default timeout, which may cause child pipelineRuns to fail when a different timeout is required. In addition, the podTemplate cannot be set either when triggering the child pipelineRun so it may also fail when a podTemplate is required to run the child pipelineRun.

This PR addresses the above issues, by setting Timeout for the pipelineRun from customRun's spec, and inheriting the podTemplate from the owner pipelineRun.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Commit messages includes a project tag in the subject - e.g. [OCI], [hub], [results], [task-loops]

_See [the contribution guide](https://github.com/tektoncd/experimental/blob/master/CONTRIBUTING.md)
for more details._
